### PR TITLE
Fix remaining Windows test issues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,6 @@ jobs:
           dnf install -y procps
         fi
       windows_swift_versions: '["6.1", "nightly-main"]'
-      windows_build_command: 'swift build'
       enable_macos_checks: true
       macos_xcode_versions: '["16.3"]'
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 var dep: [Package.Dependency] = [
     .package(
         url: "https://github.com/apple/swift-system",
-        from: "1.4.2"
+        from: "1.5.0"
     )
 ]
 #if !os(Windows)

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1014,7 +1014,7 @@ extension FileDescriptor {
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 case .success(let bytes):
-                    continuation.resume(returning: bytes)
+                    continuation.resume(returning: bytes.isEmpty ? nil : bytes)
                 }
             }
         }


### PR DESCRIPTION
testPlatformOptionsCreateNewConsole: this test was meaning to assert that the values are different, not that they're the same. Fix this simple logic issue.
testRunDetached: this test never completed reading the output, because the write fd was kept open and reading never completed. Close the write fd before reading.
testInputSequenceCustomExecutionBody, testInputAsyncSequenceCustomExecutionBody, testRedirectedOutputRedirectToSequence: these tests hit an implementation issue where EOF was not correctly detected, leading to a hang. Change the logic to return nil if an empty buffer is received.

This patch also enables CI tests for Windows.