### PR TITLE
Correct test comment.

### DIFF
--- a/Tests/SubprocessTests/SubprocessTests+Unix.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Unix.swift
@@ -280,7 +280,7 @@ extension SubprocessUnixTests {
             input: .string(content, using: UTF8.self)
         )
         #expect(catResult.terminationStatus.isSuccess)
-        // We should have read exactly 0 bytes
+        // Output should match the input content
         #expect(catResult.standardOutput == content)
     }
 


### PR DESCRIPTION
I'm guessing this comment suffered from a copy-paste mismatch from the test above.