### PR TITLE
Make Configuration.workingDirectory optional

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -39,7 +39,8 @@ public struct Configuration: Sendable {
     /// The environment to use when running the executable.
     public var environment: Environment
     /// The working directory to use when running the executable.
-    public var workingDirectory: FilePath
+    /// If this property is `nil`, the subprocess will inherit the working directory from the parent process.
+    public var workingDirectory: FilePath?
     /// The platform specific options to use when
     /// running the subprocess.
     public var platformOptions: PlatformOptions
@@ -54,7 +55,7 @@ public struct Configuration: Sendable {
         self.executable = executable
         self.arguments = arguments
         self.environment = environment
-        self.workingDirectory = workingDirectory ?? .currentWorkingDirectory
+        self.workingDirectory = workingDirectory
         self.platformOptions = platformOptions
     }
 
@@ -107,7 +108,7 @@ extension Configuration: CustomStringConvertible, CustomDebugStringConvertible {
                 executable: \(self.executable.description),
                 arguments: \(self.arguments.description),
                 environment: \(self.environment.description),
-                workingDirectory: \(self.workingDirectory),
+                workingDirectory: \(self.workingDirectory?.string ?? ""),
                 platformOptions: \(self.platformOptions.description(withIndent: 1))
             )
             """
@@ -119,7 +120,7 @@ extension Configuration: CustomStringConvertible, CustomDebugStringConvertible {
                 executable: \(self.executable.debugDescription),
                 arguments: \(self.arguments.debugDescription),
                 environment: \(self.environment.debugDescription),
-                workingDirectory: \(self.workingDirectory),
+                workingDirectory: \(self.workingDirectory?.string ?? ""),
                 platformOptions: \(self.platformOptions.description(withIndent: 1))
             )
             """
@@ -711,14 +712,6 @@ internal struct CreatedPipe: ~Copyable {
             pipe.writeEnd,
             closeWhenDone: closeWhenDone
         )
-    }
-}
-
-extension FilePath {
-    static var currentWorkingDirectory: Self {
-        let path = getcwd(nil, 0)!
-        defer { free(path) }
-        return .init(String(cString: path))
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -84,7 +84,7 @@ extension Configuration {
                 try environment.withCString(
                     encodedAs: UTF16.self
                 ) { environmentW in
-                    try intendedWorkingDir.withNTPathRepresentation { intendedWorkingDirW in
+                    try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW in
                         let created = CreateProcessW(
                             applicationNameW,
                             UnsafeMutablePointer<WCHAR>(mutating: commandAndArgsW),
@@ -223,7 +223,7 @@ extension Configuration {
                             try environment.withCString(
                                 encodedAs: UTF16.self
                             ) { environmentW in
-                                try intendedWorkingDir.withNTPathRepresentation { intendedWorkingDirW in
+                                try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW in
                                     let created = CreateProcessWithLogonW(
                                         usernameW,
                                         domainW,
@@ -769,7 +769,7 @@ extension Configuration {
         applicationName: String?,
         commandAndArgs: String,
         environment: String,
-        intendedWorkingDir: String
+        intendedWorkingDir: String?
     ) {
         // Prepare environment
         var env: [String: String] = [:]
@@ -806,19 +806,21 @@ extension Configuration {
             commandAndArgs
         ) = try self.generateWindowsCommandAndAgruments()
         // Validate workingDir
-        guard Self.pathAccessible(self.workingDirectory.string) else {
-            throw SubprocessError(
-                code: .init(
-                    .failedToChangeWorkingDirectory(self.workingDirectory.string)
-                ),
-                underlyingError: nil
-            )
+        if let workingDirectory = self.workingDirectory?.string {
+            guard Self.pathAccessible(workingDirectory) else {
+                throw SubprocessError(
+                    code: .init(
+                        .failedToChangeWorkingDirectory(workingDirectory)
+                    ),
+                    underlyingError: nil
+                )
+            }
         }
         return (
             applicationName: applicationName,
             commandAndArgs: commandAndArgs,
             environment: environmentString,
-            intendedWorkingDir: self.workingDirectory.string
+            intendedWorkingDir: self.workingDirectory?.string
         )
     }
 

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -397,9 +397,11 @@ static int _subprocess_posix_spawn_fallback(
         if (rc != 0) { return rc; }
     }
     // Setup working directory
-    rc = _subprocess_addchdir_np(&file_actions, working_directory);
-    if (rc != 0) {
-        return rc;
+    if (working_directory != NULL) {
+        rc = _subprocess_addchdir_np(&file_actions, working_directory);
+        if (rc != 0) {
+            return rc;
+        }
     }
 
     // Close parent side


### PR DESCRIPTION
On all platforms, retrieving the current working directory is a failable operation. When a Configuration is given a null working directory, instead of resolving that to the current working directory at initialization time (which can't be done safely because Configuration.init is non-failable), make Configuration.workingDirectory optional and preserve any nil input through to process creation time. Both CreateProcess (Windows) and posix_spawn or fork/exec (POSIX) inherit the working directory of the calling process if it is not specified, so this doesn't change any behavior.

It also better matches the design of other properties on the Configuration struct like the Executable, which defer resolution of their concrete value rather than doing so at Configuration.init time.

Lastly, it removes incorrect code: the implementation of FilePath.currentWorkingDirectory could crash on POSIX platforms if the current directory was no longer accessible or getcwd failed for any other reason, and on Windows it would not properly support non-ASCII characters in path names nor path names longer than 260 characters.