### PR TITLE
Restore the pipe() function removed in #17

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -870,7 +870,7 @@ internal struct CreatedPipe {
     }
 
     internal init(closeWhenDone: Bool) throws {
-        let pipe = try FileDescriptor.pipe()
+        let pipe = try FileDescriptor.ssp_pipe()
 
         self.readFileDescriptor = .init(
             pipe.readEnd,

--- a/Tests/SubprocessTests/SubprocessTests+Windows.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Windows.swift
@@ -762,7 +762,7 @@ extension SubprocessWindowsTests {
     @available(SubprocessSpan, *)
     #endif
     @Test func testRunDetached() async throws {
-        let (readFd, writeFd) = try FileDescriptor.pipe()
+        let (readFd, writeFd) = try FileDescriptor.ssp_pipe()
         SetHandleInformation(
             readFd.platformDescriptor,
             DWORD(HANDLE_FLAG_INHERIT),


### PR DESCRIPTION
This pipe() has different behavior than the pipe() provided by SwiftSystem.FileDescriptor, which this package relies on. Restore the original version and rename it to ssp_pipe() to avoid conflicting with the SwiftSystem copy.