### PR TITLE
Introduce process file descriptor (pidfd) based process monitoring for Linux

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -103,7 +103,12 @@ public struct Configuration: Sendable {
         // even if `body` throws, and we are not leaving zombie processes in the
         // process table which will cause the process termination monitoring thread
         // to effectively hang due to the pid never being awaited
-        let terminationStatus = try await Subprocess.monitorProcessTermination(forExecution: _spawnResult.execution)
+        let terminationStatus = try await Subprocess.monitorProcessTermination(
+            for: execution.processIdentifier
+        )
+
+        // Close process file descriptor now we finished monitoring
+        execution.processIdentifier.close()
 
         return try ExecutionResult(terminationStatus: terminationStatus, value: result.get())
     }

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -34,23 +34,11 @@ public struct Execution: Sendable {
     /// The process identifier of the current execution
     public let processIdentifier: ProcessIdentifier
 
-    #if os(Windows)
-    internal let consoleBehavior: PlatformOptions.ConsoleBehavior
-
-    init(
-        processIdentifier: ProcessIdentifier,
-        consoleBehavior: PlatformOptions.ConsoleBehavior
-    ) {
-        self.processIdentifier = processIdentifier
-        self.consoleBehavior = consoleBehavior
-    }
-    #else
     init(
         processIdentifier: ProcessIdentifier
     ) {
         self.processIdentifier = processIdentifier
     }
-    #endif  // os(Windows)
 }
 
 // MARK: - Output Capture

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -35,16 +35,13 @@ public struct Execution: Sendable {
     public let processIdentifier: ProcessIdentifier
 
     #if os(Windows)
-    internal nonisolated(unsafe) let processInformation: PROCESS_INFORMATION
     internal let consoleBehavior: PlatformOptions.ConsoleBehavior
 
     init(
         processIdentifier: ProcessIdentifier,
-        processInformation: PROCESS_INFORMATION,
         consoleBehavior: PlatformOptions.ConsoleBehavior
     ) {
         self.processIdentifier = processIdentifier
-        self.processInformation = processInformation
         self.consoleBehavior = consoleBehavior
     }
     #else
@@ -54,17 +51,6 @@ public struct Execution: Sendable {
         self.processIdentifier = processIdentifier
     }
     #endif  // os(Windows)
-
-    internal func release() {
-        #if os(Windows)
-        guard CloseHandle(processInformation.hThread) else {
-            fatalError("Failed to close thread HANDLE: \(SubprocessError.UnderlyingError(rawValue: GetLastError()))")
-        }
-        guard CloseHandle(processInformation.hProcess) else {
-            fatalError("Failed to close process HANDLE: \(SubprocessError.UnderlyingError(rawValue: GetLastError()))")
-        }
-        #endif
-    }
 }
 
 // MARK: - Output Capture

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -117,7 +117,7 @@ extension Execution {
             try _kill(pid, signal: signal)
         } else {
             guard _pidfd_send_signal(
-                processIdentifier.processFileDescriptor,
+                processIdentifier.processDescriptor,
                 signal.rawValue
             ) == 0 else {
                 throw SubprocessError(

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -110,7 +110,7 @@ extension Execution {
         }
         let pid = shouldSendToProcessGroup ? -(processIdentifier.value) : processIdentifier.value
 
-        #if os(Linux)
+        #if os(Linux) || os(Android)
         // On linux, use pidfd_send_signal if possible
         if shouldSendToProcessGroup {
             // pidfd_send_signal does not support sending signal to process group

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -90,24 +90,6 @@ public struct Signal: Hashable, Sendable {
     public static var windowSizeChange: Self { .init(rawValue: SIGWINCH) }
 }
 
-// MARK: - ProcessIdentifier
-
-/// A platform independent identifier for a Subprocess.
-public struct ProcessIdentifier: Sendable, Hashable, Codable {
-    /// The platform specific process identifier value
-    public let value: pid_t
-
-    public init(value: pid_t) {
-        self.value = value
-    }
-}
-
-extension ProcessIdentifier: CustomStringConvertible, CustomDebugStringConvertible {
-    public var description: String { "\(self.value)" }
-
-    public var debugDescription: String { "\(self.value)" }
-}
-
 extension Execution {
     /// Send the given signal to the child process.
     /// - Parameters:
@@ -118,13 +100,35 @@ extension Execution {
         signal: Signal,
         toProcessGroup shouldSendToProcessGroup: Bool = false
     ) throws {
-        let pid = shouldSendToProcessGroup ? -(processIdentifier.value) : processIdentifier.value
-        guard kill(pid, signal.rawValue) == 0 else {
-            throw SubprocessError(
-                code: .init(.failedToSendSignal(signal.rawValue)),
-                underlyingError: .init(rawValue: errno)
-            )
+        func _kill(_ pid: pid_t, signal: Signal) throws {
+            guard kill(pid, signal.rawValue) == 0 else {
+                throw SubprocessError(
+                    code: .init(.failedToSendSignal(signal.rawValue)),
+                    underlyingError: .init(rawValue: errno)
+                )
+            }
         }
+        let pid = shouldSendToProcessGroup ? -(processIdentifier.value) : processIdentifier.value
+
+        #if os(Linux)
+        // On linux, use pidfd_send_signal if possible
+        if shouldSendToProcessGroup {
+            // pidfd_send_signal does not support sending signal to process group
+            try _kill(pid, signal: signal)
+        } else {
+            guard _pidfd_send_signal(
+                processIdentifier.processFileDescriptor,
+                signal.rawValue
+            ) == 0 else {
+                throw SubprocessError(
+                    code: .init(.failedToSendSignal(signal.rawValue)),
+                    underlyingError: .init(rawValue: errno)
+                )
+            }
+        }
+        #else
+        try _kill(pid, signal: signal)
+        #endif
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -140,8 +140,7 @@ extension Configuration {
             threadHandle: processInfo.hThread
         )
         let execution = Execution(
-            processIdentifier: pid,
-            consoleBehavior: self.platformOptions.consoleBehavior
+            processIdentifier: pid
         )
 
         do {
@@ -285,8 +284,7 @@ extension Configuration {
             threadHandle: processInfo.hThread
         )
         let execution = Execution(
-            processIdentifier: pid,
-            consoleBehavior: self.platformOptions.consoleBehavior
+            processIdentifier: pid
         )
 
         do {

--- a/Sources/Subprocess/Result.swift
+++ b/Sources/Subprocess/Result.swift
@@ -64,7 +64,6 @@ extension CollectedResult: Equatable where Output.OutputType: Equatable, Error.O
 
 extension CollectedResult: Hashable where Output.OutputType: Hashable, Error.OutputType: Hashable {}
 
-extension CollectedResult: Codable where Output.OutputType: Codable, Error.OutputType: Codable {}
 
 extension CollectedResult: CustomStringConvertible
 where Output.OutputType: CustomStringConvertible, Error.OutputType: CustomStringConvertible {
@@ -98,8 +97,6 @@ where Output.OutputType: CustomDebugStringConvertible, Error.OutputType: CustomD
 extension ExecutionResult: Equatable where Result: Equatable {}
 
 extension ExecutionResult: Hashable where Result: Hashable {}
-
-extension ExecutionResult: Codable where Result: Codable {}
 
 extension ExecutionResult: CustomStringConvertible where Result: CustomStringConvertible {
     public var description: String {

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -82,10 +82,11 @@ int _shims_snprintf(
     char * _Nonnull str2
 );
 
+int _pidfd_open(pid_t pid);
 int _pidfd_send_signal(int pidfd, int signal);
 
 // P_PIDFD is only defined on Linux Kernel 5.4 and above
-// Define our dummy value if it's not available
+// Define our value if it's not available
 #ifndef P_PIDFD
 #define P_PIDFD 3
 #endif

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -23,7 +23,9 @@
 
 #if TARGET_OS_LINUX
 #include <sys/epoll.h>
+#include <sys/wait.h>
 #include <sys/eventfd.h>
+#include <sys/signalfd.h>
 #endif // TARGET_OS_LINUX
 
 #if __has_include(<mach/vm_page_size.h>)
@@ -81,6 +83,13 @@ int _shims_snprintf(
 );
 
 int _pidfd_send_signal(int pidfd, int signal);
+
+// P_PIDFD is only defined on Linux Kernel 5.4 and above
+// Define our dummy value if it's not available
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
 #endif
 
 #endif // !TARGET_OS_WINDOWS

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -47,6 +47,7 @@ int _subprocess_spawn(
 
 int _subprocess_fork_exec(
     pid_t * _Nonnull pid,
+    int * _Nonnull pidfd,
     const char * _Nonnull exec_path,
     const char * _Nullable working_directory,
     const int file_descriptors[_Nonnull],
@@ -78,6 +79,8 @@ int _shims_snprintf(
     char * _Nonnull str1,
     char * _Nonnull str2
 );
+
+int _pidfd_send_signal(int pidfd, int signal);
 #endif
 
 #endif // !TARGET_OS_WINDOWS

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -14,6 +14,8 @@
 #if TARGET_OS_LINUX
 // For posix_spawn_file_actions_addchdir_np
 #define _GNU_SOURCE 1
+// For pidfd_open
+#include <sys/syscall.h>
 #endif
 
 #include "include/process_shims.h"
@@ -79,6 +81,11 @@ int _shims_snprintf(
 ) {
     return snprintf(str, len, format, str1, str2);
 }
+
+int _pidfd_send_signal(int pidfd, int signal) {
+    return syscall(SYS_pidfd_send_signal, pidfd, signal, NULL, 0);
+}
+
 #endif
 
 #if __has_include(<mach/vm_page_size.h>)
@@ -303,157 +310,13 @@ int _subprocess_spawn(
 #define __GLIBC_PREREQ(maj, min) 0
 #endif
 
-#if _POSIX_SPAWN
-static int _subprocess_is_addchdir_np_available() {
-#if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)
-    // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
-    //  - Amazon Linux 2 (EoL mid-2025)
-    return 0;
-#elif defined(__OpenBSD__) || defined(__QNX__)
-    // Currently missing as of:
-    //  - OpenBSD 7.5 (April 2024)
-    //  - QNX 8 (December 2023)
-    return 0;
-#elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || (defined(__ANDROID__) && __ANDROID_API__ >= 34) || defined(__musl__)
-    // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
-    //  - Solaris 11.3 (October 2015)
-    //  - Glibc 2.29 (February 2019)
-    //  - macOS 10.15 (October 2019)
-    //  - musl 1.1.24 (October 2019)
-    //  - FreeBSD 13.1 (May 2022)
-    //  - Android 14 (October 2023)
-    return 1;
-#else
-    // Standardized posix_spawn_file_actions_addchdir version (POSIX.1-2024, June 2024) available in:
-    //  - Solaris 11.4 (August 2018)
-    //  - NetBSD 10.0 (March 2024)
-    return 1;
-#endif
+static int _pidfd_open(pid_t pid) {
+    return syscall(SYS_pidfd_open, pid, 0);
 }
-
-static int _subprocess_addchdir_np(
-    posix_spawn_file_actions_t *file_actions,
-    const char * __restrict path
-) {
-#if defined(__GLIBC__) && !__GLIBC_PREREQ(2, 29)
-    // Glibc versions prior to 2.29 don't support posix_spawn_file_actions_addchdir_np, impacting:
-    //  - Amazon Linux 2 (EoL mid-2025)
-    return ENOTSUP;
-#elif defined(__ANDROID__) && __ANDROID_API__ < 34
-    // Android versions prior to 14 (API level 34) don't support posix_spawn_file_actions_addchdir_np
-    return ENOTSUP;
-#elif defined(__OpenBSD__) || defined(__QNX__)
-    // Currently missing as of:
-    //  - OpenBSD 7.5 (April 2024)
-    //  - QNX 8 (December 2023)
-    return ENOTSUP;
-#elif defined(__GLIBC__) || TARGET_OS_DARWIN || defined(__FreeBSD__) || defined(__ANDROID__) || defined(__musl__)
-    // Pre-standard posix_spawn_file_actions_addchdir_np version available in:
-    //  - Solaris 11.3 (October 2015)
-    //  - Glibc 2.29 (February 2019)
-    //  - macOS 10.15 (October 2019)
-    //  - musl 1.1.24 (October 2019)
-    //  - FreeBSD 13.1 (May 2022)
-    //  - Android 14 (API level 34) (October 2023)
-    return posix_spawn_file_actions_addchdir_np(file_actions, path);
-#else
-    // Standardized posix_spawn_file_actions_addchdir version (POSIX.1-2024, June 2024) available in:
-    //  - Solaris 11.4 (August 2018)
-    //  - NetBSD 10.0 (March 2024)
-    return posix_spawn_file_actions_addchdir(file_actions, path);
-#endif
-}
-
-static int _subprocess_posix_spawn_fallback(
-    pid_t * _Nonnull pid,
-    const char * _Nonnull exec_path,
-    const char * _Nullable working_directory,
-    const int file_descriptors[_Nonnull],
-    char * _Nullable const args[_Nonnull],
-    char * _Nullable const env[_Nullable],
-    gid_t * _Nullable process_group_id
-) {
-    // Setup stdin, stdout, and stderr
-    posix_spawn_file_actions_t file_actions;
-
-    int rc = posix_spawn_file_actions_init(&file_actions);
-    if (rc != 0) { return rc; }
-    if (file_descriptors[0] >= 0) {
-        rc = posix_spawn_file_actions_adddup2(
-            &file_actions, file_descriptors[0], STDIN_FILENO
-        );
-        if (rc != 0) { return rc; }
-    }
-    if (file_descriptors[2] >= 0) {
-        rc = posix_spawn_file_actions_adddup2(
-            &file_actions, file_descriptors[2], STDOUT_FILENO
-        );
-        if (rc != 0) { return rc; }
-    }
-    if (file_descriptors[4] >= 0) {
-        rc = posix_spawn_file_actions_adddup2(
-            &file_actions, file_descriptors[4], STDERR_FILENO
-        );
-        if (rc != 0) { return rc; }
-    }
-    // Setup working directory
-    if (working_directory != NULL) {
-        rc = _subprocess_addchdir_np(&file_actions, working_directory);
-        if (rc != 0) {
-            return rc;
-        }
-    }
-
-    // Close parent side
-    if (file_descriptors[1] >= 0) {
-        rc = posix_spawn_file_actions_addclose(&file_actions, file_descriptors[1]);
-        if (rc != 0) { return rc; }
-    }
-    if (file_descriptors[3] >= 0) {
-        rc = posix_spawn_file_actions_addclose(&file_actions, file_descriptors[3]);
-        if (rc != 0) { return rc; }
-    }
-    if (file_descriptors[5] >= 0) {
-        rc = posix_spawn_file_actions_addclose(&file_actions, file_descriptors[5]);
-        if (rc != 0) { return rc; }
-    }
-
-    // Setup spawnattr
-    posix_spawnattr_t spawn_attr;
-    rc = posix_spawnattr_init(&spawn_attr);
-    if (rc != 0) { return rc; }
-    // Masks
-    sigset_t no_signals;
-    sigset_t all_signals;
-    sigemptyset(&no_signals);
-    sigfillset(&all_signals);
-    rc = posix_spawnattr_setsigmask(&spawn_attr, &no_signals);
-    if (rc != 0) { return rc; }
-    rc = posix_spawnattr_setsigdefault(&spawn_attr, &all_signals);
-    if (rc != 0) { return rc; }
-    // Flags
-    short flags = POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF;
-    if (process_group_id != NULL) {
-        flags |= POSIX_SPAWN_SETPGROUP;
-        rc = posix_spawnattr_setpgroup(&spawn_attr, *process_group_id);
-        if (rc != 0) { return rc; }
-    }
-    rc = posix_spawnattr_setflags(&spawn_attr, flags);
-
-    // Spawn!
-    rc = posix_spawn(
-        pid, exec_path,
-        &file_actions, &spawn_attr,
-        args, env
-    );
-    posix_spawn_file_actions_destroy(&file_actions);
-    posix_spawnattr_destroy(&spawn_attr);
-    return rc;
-}
-#endif // _POSIX_SPAWN
 
 int _subprocess_fork_exec(
     pid_t * _Nonnull pid,
+    int * _Nonnull pidfd,
     const char * _Nonnull exec_path,
     const char * _Nullable working_directory,
     const int file_descriptors[_Nonnull],
@@ -470,32 +333,6 @@ int _subprocess_fork_exec(
     write(pipefd[1], &error, sizeof(error));\
     close(pipefd[1]); \
     _exit(EXIT_FAILURE)
-
-    int require_pre_fork = _subprocess_is_addchdir_np_available() == 0 ||
-        uid != NULL ||
-        gid != NULL ||
-        process_group_id != NULL ||
-        (number_of_sgroups > 0 && sgroups != NULL) ||
-        create_session ||
-        configurator != NULL;
-
-#if _POSIX_SPAWN
-    // If posix_spawn is available on this platform and
-    // we do not require prefork, use posix_spawn if possible.
-    //
-    // (Glibc's posix_spawn does not support
-    // `POSIX_SPAWN_SETEXEC` therefore we have to keep
-    // using fork/exec if `require_pre_fork` is true.
-    if (require_pre_fork == 0) {
-        return _subprocess_posix_spawn_fallback(
-            pid, exec_path,
-            working_directory,
-            file_descriptors,
-            args, env,
-            process_group_id
-        );
-    }
-#endif
 
     // Setup pipe to catch exec failures from child
     int pipefd[2];
@@ -557,8 +394,6 @@ int _subprocess_fork_exec(
 
     if (childPid == 0) {
         // Child process
-        close(pipefd[0]);  // Close unused read end
-
         // Reset signal handlers
         for (int signo = 1; signo < _SUBPROCESS_SIG_MAX; signo++) {
             if (signo == SIGKILL || signo == SIGSTOP) {
@@ -620,25 +455,31 @@ int _subprocess_fork_exec(
         // Bind stdin, stdout, and stderr
         if (file_descriptors[0] >= 0) {
             rc = dup2(file_descriptors[0], STDIN_FILENO);
-            if (rc < 0) {
-                write_error_and_exit;
-            }
+        } else {
+            rc = close(STDIN_FILENO);
         }
+        if (rc < 0) {
+            write_error_and_exit;
+        }
+
         if (file_descriptors[2] >= 0) {
             rc = dup2(file_descriptors[2], STDOUT_FILENO);
-            if (rc < 0) {
-                write_error_and_exit;
-            }
+        } else {
+            rc = close(STDOUT_FILENO);
         }
+        if (rc < 0) {
+            write_error_and_exit;
+        }
+
         if (file_descriptors[4] >= 0) {
             rc = dup2(file_descriptors[4], STDERR_FILENO);
-            if (rc < 0) {
-                int error = errno;
-                write(pipefd[1], &error, sizeof(error));
-                close(pipefd[1]);
-                _exit(EXIT_FAILURE);
-            }
+        } else {
+            rc = close(STDERR_FILENO);
         }
+        if (rc < 0) {
+            write_error_and_exit;
+        }
+
         // Close parent side
         if (file_descriptors[1] >= 0) {
             rc = close(file_descriptors[1]);
@@ -649,12 +490,11 @@ int _subprocess_fork_exec(
         if (file_descriptors[5] >= 0) {
             rc = close(file_descriptors[5]);
         }
-        if (rc != 0) {
-            int error = errno;
-            write(pipefd[1], &error, sizeof(error));
-            close(pipefd[1]);
-            _exit(EXIT_FAILURE);
+
+        if (rc < 0) {
+            write_error_and_exit;
         }
+
         // Run custom configuratior
         if (configurator != NULL) {
             configurator();
@@ -664,6 +504,10 @@ int _subprocess_fork_exec(
         // If we reached this point, something went wrong
         write_error_and_exit;
     } else {
+        int _pidfd = _pidfd_open(childPid);
+        if (_pidfd < 0) {
+            return errno;
+        }
         // Parent process
         close(pipefd[1]);  // Close unused write end
 
@@ -680,6 +524,7 @@ int _subprocess_fork_exec(
 
         // Communicate child pid back
         *pid = childPid;
+        *pidfd = _pidfd;
         // Read from the pipe until pipe is closed
         // either due to exec succeeds or error is written
         while (1) {

--- a/Tests/SubprocessTests/PlatformConformance.swift
+++ b/Tests/SubprocessTests/PlatformConformance.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Subprocess
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
+/// This file defines protocols for platform-specific structs
+/// and adds retroactive conformances to them to ensure they all
+/// conform to a uniform shape. We opted to keep these protocols
+/// in the test target as opposed to making them public APIs
+/// because we don't directly use them in public APIs.
+
+protocol ProcessIdentifierProtocol: Sendable, Hashable, CustomStringConvertible, CustomDebugStringConvertible {
+    #if os(Windows)
+    var value: DWORD { get }
+    #else
+    var value: pid_t { get }
+    #endif
+}
+
+extension ProcessIdentifier : ProcessIdentifierProtocol {}

--- a/Tests/SubprocessTests/SubprocessTests+Unix.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Unix.swift
@@ -779,12 +779,13 @@ extension SubprocessUnixTests {
     @Test func testTerminateProcess() async throws {
         let stuckResult = try await Subprocess.run(
             // This will intentionally hang
-            .path("/bin/cat"),
+            .path("/bin/sleep"),
+            arguments: ["infinity"],
+            output: .discarded,
             error: .discarded
-        ) { subprocess, standardOutput in
+        ) { subprocess in
             // Make sure we can send signals to terminate the process
             try subprocess.send(signal: .terminate)
-            for try await _ in standardOutput {}
         }
         guard case .unhandledException(let exception) = stuckResult.terminationStatus else {
             Issue.record("Wrong termination status reported: \(stuckResult.terminationStatus)")

--- a/Tests/SubprocessTests/SubprocessTests+Windows.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Windows.swift
@@ -453,9 +453,10 @@ extension SubprocessWindowsTests {
 
 // MARK: - PlatformOption Tests
 extension SubprocessWindowsTests {
-    // Disabled until we investigate CI specific failures
-    // https://github.com/swiftlang/swift-subprocess/issues/128
-    @Test(.enabled(if: false))
+    @Test(
+        .disabled("Disabled until we investigate CI specific failures"),
+        .bug("https://github.com/swiftlang/swift-subprocess/issues/128")
+    )
     func testPlatformOptionsRunAsUser() async throws {
         try await self.withTemporaryUser { username, password, succeed in
             // Use public directory as working directory so the newly created user

--- a/Tests/SubprocessTests/SubprocessTests+Windows.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Windows.swift
@@ -453,7 +453,9 @@ extension SubprocessWindowsTests {
 
 // MARK: - PlatformOption Tests
 extension SubprocessWindowsTests {
-    @Test(.enabled(if: SubprocessWindowsTests.hasAdminPrivileges()))
+    // Disabled until we investigate CI specific failures
+    // https://github.com/swiftlang/swift-subprocess/issues/128
+    @Test(.enabled(if: false))
     func testPlatformOptionsRunAsUser() async throws {
         try await self.withTemporaryUser { username, password, succeed in
             // Use public directory as working directory so the newly created user

--- a/Tests/SubprocessTests/SubprocessTests+Windows.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Windows.swift
@@ -455,7 +455,7 @@ extension SubprocessWindowsTests {
 extension SubprocessWindowsTests {
     @Test(.enabled(if: SubprocessWindowsTests.hasAdminPrivileges()))
     func testPlatformOptionsRunAsUser() async throws {
-        try await self.withTemporaryUser { username, password in
+        try await self.withTemporaryUser { username, password, succeed in
             // Use public directory as working directory so the newly created user
             // has access to it
             let workingDirectory = FilePath("C:\\Users\\Public")
@@ -497,6 +497,12 @@ extension SubprocessWindowsTests {
                         return ""
                     }
                     return String(decodingCString: pointer, as: UTF16.self)
+                }
+                // On CI, we might failed to create user due to privilege issues
+                // There's nothing much we can do in this case
+                guard succeed else {
+                    // If we fail to create the user, skip this test
+                    return true
                 }
                 // CreateProcessWithLogonW doesn't appear to work when running in a container
                 return whoamiResult.terminationStatus == .unhandledException(STATUS_DLL_INIT_FAILED) && userName() == "ContainerAdministrator"
@@ -693,16 +699,16 @@ extension SubprocessWindowsTests {
 // MARK: - User Utils
 extension SubprocessWindowsTests {
     private func withTemporaryUser(
-        _ work: (String, String) async throws -> Void
+        _ work: (String, String, Bool) async throws -> Void
     ) async throws {
         let username: String = "TestUser\(randomString(length: 5, lettersOnly: true))"
         let password: String = "Password\(randomString(length: 10))"
 
-        func createUser(withUsername username: String, password: String) {
-            username.withCString(
+        func createUser(withUsername username: String, password: String) -> Bool {
+            return username.withCString(
                 encodedAs: UTF16.self
             ) { usernameW in
-                password.withCString(
+                return password.withCString(
                     encodedAs: UTF16.self
                 ) { passwordW in
                     var userInfo: USER_INFO_1 = USER_INFO_1()
@@ -723,27 +729,30 @@ extension SubprocessWindowsTests {
                         &error
                     )
                     guard status == NERR_Success else {
-                        Issue.record("Failed to create user with error: \(error)")
-                        return
+                        return false
                     }
+                    return true
                 }
             }
         }
 
-        createUser(withUsername: username, password: password)
+        let succeed = createUser(withUsername: username, password: password)
+
         defer {
-            // Now delete the user
-            let status = username.withCString(
-                encodedAs: UTF16.self
-            ) { usernameW in
-                return NetUserDel(nil, usernameW)
-            }
-            if status != NERR_Success {
-                Issue.record("Failed to delete user with error: \(status)")
+            if succeed {
+                // Now delete the user
+                let status = username.withCString(
+                    encodedAs: UTF16.self
+                ) { usernameW in
+                    return NetUserDel(nil, usernameW)
+                }
+                if status != NERR_Success {
+                    Issue.record("Failed to delete user with error: \(status)")
+                }
             }
         }
         // Run work
-        try await work(username, password)
+        try await work(username, password, succeed)
     }
 
     private static func hasAdminPrivileges() -> Bool {


### PR DESCRIPTION
The current process monitoring code for Linux has a flaw that makes it susceptible to infinite hangs under specific conditions:
- The parent process uses any other method (other than Subprocess itself) to spawn new processes in addition to spawning with `Subprocess`.
- The parent process fails to properly reap the non-Subprocess-spawned process, leaving it as a zombie in the process table.

This is because currently, we rely on running `waitid()` with `P_ALL` and `WNOWAIT` in an infinite loop to detect possible child process state transitions. However, we don’t reap the child process (by specifying `WNOWAIT`) unless we (Subprocess) actually spawned the process.

Here’s a simplified pseudo-code to illustrate the issue:

```swift
while true {
    var siginfo = siginfo_t()
    // We’re not reaping the child process
    if waitid(P_ALL, id_t(0), &siginfo, WEXITED | WNOWAIT) == 0 {
        guard let c = savedContinuation else {
            // If there’s no saved continuation, we didn’t spawn the process
            // In this case, we don’t reap the child process
            continue
        }

        siginfo = siginfo_t()
        waitid(P_PID, numericCast(pid), &siginfo, WEXITED) // We’re actually reaping the child process
    }
}
```

With this setup, if there are zombie children in the process table without reaping, `waitid(P_ALL)` will repeatedly return the same (non-Subprocess-spawned) PID with every call, causing an infinite loop.

You can observe this behavior with the following sample code:

```swift
let arguments = "\"\""

let pid = arguments.withCString { args in
    var pid: pid_t = -1
    let status = posix_spawn(&pid, "/bin/echo", nil, nil, [strdup(args)] + [nil], environ)
    guard status == 0 else {
        fatalError("posix_spawn: \(status), errno: \(errno)")
    }
    return pid
}
print("echo pid: \(pid)")

let result = try await Subprocess.run(
    .path("/bin/cat"),
    arguments: ["Package.swift"],
    output: .string(limit: .max, encoding: UTF8.self),
    error: .discarded
)
print("cat finished: \(result.terminationStatus)")
print("cat output: \(result.standardOutput ?? "")")
```

After running this example, you’ll notice that the parent process seems to be stuck, and the “cat finished” message is never printed. This is because the parent process never calls `waitid` on the `echo` call, leaving it in the process table. Consequently, the monitor thread runs in an infinite loop.

While some may argue that this is not a bug in `Subprocess`, but rather an issue with the parent code, since the POSIX standard mandates that the process spawning child process must reap the child process via `waitid`. However, Subprocess should still not hang due to someone else’s bug.

To resolve this issue, switch to a **Linux-specific** process monitoring method by creating and observing the process file descriptor (pidfd) using epoll. This approach is similar to the epoll implementation introduced in https://github.com/swiftlang/swift-subprocess/pull/117, with the only difference being that we’re polling pidfd instead of a regular file descriptor.

As part of this change, I also unified the “process handle” design to make it easier to expose process handles to clients later (after the 1.0 release, as requested by https://github.com/swiftlang/swift-subprocess/pull/101). We chose to use `ProcessIdentifier` to host platform-specific process file descriptors and process handles because it perfectly aligns with the original use case. To ensure flexibility, we opted for a concrete `ProcessIdentifier` type instead of just a number, allowing us to add more information if necessary.