### PR TITLE
Expose platform-specific process file descriptors

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -191,7 +191,7 @@ extension Configuration {
 public struct ProcessIdentifier: Sendable, Hashable {
     /// The platform specific process identifier value
     public let value: pid_t
-    internal let processDescriptor: PlatformFileDescriptor
+    public let processDescriptor: CInt
 
     internal init(value: pid_t, processDescriptor: PlatformFileDescriptor) {
         self.value = value

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -677,9 +677,8 @@ extension Environment {
 public struct ProcessIdentifier: Sendable, Hashable {
     /// Windows specific process identifier value
     public let value: DWORD
-    internal nonisolated(unsafe) let processDescriptor: HANDLE
-    internal nonisolated(unsafe) let threadHandle: HANDLE
-
+    public nonisolated(unsafe) let processDescriptor: HANDLE
+    public nonisolated(unsafe) let threadHandle: HANDLE
 
     internal init(value: DWORD, processDescriptor: HANDLE, threadHandle: HANDLE) {
         self.value = value

--- a/Tests/SubprocessTests/PlatformConformance.swift
+++ b/Tests/SubprocessTests/PlatformConformance.swift
@@ -35,6 +35,15 @@ protocol ProcessIdentifierProtocol: Sendable, Hashable, CustomStringConvertible,
     #else
     var value: pid_t { get }
     #endif
+
+    #if os(Linux) || os(Android)
+    var processDescriptor: PlatformFileDescriptor { get }
+    #endif
+
+    #if os(Windows)
+    nonisolated(unsafe) var processDescriptor: PlatformFileDescriptor { get }
+    nonisolated(unsafe) var threadHandle: PlatformFileDescriptor { get }
+    #endif
 }
 
 extension ProcessIdentifier : ProcessIdentifierProtocol {}

--- a/Tests/SubprocessTests/SubprocessTests+Linux.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Linux.swift
@@ -114,6 +114,22 @@ struct SubprocessLinuxTests {
             #expect(result.terminationStatus == .unhandledException(SIGTERM))
         }
     }
+
+    @Test func testUniqueProcessIdentifier() async throws {
+        _ = try await Subprocess.run(
+            .path("/bin/echo"),
+            output: .discarded,
+            error: .discarded
+        ) { subprocess in
+            if subprocess.processIdentifier.processDescriptor > 0 {
+                var statinfo = stat()
+                try #require(fstat(subprocess.processIdentifier.processDescriptor, &statinfo) == 0)
+                
+                // In kernel 6.9+, st_ino globally uniquely identifies the process
+                #expect(statinfo.st_ino > 0)
+            }
+        }
+    }
 }
 
 fileprivate enum ProcessState: String {


### PR DESCRIPTION
Expose the pidfd on Linux and process/thread HANDLEs on Windows. This is necessary for interop with certain platform-native APIs, especially on Windows. pidfds are also gaining the ability to be used for more and more with each Linux kernel release.

One test has been introduced which shows how this API could be used to associate a subprocess with a Job Object using the Windows API, and for Linux, a "test" that shows one use case for access to the raw fd, which is to read the globally unique (to the boot session) identifier for the process, allowing processes sharing the same PID to be distinguished.

FreeBSD also has the concept of process file descriptors, and would expect to expose the same ProcessIdentifier API as for Linux. This may spread to other platforms in the future.

--

Somewhat related article with some good info: https://gaultier.github.io/blog/way_too_many_ways_to_wait_for_a_child_process_with_a_timeout.html