### PR TITLE
Block the package from building on iOS-derived platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let availabilityMacro: SwiftSetting = .enableExperimentalFeature(
-    "AvailabilityMacro=SubprocessSpan: macOS 9999",
+    "AvailabilityMacro=SubprocessSpan: macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, visionOS 9999",
 )
 
 var dep: [Package.Dependency] = [
@@ -31,7 +31,7 @@ defaultTraits.insert("SubprocessSpan")
 
 let package = Package(
     name: "Subprocess",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v13), .iOS("99.0")],
     products: [
         .library(
             name: "Subprocess",

--- a/Tests/SubprocessTests/SubprocessTests+Linting.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Linting.swift
@@ -25,7 +25,7 @@ private func enableLintingTest() -> Bool {
     } catch {
         return false
     }
-    #elseif os(Linux) || os(Windows)
+    #else
     // Use swift-format directly
     do {
         _ = try Executable.name("swift-format")
@@ -66,7 +66,7 @@ struct SubprocessLintingTest {
             executable: .path("/usr/bin/xcrun"),
             arguments: ["swift-format", "lint", "-s", "--recursive", sourcePath]
         )
-        #elseif os(Linux) || os(Windows)
+        #else
         let configuration = Configuration(
             executable: .name("swift-format"),
             arguments: ["lint", "-s", "--recursive", sourcePath]


### PR DESCRIPTION
Process spawning is not available there. Also remove a couple overly-specific platform conditions in tests that would be incorrect on other Unix-like platforms such as Android and FreeBSD.