### PR TITLE
Remove the default output buffer limit

### DIFF
--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -46,7 +46,7 @@ public protocol OutputProtocol: Sendable, ~Copyable {
 #endif
 extension OutputProtocol {
     /// The max amount of data to collect for this output.
-    public var maxSize: Int { 128 * 1024 }
+    public var maxSize: Int { .max }
 }
 
 /// A concrete `Output` type for subprocesses that indicates that
@@ -240,10 +240,9 @@ extension OutputProtocol where Self == FileDescriptorOutput {
 @available(SubprocessSpan, *)
 #endif
 extension OutputProtocol where Self == StringOutput<UTF8> {
-    /// Create a `Subprocess` output that collects output as
-    /// UTF8 String with 128kb limit.
+    /// Create a `Subprocess` output that collects output as UTF8 String
     public static var string: Self {
-        .init(limit: 128 * 1024, encoding: UTF8.self)
+        .init(limit: .max, encoding: UTF8.self)
     }
 }
 
@@ -265,9 +264,8 @@ extension OutputProtocol {
 @available(SubprocessSpan, *)
 #endif
 extension OutputProtocol where Self == BytesOutput {
-    /// Create a `Subprocess` output that collects output as
-    /// `Buffer` with 128kb limit.
-    public static var bytes: Self { .init(limit: 128 * 1024) }
+    /// Create a `Subprocess` output that collects output as `Buffer` 
+    public static var bytes: Self { .init(limit: .max) }
 
     /// Create a `Subprocess` output that collects output as
     /// `Buffer` up to limit it bytes.

--- a/Tests/SubprocessTests/SubprocessTests+Unix.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Unix.swift
@@ -955,6 +955,25 @@ extension SubprocessUnixTests {
         }
         #expect(result == .unhandledException(SIGKILL))
     }
+
+    @Test func testUnlimitedBufferByDefault() async throws {
+        guard #available(SubprocessSpan , *) else {
+            return
+        }
+
+        // Make sure we can read long text from standard input
+        let expected: Data = try Data(
+            contentsOf: URL(filePath: theMysteriousIsland.string)
+        )
+        // Launch cat with default output `.string`
+        let cat = try await Subprocess.run(
+            .path("/bin/cat"),
+            arguments: ["\(theMysteriousIsland.string)"]
+        )
+        #expect(cat.terminationStatus.isSuccess)
+        // Make sure we read all bytes
+        #expect(cat.standardOutput!.data(using: .utf8) == expected)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
This PR removes the output buffer limit by default when setting `.string` or `.bytes` as `output` or `error`.

Resolves https://github.com/swiftlang/swift-subprocess/issues/44