### PR TITLE
build: replicate the SPM style build, address TODO

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -9,15 +9,5 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_library(Subprocess)
-
 add_subdirectory(_SubprocessCShims)
 add_subdirectory(Subprocess)
-
-target_compile_options(Subprocess PRIVATE
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StrictConcurrency>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTyeps>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Span>")
-
-target_link_libraries(Subprocess PRIVATE SystemPackage)

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -9,7 +9,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-target_sources(Subprocess PRIVATE
+add_library(Subprocess
   Execution.swift
   Buffer.swift
   Error.swift
@@ -24,9 +24,9 @@ target_sources(Subprocess PRIVATE
   SubprocessFoundation/Output+Foundation.swift
   SubprocessFoundation/Input+Foundation.swift
   Configuration.swift)
-
 if(WIN32)
-  target_sources(Subprocess PRIVATE Platforms/Subprocess+Windows.swift)
+  target_sources(Subprocess PRIVATE
+    Platforms/Subprocess+Windows.swift)
 elseif(LINUX OR ANDROID)
   target_sources(Subprocess PRIVATE
     Platforms/Subprocess+Linux.swift
@@ -36,3 +36,13 @@ elseif(APPLE)
     Platforms/Subprocess+Darwin.swift
     Platforms/Subprocess+Unix.swift)
 endif()
+
+target_compile_options(Subprocess PRIVATE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StrictConcurrency>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTyeps>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Span>")
+target_link_libraries(Subprocess PUBLIC
+  _SubprocessCShims)
+target_link_libraries(Subprocess PRIVATE
+  SwiftSystem::SystemPackage)

--- a/Sources/_SubprocessCShims/CMakeLists.txt
+++ b/Sources/_SubprocessCShims/CMakeLists.txt
@@ -9,7 +9,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-target_sources(Subprocess PRIVATE process_shims.c)
-
-target_include_directories(Subprocess PRIVATE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+add_library(_SubprocessCShims STATIC
+  process_shims.c)
+target_include_directories(_SubprocessCShims PUBLIC
+  include)

--- a/cmake/modules/InstallExternalDependencies.cmake
+++ b/cmake/modules/InstallExternalDependencies.cmake
@@ -11,17 +11,21 @@
 
 include_guard()
 
-# TODO: Use find_package to find a pre-built SwiftSystem
-
 include(FetchContent)
 
-FetchContent_Declare(SwiftSystem
-  GIT_REPOSITORY https://github.com/apple/swift-system.git
-  GIT_TAG a34201439c74b53f0fd71ef11741af7e7caf01e1 # 1.4.2
-  GIT_SHALLOW YES)
-list(APPEND dependencies SwiftSystem)
+find_package(SwiftSystem QUIET)
+if(NOT SwiftSystem_FOUND)
+  message("-- Vendoring swift-system")
+  FetchContent_Declare(SwiftSystem
+    GIT_REPOSITORY https://github.com/apple/swift-system.git
+    GIT_TAG a34201439c74b53f0fd71ef11741af7e7caf01e1 # 1.4.2
+    GIT_SHALLOW YES)
+  list(APPEND VendoredDependencies SwiftSystem)
+endif()
 
-
-if(dependencies)
-  FetchContent_MakeAvailable(${dependencies})
+if(VendoredDependencies)
+  FetchContent_MakeAvailable(${VendoredDependencies})
+  if(NOT TARGET SwiftSystem::SystemPackage)
+    add_library(SwiftSystem::SystemPackage ALIAS SystemPackage)
+  endif()
 endif()


### PR DESCRIPTION
This restructures the internal modules to match what we do in SPM. This is primarily to help make it easier to mirror behaviour.

Address the TODO, adding support to build against a swift-system build tree which is going to be required for integrating this into the Windows toolchain build. If one is not provided, continue the ability to vendor swift-system for ease of local development.