### PR TITLE
Update the swift-system package dependency requirement to 1.4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let availabilityMacro: SwiftSetting = .enableExperimentalFeature(
 var dep: [Package.Dependency] = [
     .package(
         url: "https://github.com/apple/swift-system",
-        from: "1.0.0"
+        from: "1.4.2"
     )
 ]
 #if !os(Windows)

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -19,7 +19,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-system",
-            from: "1.0.0"
+            from: "1.4.2"
         ),
         .package(
             url: "https://github.com/apple/swift-docc-plugin",

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -976,43 +976,6 @@ internal typealias PlatformFileDescriptor = HANDLE
 
 // MARK: - Pipe Support
 extension FileDescriptor {
-    internal static func pipe() throws -> (
-        readEnd: FileDescriptor,
-        writeEnd: FileDescriptor
-    ) {
-        var saAttributes: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES()
-        saAttributes.nLength = DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size)
-        saAttributes.bInheritHandle = true
-        saAttributes.lpSecurityDescriptor = nil
-
-        var readHandle: HANDLE? = nil
-        var writeHandle: HANDLE? = nil
-        guard CreatePipe(&readHandle, &writeHandle, &saAttributes, 0),
-            readHandle != INVALID_HANDLE_VALUE,
-            writeHandle != INVALID_HANDLE_VALUE,
-            let readHandle: HANDLE = readHandle,
-            let writeHandle: HANDLE = writeHandle
-        else {
-            throw SubprocessError(
-                code: .init(.failedToCreatePipe),
-                underlyingError: .init(rawValue: GetLastError())
-            )
-        }
-        let readFd = _open_osfhandle(
-            intptr_t(bitPattern: readHandle),
-            FileDescriptor.AccessMode.readOnly.rawValue
-        )
-        let writeFd = _open_osfhandle(
-            intptr_t(bitPattern: writeHandle),
-            FileDescriptor.AccessMode.writeOnly.rawValue
-        )
-
-        return (
-            readEnd: FileDescriptor(rawValue: readFd),
-            writeEnd: FileDescriptor(rawValue: writeFd)
-        )
-    }
-
     var platformDescriptor: PlatformFileDescriptor {
         return HANDLE(bitPattern: _get_osfhandle(self.rawValue))!
     }


### PR DESCRIPTION
1.4.0 introduced FileDescriptor.pipe() on Windows, use that implementation instead of duplicating it, which also resolves an ambiguous overload issue in the tests on newly cloned repos. 1.4.2 also has some FreeBSD and OpenBSD fixes and since this repo has some support for those platforms, we should pull it in as well.