### PR TITLE
Darwin: check for EACCES when spawning processes

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -433,7 +433,7 @@ extension Configuration {
                 }
                 // Spawn error
                 if spawnError != 0 {
-                    if spawnError == ENOENT {
+                    if spawnError == ENOENT || spawnError == EACCES {
                         // Move on to another possible path
                         continue
                     }


### PR DESCRIPTION
This was mistakenly not in sync with the Linux implementation.