### PR TITLE
Fix build on macOS 13 while maintaining minimal compatibility

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif
@@ -18,14 +18,13 @@ import System
 #if SubprocessSpan
 @available(SubprocessSpan, *)
 #endif
-internal struct AsyncBufferSequence: AsyncSequence, Sendable {
-    internal typealias Failure = any Swift.Error
-
-    internal typealias Element = SequenceOutput.Buffer
+public struct AsyncBufferSequence: AsyncSequence, Sendable {
+    public typealias Failure = any Swift.Error
+    public typealias Element = SequenceOutput.Buffer
 
     @_nonSendable
-    internal struct Iterator: AsyncIteratorProtocol {
-        internal typealias Element = SequenceOutput.Buffer
+    public struct Iterator: AsyncIteratorProtocol {
+        public typealias Element = SequenceOutput.Buffer
 
         private let fileDescriptor: TrackedFileDescriptor
         private var buffer: [UInt8]
@@ -39,7 +38,7 @@ internal struct AsyncBufferSequence: AsyncSequence, Sendable {
             self.finished = false
         }
 
-        internal mutating func next() async throws -> SequenceOutput.Buffer? {
+        public mutating func next() async throws -> SequenceOutput.Buffer? {
             let data = try await self.fileDescriptor.wrapped.readChunk(
                 upToLength: readBufferSize
             )
@@ -58,7 +57,7 @@ internal struct AsyncBufferSequence: AsyncSequence, Sendable {
         self.fileDescriptor = fileDescriptor
     }
 
-    internal func makeAsyncIterator() -> Iterator {
+    public func makeAsyncIterator() -> Iterator {
         return Iterator(fileDescriptor: self.fileDescriptor)
     }
 }

--- a/Sources/Subprocess/Atomic.swift
+++ b/Sources/Subprocess/Atomic.swift
@@ -1,0 +1,233 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Synchronization)
+import Synchronization
+#else
+
+#if canImport(os)
+internal import os
+#if canImport(C.os.lock)
+internal import C.os.lock
+#endif
+#elseif canImport(Bionic)
+@preconcurrency import Bionic
+#elseif canImport(Glibc)
+@preconcurrency import Glibc
+#elseif canImport(Musl)
+@preconcurrency import Musl
+#elseif canImport(WinSDK)
+import WinSDK
+#endif  // canImport(os)
+
+#endif  // canImport(Synchronization)
+
+internal protocol AtomicBoxProtocol: ~Copyable, Sendable {
+    borrowing func bitwiseXor(
+        _ operand: OutputConsumptionState
+    ) -> OutputConsumptionState
+
+    init(_ initialValue: OutputConsumptionState)
+}
+
+internal struct AtomicBox<Wrapped: AtomicBoxProtocol & ~Copyable>: ~Copyable, Sendable {
+
+    private let storage: Wrapped
+
+    internal init(_ storage: consuming Wrapped) {
+        self.storage = storage
+    }
+
+    borrowing internal func bitwiseXor(
+        _ operand: OutputConsumptionState
+    ) -> OutputConsumptionState {
+        return self.storage.bitwiseXor(operand)
+    }
+}
+
+#if canImport(Synchronization)
+@available(macOS 15, *)
+extension Atomic: AtomicBoxProtocol where Value == UInt8 {
+    borrowing func bitwiseXor(
+        _ operand: OutputConsumptionState
+    ) -> OutputConsumptionState {
+        let newState = self.bitwiseXor(
+            operand.rawValue,
+            ordering: .relaxed
+        ).newValue
+        return OutputConsumptionState(rawValue: newState)
+    }
+
+    init(_ initialValue: OutputConsumptionState) {
+        self = Atomic(initialValue.rawValue)
+    }
+}
+#else
+// Fallback to LockedState if `Synchronization` is not available
+extension LockedState: AtomicBoxProtocol where State == OutputConsumptionState {
+    init(_ initialValue: OutputConsumptionState) {
+        self.init(initialState: initialValue)
+    }
+
+    func bitwiseXor(
+        _ operand: OutputConsumptionState
+    ) -> OutputConsumptionState {
+        return self.withLock { state in
+            state = OutputConsumptionState(rawValue: state.rawValue ^ operand.rawValue)
+            return state
+        }
+    }
+}
+
+// MARK: - LockState
+internal struct LockedState<State>: ~Copyable {
+
+    // Internal implementation for a cheap lock to aid sharing code across platforms
+    private struct _Lock {
+        #if canImport(os)
+        typealias Primitive = os_unfair_lock
+        #elseif os(FreeBSD) || os(OpenBSD)
+        typealias Primitive = pthread_mutex_t?
+        #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
+        typealias Primitive = pthread_mutex_t
+        #elseif canImport(WinSDK)
+        typealias Primitive = SRWLOCK
+        #elseif os(WASI)
+        // WASI is single-threaded, so we don't need a lock.
+        typealias Primitive = Void
+        #endif
+
+        typealias PlatformLock = UnsafeMutablePointer<Primitive>
+        var _platformLock: PlatformLock
+
+        fileprivate static func initialize(_ platformLock: PlatformLock) {
+            #if canImport(os)
+            platformLock.initialize(to: os_unfair_lock())
+            #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
+            pthread_mutex_init(platformLock, nil)
+            #elseif canImport(WinSDK)
+            InitializeSRWLock(platformLock)
+            #elseif os(WASI)
+            // no-op
+            #else
+            #error("LockedState._Lock.initialize is unimplemented on this platform")
+            #endif
+        }
+
+        fileprivate static func deinitialize(_ platformLock: PlatformLock) {
+            #if canImport(Bionic) || canImport(Glibc) || canImport(Musl)
+            pthread_mutex_destroy(platformLock)
+            #endif
+            platformLock.deinitialize(count: 1)
+        }
+
+        static fileprivate func lock(_ platformLock: PlatformLock) {
+            #if canImport(os)
+            os_unfair_lock_lock(platformLock)
+            #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
+            pthread_mutex_lock(platformLock)
+            #elseif canImport(WinSDK)
+            AcquireSRWLockExclusive(platformLock)
+            #elseif os(WASI)
+            // no-op
+            #else
+            #error("LockedState._Lock.lock is unimplemented on this platform")
+            #endif
+        }
+
+        static fileprivate func unlock(_ platformLock: PlatformLock) {
+            #if canImport(os)
+            os_unfair_lock_unlock(platformLock)
+            #elseif canImport(Bionic) || canImport(Glibc) || canImport(Musl)
+            pthread_mutex_unlock(platformLock)
+            #elseif canImport(WinSDK)
+            ReleaseSRWLockExclusive(platformLock)
+            #elseif os(WASI)
+            // no-op
+            #else
+            #error("LockedState._Lock.unlock is unimplemented on this platform")
+            #endif
+        }
+    }
+
+    private class _Buffer: ManagedBuffer<State, _Lock.Primitive> {
+        deinit {
+            withUnsafeMutablePointerToElements {
+                _Lock.deinitialize($0)
+            }
+        }
+    }
+
+    private let _buffer: ManagedBuffer<State, _Lock.Primitive>
+
+    package init(initialState: State) {
+        _buffer = _Buffer.create(
+            minimumCapacity: 1,
+            makingHeaderWith: { buf in
+                buf.withUnsafeMutablePointerToElements {
+                    _Lock.initialize($0)
+                }
+                return initialState
+            }
+        )
+    }
+
+    package func withLock<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try withLockUnchecked(body)
+    }
+
+    package func withLockUnchecked<T>(_ body: (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            defer { _Lock.unlock(lock) }
+            return try body(&state.pointee)
+        }
+    }
+
+    // Ensures the managed state outlives the locked scope.
+    package func withLockExtendingLifetimeOfState<T>(_ body: @Sendable (inout State) throws -> T) rethrows -> T {
+        try _buffer.withUnsafeMutablePointers { state, lock in
+            _Lock.lock(lock)
+            return try withExtendedLifetime(state.pointee) {
+                defer { _Lock.unlock(lock) }
+                return try body(&state.pointee)
+            }
+        }
+    }
+}
+
+extension LockedState where State == Void {
+    internal init() {
+        self.init(initialState: ())
+    }
+
+    internal func withLock<R: Sendable>(_ body: @Sendable () throws -> R) rethrows -> R {
+        return try withLock { _ in
+            try body()
+        }
+    }
+
+    internal func lock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.lock(lock)
+        }
+    }
+
+    internal func unlock() {
+        _buffer.withUnsafeMutablePointerToElements { lock in
+            _Lock.unlock(lock)
+        }
+    }
+}
+
+extension LockedState: @unchecked Sendable where State: Sendable {}
+
+#endif

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -335,6 +335,7 @@ extension Configuration: CustomStringConvertible, CustomDebugStringConvertible {
             )
             """
     }
+
 }
 
 // MARK: - Cleanup

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -14,7 +14,7 @@
 import Darwin
 internal import Dispatch
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -12,7 +12,7 @@
 #if canImport(Glibc) || canImport(Bionic) || canImport(Musl)
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -12,7 +12,7 @@
 #if canImport(Darwin) || canImport(Glibc) || canImport(Bionic) || canImport(Musl)
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -14,7 +14,7 @@
 import WinSDK
 internal import Dispatch
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/Result.swift
+++ b/Sources/Subprocess/Result.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -20,7 +20,7 @@ import FoundationEssentials
 #endif  // canImport(Darwin)
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Tests/SubprocessTests/SubprocessTests+Darwin.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Darwin.swift
@@ -17,7 +17,7 @@ import _SubprocessCShims
 import Testing
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Tests/SubprocessTests/SubprocessTests+Windows.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Windows.swift
@@ -17,7 +17,7 @@ import Testing
 import Dispatch
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif

--- a/Tests/TestResources/TestResources.swift
+++ b/Tests/TestResources/TestResources.swift
@@ -17,7 +17,7 @@ import WinSDK
 import Foundation
 
 #if canImport(System)
-import System
+@preconcurrency import System
 #else
 @preconcurrency import SystemPackage
 #endif


### PR DESCRIPTION
This PR introduces `AtomicBox` as an internal abstraction on atomic values. It uses `Atomic` on platforms where `Synchronization` is available, and falls back to `LockedState` otherwise.

I also had to expose `AsyncBufferSequence` as a public type due to a change in `AsyncSequence`: `AsyncSequence`'s [`Failure` ](https://github.com/swiftlang/swift/blob/e9253b749ff7cd4365985cd5e6ae773ae39d461d/stdlib/public/Concurrency/AsyncSequence.swift#L83) property has newer availability than `AsyncSequence` itself. This means we can't vend properties such as `var standardOutput: some AsyncSequence<Buffer, any Swift.Error>` on platforms "sandwiched" between the two availabilities (i.e. macOS 13) because the compiler requires this property to be at least the same availability as `AsyncSequence.Failure`. Unfortunately, there are no known workarounds besides just exposing the concrete type directly.

Tested on macOS 13.5 + Swift 6.0 / Swift 6.1