### PR TITLE
Windows: Add PIPE_REJECT_REMOTE_CLIENTS flag to CreateNamedPipeW to explicitly disallow remote pipes

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -864,7 +864,7 @@ internal struct CreatedPipe: ~Copyable {
                 return CreateNamedPipeW(
                     pipeNameW,
                     openMode,
-                    DWORD(PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT),
+                    DWORD(PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS),
                     1, // Max instance,
                     DWORD(readBufferSize),
                     DWORD(readBufferSize),


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/swift-subprocess/pull/117 to address https://github.com/swiftlang/swift-subprocess/pull/117#discussion_r2239283128