### PR TITLE
Emulate POSIX_SPAWN_CLOEXEC_DEFAULT in fork/exec

### DIFF
--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -662,7 +662,7 @@ int _subprocess_fork_exec(
         #endif
         if (rc != 0) {
             // close_range failed (or doesn't exist), fall back to close()
-            for (int fd = STDERR_FILENO + 1; fd < _highest_possibly_open_fd(); fd++) {
+            for (int fd = STDERR_FILENO + 1; fd <= _highest_possibly_open_fd(); fd++) {
                 // We must NOT close pipefd[1] for writing errors
                 if (fd != pipefd[1]) {
                     close(fd);

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -1935,17 +1935,7 @@ extension SubprocessIntegrationTests {
         #expect(result.value.error == "hello stderr")
     }
 
-    @Test(
-        .disabled("Linux requires #46 to be fixed", {
-            #if os(Linux)
-            return true
-            #else
-            return false
-            #endif
-        }),
-        .bug("https://github.com/swiftlang/swift-subprocess/issues/46")
-    )
-    func testSubprocessPipeChain() async throws {
+    @Test func testSubprocessPipeChain() async throws {
         struct Pipe: @unchecked Sendable {
             #if os(Windows)
             let readEnd: HANDLE

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -312,17 +312,7 @@ extension SubprocessUnixTests {
         }
     }
 
-    @Test(
-        .disabled("Linux requires #46 to be fixed", {
-            #if os(Linux)
-            return true
-            #else
-            return false
-            #endif
-        }),
-        .bug("https://github.com/swiftlang/swift-subprocess/issues/46")
-    )
-    func testSubprocessDoesNotInheritVeryHighFileDescriptors() async throws {
+    @Test func testSubprocessDoesNotInheritVeryHighFileDescriptors() async throws {
         var openedFileDescriptors: [CInt] = []
         // Open /dev/null to use as source for duplication
         let devnull: FileDescriptor = try .openDevNull(withAccessMode: .readOnly)
@@ -389,17 +379,7 @@ extension SubprocessUnixTests {
         #expect(checklist.isEmpty)
     }
 
-    @Test(
-        .disabled("Linux requires #46 to be fixed", {
-            #if os(Linux)
-            return true
-            #else
-            return false
-            #endif
-        }),
-        .bug("https://github.com/swiftlang/swift-subprocess/issues/46")
-    )
-    func testSubprocessDoesNotInheritRandomFileDescriptors() async throws {
+    @Test(.requiresBash) func testSubprocessDoesNotInheritRandomFileDescriptors() async throws {
         let pipe = try FileDescriptor.ssp_pipe()
         defer {
             try? pipe.readEnd.close()
@@ -407,7 +387,7 @@ extension SubprocessUnixTests {
         }
         // Spawn bash and then attempt to write to the write end
         let result = try await Subprocess.run(
-            .path("/bin/sh"),
+            .path("/bin/bash"),
             arguments: [
                 "-c",
                 """


### PR DESCRIPTION
POSIX_SPAWN_CLOEXEC_DEFAULT is only available on Darwin. Emulate POSIX_SPAWN_CLOEXEC_DEFAULT on other platforms by calling close after fork, before exec.

This commit also removes _subprocess_posix_spawn_fallback because we can't emulate POSIX_SPAWN_CLOEXEC_DEFAULT in a thread-safe manner while using posix_spawn.

Resolves: https://github.com/swiftlang/swift-subprocess/issues/46
Resolves: https://github.com/swiftlang/swift-subprocess/issues/132