### PR TITLE
Remove the incorrect comment regarding _subprocess_block_everything_but_something_went_seriously_wrong_signals

### DIFF
--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -87,7 +87,6 @@ vm_size_t _subprocess_vm_size(void) {
 // MARK: - Private Helpers
 static pthread_mutex_t _subprocess_fork_lock = PTHREAD_MUTEX_INITIALIZER;
 
-// Used after fork, before exec
 static int _subprocess_block_everything_but_something_went_seriously_wrong_signals(sigset_t *old_mask) {
     sigset_t mask;
     int r = 0;


### PR DESCRIPTION
This function is called before fork.

Resolves https://github.com/swiftlang/swift-subprocess/issues/50