### PR TITLE
Remove the default collected output buffer limit and throw an error when the limit is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ let result = try await run(.path("/bin/exe"), platformOptions: platformOptions)
 
 By default, `Subprocess`:
 - Doesn’t send any input to the child process’s standard input
-- Captures the child process’s standard output as a `String`, up to 128kB
+- Asks the user how to capture the output
 - Ignores the child process’s standard error
 
 You can tailor how `Subprocess` handles the standard input, standard output, and standard error by setting the `input`, `output`, and `error` parameters:
@@ -222,13 +222,13 @@ Use it by setting `.fileDescriptor(closeAfterSpawningProcess:)` for `output` or 
 
 This option collects output as a `String` with the given encoding.
 
-Use it by setting `.string` or `.string(limit:encoding:)` for `output` or `error`.
+Use it by setting `.string(limit:encoding:)` for `output` or `error`.
 
 #### `BytesOutput`
 
 This option collects output as `[UInt8]`.
 
-Use it by setting `.bytes` or `.bytes(limit:)` for `output` or `error`.
+Use it by setting`.bytes(limit:)` for `output` or `error`.
 
 
 ### Cross-platform support

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -41,7 +41,7 @@ public func run<
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input = .none,
-    output: Output = .string,
+    output: Output,
     error: Error = .discarded
 ) async throws -> CollectedResult<Output, Error> {
     let configuration = Configuration(
@@ -84,7 +84,7 @@ public func run<
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: borrowing Span<InputElement>,
-    output: Output = .string,
+    output: Output,
     error: Error = .discarded
 ) async throws -> CollectedResult<Output, Error> {
     typealias RunResult = (
@@ -483,7 +483,7 @@ public func run<
 >(
     _ configuration: Configuration,
     input: Input = .none,
-    output: Output = .string,
+    output: Output,
     error: Error = .discarded
 ) async throws -> CollectedResult<Output, Error> {
     typealias RunResult = (

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -42,6 +42,7 @@ extension SubprocessError {
             case failedToMonitorProcess
             case streamOutputExceedsLimit(Int)
             case asyncIOFailed(String)
+            case outputBufferLimitExceeded(Int)
             // Signal
             case failedToSendSignal(Int32)
             // Windows Only
@@ -70,18 +71,20 @@ extension SubprocessError {
                 return 6
             case .asyncIOFailed(_):
                 return 7
-            case .failedToSendSignal(_):
+            case .outputBufferLimitExceeded(_):
                 return 8
-            case .failedToTerminate:
+            case .failedToSendSignal(_):
                 return 9
-            case .failedToSuspend:
+            case .failedToTerminate:
                 return 10
-            case .failedToResume:
+            case .failedToSuspend:
                 return 11
-            case .failedToCreatePipe:
+            case .failedToResume:
                 return 12
-            case .invalidWindowsPath(_):
+            case .failedToCreatePipe:
                 return 13
+            case .invalidWindowsPath(_):
+                return 14
             }
         }
 
@@ -113,6 +116,8 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
             return "Failed to create output from current buffer because the output limit (\(limit)) was reached."
         case .asyncIOFailed(let reason):
             return "An error occurred within the AsyncIO subsystem: \(reason). Underlying error: \(self.underlyingError!)"
+        case .outputBufferLimitExceeded(let limit):
+            return "Output exceeds the limit of \(limit) bytes."
         case .failedToSendSignal(let signal):
             return "Failed to send signal \(signal) to the child process."
         case .failedToTerminate:

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -43,13 +43,8 @@ public struct DataOutput: OutputProtocol {
 
 extension OutputProtocol where Self == DataOutput {
     /// Create a `Subprocess` output that collects output as `Data`
-    /// up to 128kb.
-    public static var data: Self {
-        return .data(limit: 128 * 1024)
-    }
-
-    /// Create a `Subprocess` output that collects output as `Data`
-    /// with given max number of bytes to collect.
+    /// with given buffer limit in bytes. Subprocess throws an error
+    /// if the child process emits more bytes than the limit.
     public static func data(limit: Int) -> Self {
         return .init(limit: limit)
     }

--- a/Tests/SubprocessTests/SubprocessTests+Darwin.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Darwin.swift
@@ -41,7 +41,7 @@ struct SubprocessDarwinTests {
             .path("/bin/bash"),
             arguments: ["-c", "ps -o pid,pgid,tpgid -p $$"],
             platformOptions: platformOptions,
-            output: .string
+            output: .string(limit: .max)
         )
         try assertNewSessionCreated(with: psResult)
     }
@@ -58,7 +58,7 @@ struct SubprocessDarwinTests {
         let pwdResult = try await Subprocess.run(
             .path("/bin/pwd"),
             platformOptions: platformOptions,
-            output: .string
+            output: .string(limit: .max)
         )
         #expect(pwdResult.terminationStatus.isSuccess)
         let currentDir = try #require(

--- a/Tests/SubprocessTests/SubprocessTests+Linting.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Linting.swift
@@ -72,7 +72,7 @@ struct SubprocessLintingTest {
         let lintResult = try await Subprocess.run(
             configuration,
             output: .discarded,
-            error: .string
+            error: .string(limit: .max)
         )
         #expect(
             lintResult.terminationStatus.isSuccess,

--- a/Tests/SubprocessTests/SubprocessTests+Linux.swift
+++ b/Tests/SubprocessTests/SubprocessTests+Linux.swift
@@ -50,8 +50,8 @@ struct SubprocessLinuxTests {
             .path("/usr/bin/id"),
             arguments: ["-g"],
             platformOptions: platformOptions,
-            output: .string,
-            error: .string
+            output: .string(limit: 32),
+            error: .string(limit: 32)
         )
         let error = try #require(idResult.standardError)
         try #require(error == "")


### PR DESCRIPTION
As discussed in https://github.com/swiftlang/swift-subprocess/issues/44 , remove the default output limit since we can't really specify one. Also throw an error if output exits limit.

Resolves: https://github.com/swiftlang/swift-subprocess/issues/44