### PR TITLE
Block signal masks pre-fork and restore post-fork.

### DIFF
--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -26,12 +26,12 @@ public struct AsyncBufferSequence: AsyncSequence, Sendable {
     public struct Iterator: AsyncIteratorProtocol {
         public typealias Element = SequenceOutput.Buffer
 
-        private let diskIO: DiskIO
+        private let diskIO: TrackedPlatformDiskIO
         private var buffer: [UInt8]
         private var currentPosition: Int
         private var finished: Bool
 
-        internal init(diskIO: DiskIO) {
+        internal init(diskIO: TrackedPlatformDiskIO) {
             self.diskIO = diskIO
             self.buffer = []
             self.currentPosition = 0
@@ -51,9 +51,9 @@ public struct AsyncBufferSequence: AsyncSequence, Sendable {
         }
     }
 
-    private let diskIO: DiskIO
+    private let diskIO: TrackedPlatformDiskIO
 
-    internal init(diskIO: DiskIO) {
+    internal init(diskIO: TrackedPlatformDiskIO) {
         self.diskIO = diskIO
     }
 

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -92,7 +92,7 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
     public var description: String {
         switch self.code.storage {
         case .spawnFailed:
-            return "Failed to spawn the new process."
+            return "Failed to spawn the new process with underlying error: \(self.underlyingError!)"
         case .executableNotFound(let executableName):
             return "Executable \"\(executableName)\" is not found or cannot be executed."
         case .failedToChangeWorkingDirectory(let workingDirectory):

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -42,6 +42,7 @@ public final class Execution<
 
     internal let output: Output
     internal let error: Error
+    internal let inputPipe: CreatedPipe
     internal let outputPipe: CreatedPipe
     internal let errorPipe: CreatedPipe
     internal let outputConsumptionState: AtomicBox
@@ -53,6 +54,7 @@ public final class Execution<
         processIdentifier: ProcessIdentifier,
         output: Output,
         error: Error,
+        inputPipe: CreatedPipe,
         outputPipe: CreatedPipe,
         errorPipe: CreatedPipe,
         consoleBehavior: PlatformOptions.ConsoleBehavior
@@ -60,6 +62,7 @@ public final class Execution<
         self.processIdentifier = processIdentifier
         self.output = output
         self.error = error
+        self.inputPipe = inputPipe
         self.outputPipe = outputPipe
         self.errorPipe = errorPipe
         self.outputConsumptionState = AtomicBox()
@@ -70,12 +73,14 @@ public final class Execution<
         processIdentifier: ProcessIdentifier,
         output: Output,
         error: Error,
+        inputPipe: CreatedPipe,
         outputPipe: CreatedPipe,
         errorPipe: CreatedPipe
     ) {
         self.processIdentifier = processIdentifier
         self.output = output
         self.error = error
+        self.inputPipe = inputPipe
         self.outputPipe = outputPipe
         self.errorPipe = errorPipe
         self.outputConsumptionState = AtomicBox()
@@ -98,11 +103,11 @@ extension Execution where Output == SequenceOutput {
         )
 
         guard consumptionState.contains(.standardOutputConsumed),
-            let fd = self.outputPipe.readFileDescriptor
+            let readFd = self.outputPipe.readFileDescriptor
         else {
             fatalError("The standard output has already been consumed")
         }
-        return AsyncBufferSequence(fileDescriptor: fd)
+        return AsyncBufferSequence(diskIO: readFd)
     }
 }
 
@@ -121,11 +126,11 @@ extension Execution where Error == SequenceOutput {
         )
 
         guard consumptionState.contains(.standardErrorConsumed),
-            let fd = self.errorPipe.readFileDescriptor
+            let readFd = self.errorPipe.readFileDescriptor
         else {
             fatalError("The standard output has already been consumed")
         }
-        return AsyncBufferSequence(fileDescriptor: fd)
+        return AsyncBufferSequence(diskIO: readFd)
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -354,9 +354,9 @@ extension Configuration {
                     processIdentifier: .init(value: pid),
                     output: output,
                     error: error,
-                    inputPipe: inputPipe.prepareForReadWrite(),
-                    outputPipe: outputPipe.prepareForReadWrite(),
-                    errorPipe: errorPipe.prepareForReadWrite()
+                    inputPipe: inputPipe.createInputPipe(),
+                    outputPipe: outputPipe.createOutputPipe(),
+                    errorPipe: errorPipe.createOutputPipe()
                 )
             }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -195,7 +195,7 @@ extension Configuration {
                 // Input
                 var result: Int32 = -1
                 if let inputRead = inputPipe.readFileDescriptor {
-                    result = posix_spawn_file_actions_adddup2(&fileActions, inputRead.wrapped.rawValue, 0)
+                    result = posix_spawn_file_actions_adddup2(&fileActions, inputRead.platformDescriptor, 0)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -206,7 +206,7 @@ extension Configuration {
                 }
                 if let inputWrite = inputPipe.writeFileDescriptor {
                     // Close parent side
-                    result = posix_spawn_file_actions_addclose(&fileActions, inputWrite.wrapped.rawValue)
+                    result = posix_spawn_file_actions_addclose(&fileActions, inputWrite.platformDescriptor)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -217,7 +217,7 @@ extension Configuration {
                 }
                 // Output
                 if let outputWrite = outputPipe.writeFileDescriptor {
-                    result = posix_spawn_file_actions_adddup2(&fileActions, outputWrite.wrapped.rawValue, 1)
+                    result = posix_spawn_file_actions_adddup2(&fileActions, outputWrite.platformDescriptor, 1)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -228,7 +228,7 @@ extension Configuration {
                 }
                 if let outputRead = outputPipe.readFileDescriptor {
                     // Close parent side
-                    result = posix_spawn_file_actions_addclose(&fileActions, outputRead.wrapped.rawValue)
+                    result = posix_spawn_file_actions_addclose(&fileActions, outputRead.platformDescriptor)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -239,7 +239,7 @@ extension Configuration {
                 }
                 // Error
                 if let errorWrite = errorPipe.writeFileDescriptor {
-                    result = posix_spawn_file_actions_adddup2(&fileActions, errorWrite.wrapped.rawValue, 2)
+                    result = posix_spawn_file_actions_adddup2(&fileActions, errorWrite.platformDescriptor, 2)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -250,7 +250,7 @@ extension Configuration {
                 }
                 if let errorRead = errorPipe.readFileDescriptor {
                     // Close parent side
-                    result = posix_spawn_file_actions_addclose(&fileActions, errorRead.wrapped.rawValue)
+                    result = posix_spawn_file_actions_addclose(&fileActions, errorRead.platformDescriptor)
                     guard result == 0 else {
                         try self.cleanupPreSpawn(input: inputPipe, output: outputPipe, error: errorPipe)
                         throw SubprocessError(
@@ -354,8 +354,9 @@ extension Configuration {
                     processIdentifier: .init(value: pid),
                     output: output,
                     error: error,
-                    outputPipe: outputPipe,
-                    errorPipe: errorPipe
+                    inputPipe: inputPipe.prepareForReadWrite(),
+                    outputPipe: outputPipe.prepareForReadWrite(),
+                    errorPipe: errorPipe.prepareForReadWrite()
                 )
             }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -71,12 +71,12 @@ extension Configuration {
                 }
                 // Setup input
                 let fileDescriptors: [CInt] = [
-                    inputPipe.readFileDescriptor?.wrapped.rawValue ?? -1,
-                    inputPipe.writeFileDescriptor?.wrapped.rawValue ?? -1,
-                    outputPipe.writeFileDescriptor?.wrapped.rawValue ?? -1,
-                    outputPipe.readFileDescriptor?.wrapped.rawValue ?? -1,
-                    errorPipe.writeFileDescriptor?.wrapped.rawValue ?? -1,
-                    errorPipe.readFileDescriptor?.wrapped.rawValue ?? -1,
+                    inputPipe.readFileDescriptor?.platformDescriptor ?? -1,
+                    inputPipe.writeFileDescriptor?.platformDescriptor ?? -1,
+                    outputPipe.writeFileDescriptor?.platformDescriptor ?? -1,
+                    outputPipe.readFileDescriptor?.platformDescriptor ?? -1,
+                    errorPipe.writeFileDescriptor?.platformDescriptor ?? -1,
+                    errorPipe.readFileDescriptor?.platformDescriptor ?? -1,
                 ]
 
                 let workingDirectory: String = self.workingDirectory.string
@@ -126,8 +126,9 @@ extension Configuration {
                     processIdentifier: .init(value: pid),
                     output: output,
                     error: error,
-                    outputPipe: outputPipe,
-                    errorPipe: errorPipe
+                    inputPipe: inputPipe.prepareForReadWrite(),
+                    outputPipe: outputPipe.prepareForReadWrite(),
+                    errorPipe: errorPipe.prepareForReadWrite()
                 )
             }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -126,9 +126,9 @@ extension Configuration {
                     processIdentifier: .init(value: pid),
                     output: output,
                     error: error,
-                    inputPipe: inputPipe.prepareForReadWrite(),
-                    outputPipe: outputPipe.prepareForReadWrite(),
-                    errorPipe: errorPipe.prepareForReadWrite()
+                    inputPipe: inputPipe.createInputPipe(),
+                    outputPipe: outputPipe.createOutputPipe(),
+                    errorPipe: errorPipe.createOutputPipe()
                 )
             }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -151,8 +151,9 @@ extension Configuration {
             processIdentifier: pid,
             output: output,
             error: error,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe,
+            inputPipe: inputPipe.prepareForReadWrite(),
+            outputPipe: outputPipe.prepareForReadWrite(),
+            errorPipe: errorPipe.prepareForReadWrite(),
             consoleBehavior: self.platformOptions.consoleBehavior
         )
     }
@@ -267,8 +268,9 @@ extension Configuration {
             processIdentifier: pid,
             output: output,
             error: error,
-            outputPipe: outputPipe,
-            errorPipe: errorPipe,
+            inputPipe: inputPipe.prepareForReadWrite(),
+            outputPipe: outputPipe.prepareForReadWrite(),
+            errorPipe: errorPipe.prepareForReadWrite(),
             consoleBehavior: self.platformOptions.consoleBehavior
         )
     }
@@ -1019,7 +1021,16 @@ extension FileDescriptor {
     var platformDescriptor: PlatformFileDescriptor {
         return HANDLE(bitPattern: _get_osfhandle(self.rawValue))!
     }
+}
 
+extension CreatedPipe {
+    /// On Windows, we use file descriptors directly
+    internal func prepareForReadWrite() -> CreatedPipe {
+        return self
+    }
+}
+
+extension DiskIO {
     internal func readChunk(upToLength maxLength: Int) async throws -> SequenceOutput.Buffer? {
         return try await withCheckedThrowingContinuation { continuation in
             self.readUntilEOF(
@@ -1039,6 +1050,9 @@ extension FileDescriptor {
         upToLength maxLength: Int,
         resultHandler: @Sendable @escaping (Swift.Result<[UInt8], any (Error & Sendable)>) -> Void
     ) {
+        guard case .fileDescriptor(let fd) = self.storage else {
+            fatalError("On Windows DiskIO should be backed by file descriptor")
+        }
         DispatchQueue.global(qos: .userInitiated).async {
             var totalBytesRead: Int = 0
             var lastError: DWORD? = nil
@@ -1053,7 +1067,7 @@ extension FileDescriptor {
                     let bufferPtr = baseAddress.advanced(by: totalBytesRead)
                     var bytesRead: DWORD = 0
                     let readSucceed = ReadFile(
-                        self.platformDescriptor,
+                        fd.platformDescriptor,
                         UnsafeMutableRawPointer(mutating: bufferPtr),
                         DWORD(maxLength - totalBytesRead),
                         &bytesRead,
@@ -1094,7 +1108,7 @@ extension FileDescriptor {
         }
     }
 
-    #if SubprocessSpan
+#if SubprocessSpan
     @available(SubprocessSpan, *)
     internal func write(
         _ span: borrowing RawSpan
@@ -1112,7 +1126,7 @@ extension FileDescriptor {
             }
         }
     }
-    #endif
+#endif
 
     internal func write(
         _ array: [UInt8]
@@ -1133,32 +1147,29 @@ extension FileDescriptor {
         }
     }
 
-    package func write(
+    internal func write(
         _ ptr: UnsafeRawBufferPointer,
         completion: @escaping (Int, Swift.Error?) -> Void
     ) {
-        func _write(
-            _ ptr: UnsafeRawBufferPointer,
-            count: Int,
-            completion: @escaping (Int, Swift.Error?) -> Void
-        ) {
-            var writtenBytes: DWORD = 0
-            let writeSucceed = WriteFile(
-                self.platformDescriptor,
-                ptr.baseAddress,
-                DWORD(count),
-                &writtenBytes,
-                nil
+        guard case .fileDescriptor(let fd) = self.storage else {
+            fatalError("On Windows DiskIO should be backed by file descriptor")
+        }
+        var writtenBytes: DWORD = 0
+        let writeSucceed = WriteFile(
+            fd.platformDescriptor,
+            ptr.baseAddress,
+            DWORD(ptr.count),
+            &writtenBytes,
+            nil
+        )
+        if !writeSucceed {
+            let error = SubprocessError(
+                code: .init(.failedToWriteToSubprocess),
+                underlyingError: .init(rawValue: GetLastError())
             )
-            if !writeSucceed {
-                let error = SubprocessError(
-                    code: .init(.failedToWriteToSubprocess),
-                    underlyingError: .init(rawValue: GetLastError())
-                )
-                completion(Int(writtenBytes), error)
-            } else {
-                completion(Int(writtenBytes), nil)
-            }
+            completion(Int(writtenBytes), error)
+        } else {
+            completion(Int(writtenBytes), nil)
         }
     }
 }

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -128,8 +128,8 @@ extension StandardInputWriter {
     }
 }
 
-extension DiskIO {
-    #if os(Windows)
+#if os(Windows)
+extension TrackedFileDescriptor {
     internal func write(
         _ data: Data
     ) async throws -> Int {
@@ -148,7 +148,9 @@ extension DiskIO {
             }
         }
     }
-    #else
+}
+#else
+extension TrackedDispatchIO {
     internal func write(
         _ data: Data
     ) async throws -> Int {
@@ -173,7 +175,7 @@ extension DiskIO {
             }
         }
     }
-    #endif
 }
+#endif // os(Windows)
 
 #endif  // SubprocessFoundation

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -111,7 +111,7 @@ extension StandardInputWriter {
     public func write(
         _ data: Data
     ) async throws -> Int {
-        return try await self.fileDescriptor.wrapped.write(data)
+        return try await self.diskIO.write(data)
     }
 
     /// Write a AsyncSequence of Data to the standard input of the subprocess.
@@ -128,7 +128,7 @@ extension StandardInputWriter {
     }
 }
 
-extension FileDescriptor {
+extension DiskIO {
     #if os(Windows)
     internal func write(
         _ data: Data

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -30,6 +30,7 @@
 #include <signal.h>
 #include <string.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #include <stdio.h>
 
@@ -83,6 +84,42 @@ vm_size_t _subprocess_vm_size(void) {
 }
 #endif
 
+// MARK: - Private Helpers
+static pthread_mutex_t _subprocess_fork_lock = PTHREAD_MUTEX_INITIALIZER;
+
+// Used after fork, before exec
+static int _subprocess_block_everything_but_something_went_seriously_wrong_signals(sigset_t *old_mask) {
+    sigset_t mask;
+    int r = 0;
+    r |= sigfillset(&mask);
+    r |= sigdelset(&mask, SIGABRT);
+    r |= sigdelset(&mask, SIGBUS);
+    r |= sigdelset(&mask, SIGFPE);
+    r |= sigdelset(&mask, SIGILL);
+    r |= sigdelset(&mask, SIGKILL);
+    r |= sigdelset(&mask, SIGSEGV);
+    r |= sigdelset(&mask, SIGSTOP);
+    r |= sigdelset(&mask, SIGSYS);
+    r |= sigdelset(&mask, SIGTRAP);
+
+    r |= pthread_sigmask(SIG_BLOCK, &mask, old_mask);
+    return r;
+}
+
+#define _subprocess_precondition(__cond) do { \
+    int eval = (__cond); \
+    if (!eval) { \
+        __builtin_trap(); \
+    } \
+} while(0)
+
+#if __DARWIN_NSIG
+#  define _SUBPROCESS_SIG_MAX __DARWIN_NSIG
+#else
+#  define _SUBPROCESS_SIG_MAX 32
+#endif
+
+
 // MARK: - Darwin (posix_spawn)
 #if TARGET_OS_MAC
 static int _subprocess_spawn_prefork(
@@ -97,6 +134,11 @@ static int _subprocess_spawn_prefork(
     int number_of_sgroups, const gid_t * _Nullable sgroups,
     int create_session
 ) {
+#define write_error_and_exit int error = errno; \
+    write(pipefd[1], &error, sizeof(error));\
+    close(pipefd[1]); \
+    _exit(EXIT_FAILURE)
+
     // Set `POSIX_SPAWN_SETEXEC` flag since we are forking ourselves
     short flags = 0;
     int rc = posix_spawnattr_getflags(spawn_attrs, &flags);
@@ -147,7 +189,7 @@ static int _subprocess_spawn_prefork(
 #pragma GCC diagnostic ignored "-Wdeprecated"
     pid_t childPid = fork();
 #pragma GCC diagnostic pop
-    if (childPid == -1) {
+    if (childPid < 0) {
         close(pipefd[0]);
         close(pipefd[1]);
         return errno;
@@ -160,28 +202,19 @@ static int _subprocess_spawn_prefork(
         // Perform setups
         if (number_of_sgroups > 0 && sgroups != NULL) {
             if (setgroups(number_of_sgroups, sgroups) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
         if (uid != NULL) {
             if (setuid(*uid) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
         if (gid != NULL) {
             if (setgid(*gid) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
@@ -197,20 +230,32 @@ static int _subprocess_spawn_prefork(
         _exit(EXIT_FAILURE);
     } else {
         // Parent process
-        close(pipefd[1]);  // Close unused write end
+        // Close unused write end
+        close(pipefd[1]);
         // Communicate child pid back
         *pid = childPid;
         // Read from the pipe until pipe is closed
-        // Eitehr due to exec succeeds or error is written
-        int childError = 0;
-        if (read(pipefd[0], &childError, sizeof(childError)) > 0) {
-            // We encountered error
-            close(pipefd[0]);
-            return childError;
-        } else {
-            // Child process exec was successful
-            close(pipefd[0]);
-            return 0;
+        // either due to exec succeeds or error is written
+        while (true) {
+            int childError = 0;
+            ssize_t read_rc = read(pipefd[0], &childError, sizeof(childError));
+            if (read_rc == 0) {
+                // exec worked!
+                close(pipefd[0]);
+                return 0;
+            } else if (read_rc > 0) {
+                // Child exec failed and reported back
+                close(pipefd[0]);
+                return childError;
+            } else {
+                // Read failed
+                if (errno == EINTR) {
+                    continue;
+                } else {
+                    close(pipefd[0]);
+                    return errno;
+                }
+            }
         }
     }
 }
@@ -416,6 +461,11 @@ int _subprocess_fork_exec(
     int create_session,
     void (* _Nullable configurator)(void)
 ) {
+#define write_error_and_exit int error = errno; \
+    write(pipefd[1], &error, sizeof(error));\
+    close(pipefd[1]); \
+    _exit(EXIT_FAILURE)
+
     int require_pre_fork = _subprocess_is_addchdir_np_available() == 0 ||
         uid != NULL ||
         gid != NULL ||
@@ -474,12 +524,27 @@ int _subprocess_fork_exec(
         return errno;
     }
 
+    // Protect the signal masking below
+    // Note that we only unlock in parent since child
+    // will be exec'd anyway
+    int rc = pthread_mutex_lock(&_subprocess_fork_lock);
+    _subprocess_precondition(rc == 0);
+    // Block all signals on this thread
+    sigset_t old_sigmask;
+    rc = _subprocess_block_everything_but_something_went_seriously_wrong_signals(&old_sigmask);
+    if (rc != 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return errno;
+    }
+
     // Finally, fork
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
     pid_t childPid = fork();
 #pragma GCC diagnostic pop
-    if (childPid == -1) {
+    if (childPid < 0) {
+        // Fork failed
         close(pipefd[0]);
         close(pipefd[1]);
         return errno;
@@ -489,41 +554,53 @@ int _subprocess_fork_exec(
         // Child process
         close(pipefd[0]);  // Close unused read end
 
+        // Reset signal handlers
+        for (int signo = 1; signo < _SUBPROCESS_SIG_MAX; signo++) {
+            if (signo == SIGKILL || signo == SIGSTOP) {
+                continue;
+            }
+            void (*err_ptr)(int) = signal(signo, SIG_DFL);
+            if (err_ptr != SIG_ERR) {
+                continue;
+            }
+
+            if (errno == EINVAL) {
+                break; // probably too high of a signal
+            }
+
+            write_error_and_exit;
+        }
+
+        // Reset signal mask
+        sigset_t sigset = { 0 };
+        sigemptyset(&sigset);
+        int rc = sigprocmask(SIG_SETMASK, &sigset, NULL) != 0;
+        if (rc != 0) {
+            write_error_and_exit;
+        }
+
         // Perform setups
         if (working_directory != NULL) {
             if (chdir(working_directory) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
-
         if (uid != NULL) {
             if (setuid(*uid) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
         if (gid != NULL) {
             if (setgid(*gid) != 0) {
-                int error =  errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
         if (number_of_sgroups > 0 && sgroups != NULL) {
             if (setgroups(number_of_sgroups, sgroups) != 0) {
-                int error = errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
 
@@ -536,23 +613,16 @@ int _subprocess_fork_exec(
         }
 
         // Bind stdin, stdout, and stderr
-        int rc = 0;
         if (file_descriptors[0] >= 0) {
             rc = dup2(file_descriptors[0], STDIN_FILENO);
             if (rc < 0) {
-                int error = errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
         if (file_descriptors[2] >= 0) {
             rc = dup2(file_descriptors[2], STDOUT_FILENO);
             if (rc < 0) {
-                int error = errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
+                write_error_and_exit;
             }
         }
         if (file_descriptors[4] >= 0) {
@@ -572,7 +642,7 @@ int _subprocess_fork_exec(
             rc = close(file_descriptors[3]);
         }
         if (file_descriptors[4] >= 0) {
-            rc = close(file_descriptors[5]);
+            rc = close(file_descriptors[4]);
         }
         if (rc != 0) {
             int error = errno;
@@ -587,26 +657,46 @@ int _subprocess_fork_exec(
         // Finally, exec
         execve(exec_path, args, env);
         // If we reached this point, something went wrong
-        int error = errno;
-        write(pipefd[1], &error, sizeof(error));
-        close(pipefd[1]);
-        _exit(EXIT_FAILURE);
+        write_error_and_exit;
     } else {
         // Parent process
         close(pipefd[1]);  // Close unused write end
+
+        // Restore old signmask
+        rc = pthread_sigmask(SIG_SETMASK, &old_sigmask, NULL);
+        if (rc != 0) {
+            close(pipefd[0]);
+            return errno;
+        }
+
+        // Unlock
+        rc = pthread_mutex_unlock(&_subprocess_fork_lock);
+        _subprocess_precondition(rc == 0);
+
         // Communicate child pid back
         *pid = childPid;
         // Read from the pipe until pipe is closed
-        // Eitehr due to exec succeeds or error is written
-        int childError = 0;
-        if (read(pipefd[0], &childError, sizeof(childError)) > 0) {
-            // We encountered error
-            close(pipefd[0]);
-            return childError;
-        } else {
-            // Child process exec was successful
-            close(pipefd[0]);
-            return 0;
+        // either due to exec succeeds or error is written
+        while (1) {
+            int childError = 0;
+            ssize_t read_rc = read(pipefd[0], &childError, sizeof(childError));
+            if (read_rc == 0) {
+                // exec worked!
+                close(pipefd[0]);
+                return 0;
+            } else if (read_rc > 0) {
+                // Child exec failed and reported back
+                close(pipefd[0]);
+                return childError;
+            } else {
+                // Read failed
+                if (errno == EINTR) {
+                    continue;
+                } else {
+                    close(pipefd[0]);
+                    return errno;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR introduces proper signal blocking and restoring for custom `fork/exec` on Linux.

Resolves: https://github.com/iCharlesHu/Subprocess/issues/45
Resolves: https://github.com/iCharlesHu/Subprocess/issues/46

—

During testing, one of the newly added tests revealed that we were not managing `DispatchIO` correctly during early terminations on Darwin and Linux. Currently, we simply close the file descriptors in the clean-up handler, which is incorrect because `DispatchIO` is used for read/write operations on these file descriptors. Modifying the file descriptor after it has been “transferred” to `DispatchIO` is considered a programmer error.

Rearchitect `TrackedFileDescriptor` (now renamed `DiskIO`) to either hold a `FileDescriptor` or a `DispatchIO`. We create `DispatchIO` as the final step of `spawn()` and use it for read/write operations and cleanup, instead of using a raw file descriptor. This allows `DispatchIO` to naturally close the file descriptor itself.