### PR TITLE
Fix an issue where standard error write file descriptor was incorrectly passed to fork/exec twice

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -82,7 +82,7 @@ extension Configuration {
                     outputWriteFileDescriptor?.platformDescriptor() ?? -1,
                     outputReadFileDescriptor?.platformDescriptor() ?? -1,
                     errorWriteFileDescriptor?.platformDescriptor() ?? -1,
-                    errorWriteFileDescriptor?.platformDescriptor() ?? -1,
+                    errorReadFileDescriptor?.platformDescriptor() ?? -1,
                 ]
 
                 let workingDirectory: String = self.workingDirectory.string

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -641,8 +641,8 @@ int _subprocess_fork_exec(
         if (file_descriptors[3] >= 0) {
             rc = close(file_descriptors[3]);
         }
-        if (file_descriptors[4] >= 0) {
-            rc = close(file_descriptors[4]);
+        if (file_descriptors[5] >= 0) {
+            rc = close(file_descriptors[5]);
         }
         if (rc != 0) {
             int error = errno;


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift-subprocess/issues/52