### PR TITLE
Subprocess: avoid some `strdup` deprecation warnings on Windows

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -533,9 +533,17 @@ internal enum StringOrRawBytes: Sendable, Hashable {
     func createRawBytes() -> UnsafeMutablePointer<CChar> {
         switch self {
         case .string(let string):
+#if os(Windows)
+            return _strdup(string)
+#else
             return strdup(string)
+#endif
         case .rawBytes(let rawBytes):
+#if os(Windows)
+            return _strdup(rawBytes)
+#else
             return strdup(rawBytes)
+#endif
         }
     }
 


### PR DESCRIPTION
Use the POSIX compliant `_strdup` on Windows instead of `strdup` to avoid some warnings when building.