### PR TITLE
Fix build error with static Linux SDK (Musl libc)

### DIFF
--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -251,6 +251,9 @@ int _subprocess_spawn(
 
 // MARK: - Linux (fork/exec + posix_spawn fallback)
 #if TARGET_OS_LINUX
+#ifndef __GLIBC_PREREQ
+#define __GLIBC_PREREQ(maj, min) 0
+#endif
 
 #if _POSIX_SPAWN
 static int _subprocess_is_addchdir_np_available() {


### PR DESCRIPTION
There, siginfo is defined differently, and Glibc macros are not available.

Closes #13