### PR TITLE
Remove Codable from TerminationStatus

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -456,7 +456,7 @@ extension Environment: CustomStringConvertible, CustomDebugStringConvertible {
 
 /// An exit status of a subprocess.
 @frozen
-public enum TerminationStatus: Sendable, Hashable, Codable {
+public enum TerminationStatus: Sendable, Hashable {
     #if canImport(WinSDK)
     public typealias Code = DWORD
     #else


### PR DESCRIPTION
It doesn't seem like there's any good reason for this to be Codable. It was already removed from:

- ProcessIdentifier
- ExecutionResult (conditionally)
- CollectedResult (conditionally)

Closes #107