### PR TITLE
Remove dead code causing a failure on Windows

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1235,13 +1235,4 @@ extension UInt8 {
     }
 }
 
-extension OutputProtocol {
-    internal func output(from data: [UInt8]) throws -> OutputType {
-        return try data.withUnsafeBytes {
-            let span = RawSpan(_unsafeBytes: $0)
-            return try self.output(from: span)
-        }
-    }
-}
-
 #endif  // canImport(WinSDK)


### PR DESCRIPTION
This appears to be unused, and causes the build to fail on Windows with Swift 6.1.