### PR TITLE
Disable tests which double-close file descriptors

### DIFF
--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -973,17 +973,19 @@ extension SubprocessIntegrationTests {
             options: .create,
             permissions: [.ownerReadWrite, .groupReadWrite]
         )
-        let echoResult = try await _run(
-            setup,
-            input: .none,
-            output: .fileDescriptor(
-                outputFile,
-                closeAfterSpawningProcess: false
-            ),
-            error: .discarded
-        )
-        #expect(echoResult.terminationStatus.isSuccess)
-        try outputFile.close()
+        let echoResult = try await outputFile.closeAfter {
+            let echoResult = try await _run(
+                setup,
+                input: .none,
+                output: .fileDescriptor(
+                    outputFile,
+                    closeAfterSpawningProcess: false
+                ),
+                error: .discarded
+            )
+            #expect(echoResult.terminationStatus.isSuccess)
+            return echoResult
+        }
         let outputData: Data = try Data(
             contentsOf: URL(filePath: outputFilePath.string)
         )
@@ -994,7 +996,7 @@ extension SubprocessIntegrationTests {
         #expect(output == expected)
     }
 
-    @Test func testFileDescriptorOutputAutoClose() async throws {
+    @Test(.disabled("Cannot ever safely call unbalanced close() on the same fd")) func testFileDescriptorOutputAutoClose() async throws {
         #if os(Windows)
         let setup = TestSetup(
             executable: .name("cmd.exe"),
@@ -1254,17 +1256,19 @@ extension SubprocessIntegrationTests {
             options: .create,
             permissions: [.ownerReadWrite, .groupReadWrite]
         )
-        let echoResult = try await _run(
-            setup,
-            input: .none,
-            output: .discarded,
-            error: .fileDescriptor(
-                outputFile,
-                closeAfterSpawningProcess: false
+        let echoResult = try await outputFile.closeAfter {
+            let echoResult = try await _run(
+                setup,
+                input: .none,
+                output: .discarded,
+                error: .fileDescriptor(
+                    outputFile,
+                    closeAfterSpawningProcess: false
+                )
             )
-        )
-        #expect(echoResult.terminationStatus.isSuccess)
-        try outputFile.close()
+            #expect(echoResult.terminationStatus.isSuccess)
+            return echoResult
+        }
         let outputData: Data = try Data(
             contentsOf: URL(filePath: outputFilePath.string)
         )
@@ -1275,7 +1279,7 @@ extension SubprocessIntegrationTests {
         #expect(output == expected)
     }
 
-    @Test func testFileDescriptorErrorOutputAutoClose() async throws {
+    @Test(.disabled("Cannot ever safely call unbalanced close() on the same fd")) func testFileDescriptorErrorOutputAutoClose() async throws {
         #if os(Windows)
         let setup = TestSetup(
             executable: .name("cmd.exe"),
@@ -1338,20 +1342,22 @@ extension SubprocessIntegrationTests {
             options: .create,
             permissions: [.ownerReadWrite, .groupReadWrite]
         )
-        let echoResult = try await _run(
-            setup,
-            input: .none,
-            output: .fileDescriptor(
-                outputFile,
-                closeAfterSpawningProcess: false
-            ),
-            error: .fileDescriptor(
-                outputFile,
-                closeAfterSpawningProcess: false
+        let echoResult = try await outputFile.closeAfter {
+            let echoResult = try await _run(
+                setup,
+                input: .none,
+                output: .fileDescriptor(
+                    outputFile,
+                    closeAfterSpawningProcess: false
+                ),
+                error: .fileDescriptor(
+                    outputFile,
+                    closeAfterSpawningProcess: false
+                )
             )
-        )
-        #expect(echoResult.terminationStatus.isSuccess)
-        try outputFile.close()
+            #expect(echoResult.terminationStatus.isSuccess)
+            return echoResult
+        }
         let outputData: Data = try Data(
             contentsOf: URL(filePath: outputFilePath.string)
         )

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -299,6 +299,12 @@ extension SubprocessProcessMonitoringTests {
         let testCount = 100
         var spawnedProcesses: [ProcessIdentifier] = []
 
+        defer {
+            for pid in spawnedProcesses {
+                pid.close()
+            }
+        }
+
         for _ in 0 ..< testCount {
             let config = self.immediateExitProcess(withExitCode: 0)
             let spawnResult = try config.spawn(
@@ -307,12 +313,6 @@ extension SubprocessProcessMonitoringTests {
                 errorPipe: self.devNullOutputPipe()
             )
             spawnedProcesses.append(spawnResult.execution.processIdentifier)
-        }
-
-        defer {
-            for pid in spawnedProcesses {
-                pid.close()
-            }
         }
 
         try await withThrowingTaskGroup { group in


### PR DESCRIPTION
A couple tests attempt to double-close a file descriptor. You cannot ever safely do this as even the act of spawning a process itself may have re-allocated the same file descriptor in the calling process - for example, the pidfd file descriptor, or other threads may have changed state. Disable these tests until we figure out what to do with them. It's possible the solution may involve [#161](https://github.com/swiftlang/swift-subprocess/issues/161), where Subprocess's own FileDescriptor type can have its own logic for refusing to double-close, and we validate the condition at that level rather than at the POSIX level.

Also moves some other code to using closeAfter to guarantee proper cleanup.