### PR TITLE
Allow both `standardOutput` and `standardError` to be streamed simultaneously with closure-based run.

### DIFF
--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -122,13 +122,13 @@ extension Execution where Error == SequenceOutput {
     /// via pipe under the hood and each pipe can only be consumed once.
     public var standardError: AsyncBufferSequence {
         let consumptionState = self.outputConsumptionState.bitwiseXor(
-            OutputConsumptionState.standardOutputConsumed
+            OutputConsumptionState.standardErrorConsumed
         )
 
         guard consumptionState.contains(.standardErrorConsumed),
             let readFd = self.errorPipe.readEnd
         else {
-            fatalError("The standard output has already been consumed")
+            fatalError("The standard error has already been consumed")
         }
         return AsyncBufferSequence(diskIO: readFd)
     }


### PR DESCRIPTION
This change fixes #41 by cleaning up a presumed simple copy/paste bug that prevents both the `standardOutput` and `standardError` sequences from being accessed in a single run closure.