### PR TITLE
Call spawn() on a background thread because it might block

### DIFF
--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(Subprocess
   Buffer.swift
   Error.swift
   Teardown.swift
+  Thread.swift
   Result.swift
   IO/Output.swift
   IO/Input.swift

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -84,7 +84,7 @@ public struct Configuration: Sendable {
         isolation: isolated (any Actor)? = #isolation,
         _ body: ((Execution, consuming IOChannel?, consuming IOChannel?, consuming IOChannel?) async throws -> Result)
     ) async throws -> ExecutionResult<Result> {
-        let spawnResults = try self.spawn(
+        let spawnResults = try await self.spawn(
             withInput: input,
             outputPipe: output,
             errorPipe: error

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -660,7 +660,11 @@ internal struct IODescriptor: ~Copyable {
     #endif
 
     internal var closeWhenDone: Bool
+    #if canImport(WinSDK)
+    internal nonisolated(unsafe) let descriptor: Descriptor
+    #else
     internal let descriptor: Descriptor
+    #endif
 
     internal init(
         _ descriptor: Descriptor,

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -153,11 +153,24 @@ extension PlatformOptions: CustomStringConvertible, CustomDebugStringConvertible
 
 // MARK: - Spawn
 extension Configuration {
+    // @unchecked Sendable because we need to capture UnsafePointers
+    // to send to another thread. While UnsafePointers are not
+    // Sendable, we are not mutating them -- we only need these type
+    // for C interface.
+    internal struct SpawnContext: @unchecked Sendable {
+        let fileActions: posix_spawn_file_actions_t?
+        let spawnAttributes: posix_spawnattr_t?
+        let argv: [UnsafeMutablePointer<CChar>?]
+        let env: [UnsafeMutablePointer<CChar>?]
+        let uidPtr: UnsafeMutablePointer<uid_t>?
+        let gidPtr: UnsafeMutablePointer<gid_t>?
+    }
+
     internal func spawn(
         withInput inputPipe: consuming CreatedPipe,
         outputPipe: consuming CreatedPipe,
         errorPipe: consuming CreatedPipe
-    ) throws -> SpawnResult {
+    ) async throws -> SpawnResult {
         // Instead of checking if every possible executable path
         // is valid, spawn each directly and catch ENOENT
         let possiblePaths = self.executable.possibleExecutablePaths(
@@ -167,7 +180,7 @@ extension Configuration {
         var outputPipeBox: CreatedPipe? = consume outputPipe
         var errorPipeBox: CreatedPipe? = consume errorPipe
 
-        return try self.preSpawn { args throws -> SpawnResult in
+        return try await self.preSpawn { args throws -> SpawnResult in
             let (env, uidPtr, gidPtr, supplementaryGroups) = args
             var _inputPipe = inputPipeBox.take()!
             var _outputPipe = outputPipeBox.take()!
@@ -181,8 +194,6 @@ extension Configuration {
             let errorWriteFileDescriptor: IODescriptor? = _errorPipe.writeFileDescriptor()
 
             for possibleExecutablePath in possiblePaths {
-                var pid: pid_t = 0
-
                 // Setup Arguments
                 let argv: [UnsafeMutablePointer<CChar>?] = self.arguments.createArgs(
                     withExecutablePath: possibleExecutablePath
@@ -389,21 +400,35 @@ extension Configuration {
                 }
 
                 // Spawn
-                let spawnError: CInt = possibleExecutablePath.withCString { exePath in
-                    return supplementaryGroups.withOptionalUnsafeBufferPointer { sgroups in
-                        return _subprocess_spawn(
-                            &pid,
-                            exePath,
-                            &fileActions,
-                            &spawnAttributes,
-                            argv,
-                            env,
-                            uidPtr,
-                            gidPtr,
-                            Int32(supplementaryGroups?.count ?? 0),
-                            sgroups?.baseAddress,
-                            self.platformOptions.createSession ? 1 : 0
-                        )
+                let spawnContext = SpawnContext(
+                    fileActions: fileActions,
+                    spawnAttributes: spawnAttributes,
+                    argv: argv,
+                    env: env,
+                    uidPtr: uidPtr,
+                    gidPtr: gidPtr
+                )
+                let (spawnError, pid) = try await runOnBackgroundThread {
+                    return possibleExecutablePath.withCString { exePath in
+                        return supplementaryGroups.withOptionalUnsafeBufferPointer { sgroups in
+                            var pid: pid_t = 0
+                            var _fileActions = spawnContext.fileActions
+                            var _spawnAttributes = spawnContext.spawnAttributes
+                            let rc = _subprocess_spawn(
+                                &pid,
+                                exePath,
+                                &_fileActions,
+                                &_spawnAttributes,
+                                spawnContext.argv,
+                                spawnContext.env,
+                                spawnContext.uidPtr,
+                                spawnContext.gidPtr,
+                                Int32(supplementaryGroups?.count ?? 0),
+                                sgroups?.baseAddress,
+                                self.platformOptions.createSession ? 1 : 0
+                            )
+                            return (rc, pid)
+                        }
                     }
                 }
                 // Spawn error

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -225,9 +225,9 @@ private func monitorThreadFunc(context: MonitorThreadContext) {
         repeating: epoll_event(events: 0, data: epoll_data(fd: 0)),
         count: 256
     )
-    var waitMask = sigset_t();
-    sigemptyset(&waitMask);
-    sigaddset(&waitMask, SIGCHLD);
+    var waitMask = sigset_t()
+    sigemptyset(&waitMask)
+    sigaddset(&waitMask, SIGCHLD)
     // Enter the monitor loop
     monitorLoop: while true {
         let eventCount = epoll_pwait(

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -350,8 +350,8 @@ extension Configuration {
     )
 
     internal func preSpawn<Result: ~Copyable>(
-        _ work: (PreSpawnArgs) throws -> Result
-    ) throws -> Result {
+        _ work: (PreSpawnArgs) async throws -> Result
+    ) async throws -> Result {
         // Prepare environment
         let env = self.environment.createEnv()
         defer {
@@ -378,7 +378,7 @@ extension Configuration {
         if let groupsValue = self.platformOptions.supplementaryGroups {
             supplementaryGroups = groupsValue
         }
-        return try work(
+        return try await work(
             (
                 env: env,
                 uidPtr: uidPtr,

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -1,0 +1,325 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
+internal import Dispatch
+import _SubprocessCShims
+
+#if canImport(Synchronization)
+import Synchronization
+#endif
+
+#if canImport(Darwin)
+internal func runOnBackgroundThread<Result>(
+    _ body: @Sendable @escaping () throws -> Result
+) async throws -> Result {
+    let result = try await withCheckedThrowingContinuation { continuation in
+        // On Darwin, use DispatchQueue directly
+        DispatchQueue.global().async {
+            do {
+                let result = try body()
+                continuation.resume(returning: result)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+    return result
+}
+#else
+
+#if canImport(WinSDK)
+private typealias MutexType = CRITICAL_SECTION
+private typealias ConditionType = CONDITION_VARIABLE
+private typealias ThreadType = HANDLE
+#else
+private typealias MutexType = pthread_mutex_t
+private typealias ConditionType = pthread_cond_t
+private typealias ThreadType = pthread_t
+#endif
+
+private struct BackgroundWorkItem {
+    private let work: @Sendable () -> Void
+
+    init<Result>(
+        _ body: @Sendable @escaping () throws -> Result,
+        continuation: CheckedContinuation<Result, Error>
+    ) {
+        self.work = {
+            do {
+                let result = try body()
+                continuation.resume(returning: result)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    func run() {
+        self.work()
+    }
+}
+
+// We can't use Mutex directly here because we need the underlying `pthread_mutex_t` to be
+// exposed so we can use it with `pthread_cond_wait`.
+private final class WorkQueue: Sendable {
+    private nonisolated(unsafe) var queue: [BackgroundWorkItem]
+    internal nonisolated(unsafe) let mutex: UnsafeMutablePointer<MutexType>
+    internal nonisolated(unsafe) let waitCondition: UnsafeMutablePointer<ConditionType>
+
+    init() {
+        self.queue = []
+        self.mutex = UnsafeMutablePointer<MutexType>.allocate(capacity: 1)
+        self.waitCondition = UnsafeMutablePointer<ConditionType>.allocate(capacity: 1)
+        #if canImport(WinSDK)
+        InitializeCriticalSection(self.mutex)
+        InitializeConditionVariable(self.waitCondition)
+        #else
+        pthread_mutex_init(self.mutex, nil)
+        pthread_cond_init(self.waitCondition, nil)
+        #endif
+    }
+
+    func withLock<R>(_ body: (inout [BackgroundWorkItem]) throws -> R) rethrows -> R {
+        try withUnsafeUnderlyingLock { _, queue in
+            try body(&queue)
+        }
+    }
+
+    private func withUnsafeUnderlyingLock<R>(
+        _ body: (UnsafeMutablePointer<MutexType>, inout [BackgroundWorkItem]) throws -> R
+    ) rethrows -> R {
+        #if canImport(WinSDK)
+        EnterCriticalSection(self.mutex)
+        defer {
+            LeaveCriticalSection(self.mutex);
+        }
+        #else
+        pthread_mutex_lock(self.mutex)
+        defer {
+            pthread_mutex_unlock(mutex)
+        }
+        #endif
+        return try body(mutex, &queue)
+    }
+
+    // Only called in worker thread. Sleeps the thread if there's no more item
+    func dequeue() -> BackgroundWorkItem? {
+        return self.withUnsafeUnderlyingLock { mutex, queue in
+            if queue.isEmpty {
+                // Sleep the worker thread if there's no more work
+                #if canImport(WinSDK)
+                SleepConditionVariableCS(self.waitCondition, mutex, INFINITE)
+                #else
+                pthread_cond_wait(self.waitCondition, mutex)
+                #endif
+            }
+            guard !queue.isEmpty else {
+                return nil
+            }
+            return queue.removeFirst()
+        }
+    }
+
+    // Only called in parent thread. Signals wait condition to wake up worker thread
+    func enqueue(_ workItem: BackgroundWorkItem) {
+        self.withLock { queue in
+            queue.append(workItem)
+            #if canImport(WinSDK)
+            WakeConditionVariable(self.waitCondition);
+            #else
+            pthread_cond_signal(self.waitCondition)
+            #endif
+        }
+    }
+
+    func shutdown() {
+        self.withLock { queue in
+            queue.removeAll()
+            #if canImport(WinSDK)
+            WakeConditionVariable(self.waitCondition);
+            #else
+            pthread_cond_signal(self.waitCondition)
+            #endif
+        }
+    }
+}
+
+private let _workQueue = WorkQueue()
+private let _workQueueShutdownFlag: Atomic<UInt8> = Atomic(0)
+
+// Okay to be unlocked global mutable because this value is only set once like dispatch_once
+private nonisolated(unsafe) var _workerThread: Result<ThreadType, any Error> = .failure(SubprocessError(code: .init(.spawnFailed), underlyingError: nil))
+
+private let setupWorkerThread: () = {
+    do {
+        #if canImport(WinSDK)
+        let workerThread = try begin_thread_x {
+            while true {
+                // This dequeue call will suspend the thread if there's no more work left
+                guard let workItem = _workQueue.dequeue() else {
+                    break
+                }
+                workItem.run()
+            }
+            return 0
+        }
+        #else
+        let workerThread = try pthread_create {
+            while true {
+                // This dequeue call will suspend the thread if there's no more work left
+                guard let workItem = _workQueue.dequeue() else {
+                    break
+                }
+                workItem.run()
+            }
+        }
+        #endif
+        _workerThread = .success(workerThread)
+    } catch {
+        _workerThread = .failure(error)
+    }
+
+    atexit {
+        _shutdownWorkerThread()
+    }
+}()
+
+private func _shutdownWorkerThread() {
+    guard case .success(let thread) = _workerThread else {
+        return
+    }
+    guard _workQueueShutdownFlag.add(1, ordering: .sequentiallyConsistent).newValue == 1 else {
+        // We already shutdown this thread
+        return
+    }
+    _workQueue.shutdown()
+    #if canImport(WinSDK)
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+    DeleteCriticalSection(_workQueue.mutex)
+    // We do not need to destroy CONDITION_VARIABLE
+    #else
+    pthread_join(thread, nil)
+    pthread_mutex_destroy(_workQueue.mutex)
+    pthread_cond_destroy(_workQueue.waitCondition)
+    #endif
+    _workQueue.mutex.deallocate()
+    _workQueue.waitCondition.deallocate()
+}
+
+internal func runOnBackgroundThread<Result>(
+    _ body: @Sendable @escaping () throws -> Result
+) async throws -> Result {
+    // Only executed once
+    setupWorkerThread
+
+    let result = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Result, any Error>) in
+        let workItem = BackgroundWorkItem(body, continuation: continuation)
+        _workQueue.enqueue(workItem)
+    }
+    return result
+}
+
+#endif
+
+// MARK: - Thread Creation Primitives
+#if canImport(Glibc) || canImport(Bionic) || canImport(Musl)
+internal func pthread_create(
+    _ body: @Sendable @escaping () -> ()
+) throws(SubprocessError.UnderlyingError) -> pthread_t {
+    final class Context {
+        let body: @Sendable () -> ()
+        init(body: @Sendable @escaping () -> Void) {
+            self.body = body
+        }
+    }
+    #if canImport(Glibc) || canImport(Musl)
+    func proc(_ context: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
+        (Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Context).body()
+        return nil
+    }
+    #elseif canImport(Bionic)
+    func proc(_ context: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
+        (Unmanaged<AnyObject>.fromOpaque(context).takeRetainedValue() as! Context).body()
+        return context
+    }
+    #endif
+    #if canImport(Glibc) || canImport(Bionic)
+    var thread = pthread_t()
+    #else
+    var thread: pthread_t?
+    #endif
+    let rc = pthread_create(
+        &thread,
+        nil,
+        proc,
+        Unmanaged.passRetained(Context(body: body)).toOpaque()
+    )
+    if rc != 0 {
+        throw SubprocessError.UnderlyingError(rawValue: rc)
+    }
+    #if canImport(Glibc) || canImport(Bionic)
+    return thread
+    #else
+    return thread!
+    #endif
+}
+
+#elseif canImport(WinSDK)
+/// Microsoft documentation for `CreateThread` states:
+/// > A thread in an executable that calls the C run-time library (CRT)
+/// > should use the _beginthreadex and _endthreadex functions for
+/// > thread management rather than CreateThread and ExitThread
+internal func begin_thread_x(
+    _ body: @Sendable @escaping () -> UInt32
+) throws(SubprocessError.UnderlyingError) -> HANDLE {
+    final class Context {
+        let body: @Sendable () -> UInt32
+        init(body: @Sendable @escaping () -> UInt32) {
+            self.body = body
+        }
+    }
+
+    func proc(_ context: UnsafeMutableRawPointer?) -> UInt32 {
+        return Unmanaged<Context>.fromOpaque(context!).takeRetainedValue().body()
+    }
+
+    let threadHandleValue = _beginthreadex(
+        nil,
+        0,
+        proc,
+        Unmanaged.passRetained(Context(body: body)).toOpaque(),
+        0,
+        nil
+    )
+    guard threadHandleValue != 0,
+          let threadHandle = HANDLE(bitPattern: threadHandleValue) else {
+        // _beginthreadex uses errno instead of GetLastError()
+        let capturedError = _subprocess_windows_get_errno()
+        throw SubprocessError.UnderlyingError(rawValue: DWORD(capturedError))
+    }
+
+    return threadHandle
+}
+#endif
+

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -106,7 +106,7 @@ private final class WorkQueue: Sendable {
         #if canImport(WinSDK)
         EnterCriticalSection(self.mutex)
         defer {
-            LeaveCriticalSection(self.mutex);
+            LeaveCriticalSection(self.mutex)
         }
         #else
         pthread_mutex_lock(self.mutex)
@@ -140,7 +140,7 @@ private final class WorkQueue: Sendable {
         self.withLock { queue in
             queue.append(workItem)
             #if canImport(WinSDK)
-            WakeConditionVariable(self.waitCondition);
+            WakeConditionVariable(self.waitCondition)
             #else
             pthread_cond_signal(self.waitCondition)
             #endif
@@ -151,7 +151,7 @@ private final class WorkQueue: Sendable {
         self.withLock { queue in
             queue.removeAll()
             #if canImport(WinSDK)
-            WakeConditionVariable(self.waitCondition);
+            WakeConditionVariable(self.waitCondition)
             #else
             pthread_cond_signal(self.waitCondition)
             #endif
@@ -209,8 +209,8 @@ private func _shutdownWorkerThread() {
     }
     _workQueue.shutdown()
     #if canImport(WinSDK)
-    WaitForSingleObject(thread, INFINITE);
-    CloseHandle(thread);
+    WaitForSingleObject(thread, INFINITE)
+    CloseHandle(thread)
     DeleteCriticalSection(_workQueue.mutex)
     // We do not need to destroy CONDITION_VARIABLE
     #else
@@ -225,7 +225,7 @@ private func _shutdownWorkerThread() {
 // MARK: - AtomicCounter
 
 #if canImport(Darwin)
-// Unfortunately on Darwin we can unconditionally use Atomic since it requires macOS 15
+// Unfortunately on Darwin we cannot unconditionally use Atomic since it requires macOS 15
 internal struct AtomicCounter: ~Copyable {
     private let storage: OSAllocatedUnfairLock<UInt8>
 

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -29,7 +29,6 @@ import _SubprocessCShims
 import Synchronization
 #endif
 
-
 #if canImport(WinSDK)
 private typealias MutexType = CRITICAL_SECTION
 private typealias ConditionType = CONDITION_VARIABLE
@@ -285,7 +284,8 @@ internal func begin_thread_x(
         nil
     )
     guard threadHandleValue != 0,
-          let threadHandle = HANDLE(bitPattern: threadHandleValue) else {
+        let threadHandle = HANDLE(bitPattern: threadHandleValue)
+    else {
         // _beginthreadex uses errno instead of GetLastError()
         let capturedError = _subprocess_windows_get_errno()
         throw SubprocessError.UnderlyingError(rawValue: DWORD(capturedError))
@@ -304,28 +304,28 @@ internal func pthread_create(
             self.body = body
         }
     }
-#if canImport(Darwin)
+    #if canImport(Darwin)
     func proc(_ context: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
         (Unmanaged<AnyObject>.fromOpaque(context).takeRetainedValue() as! Context).body()
         return context
     }
-#elseif canImport(Glibc) || canImport(Musl)
+    #elseif canImport(Glibc) || canImport(Musl)
     func proc(_ context: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
         (Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Context).body()
         return context
     }
-#elseif canImport(Bionic)
+    #elseif canImport(Bionic)
     func proc(_ context: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
         (Unmanaged<AnyObject>.fromOpaque(context).takeRetainedValue() as! Context).body()
         return context
     }
-#endif
+    #endif
 
-#if canImport(Glibc) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Bionic)
     var thread = pthread_t()
-#else
+    #else
     var thread: pthread_t?
-#endif
+    #endif
     let rc = pthread_create(
         &thread,
         nil,
@@ -335,12 +335,11 @@ internal func pthread_create(
     if rc != 0 {
         throw SubprocessError.UnderlyingError(rawValue: rc)
     }
-#if canImport(Glibc) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Bionic)
     return thread
-#else
+    #else
     return thread!
-#endif
+    #endif
 }
 
 #endif // canImport(WinSDK)
-

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -135,7 +135,8 @@ extension SubprocessAsyncIOTests {
 
 // MARK: - Error Handling Tests
 extension SubprocessAsyncIOTests {
-    @Test func testWriteToClosedPipe() async throws {
+    @Test(.disabled("Cannot safely write to a closed fd without risking it being reused"))
+    func testWriteToClosedPipe() async throws {
         var pipe = try CreatedPipe(closeWhenDone: true, purpose: .input)
         var writeChannel = try _require(pipe.writeFileDescriptor()).createIOChannel()
         var readChannel = try _require(pipe.readFileDescriptor()).createIOChannel()
@@ -171,7 +172,8 @@ extension SubprocessAsyncIOTests {
 
     }
 
-    @Test func testReadFromClosedPipe() async throws {
+    @Test(.disabled("Cannot safely read from a closed fd without risking it being reused"))
+    func testReadFromClosedPipe() async throws {
         var pipe = try CreatedPipe(closeWhenDone: true, purpose: .input)
         var writeChannel = try _require(pipe.writeFileDescriptor()).createIOChannel()
         var readChannel = try _require(pipe.readFileDescriptor()).createIOChannel()

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -103,7 +103,7 @@ struct SubprocessProcessMonitoringTests {
         config: Configuration,
         _ body: (Execution) async throws -> Void
     ) async throws {
-        let spawnResult = try config.spawn(
+        let spawnResult = try await config.spawn(
             withInput: self.devNullInputPipe(),
             outputPipe: self.devNullOutputPipe(),
             errorPipe: self.devNullOutputPipe()
@@ -307,7 +307,7 @@ extension SubprocessProcessMonitoringTests {
 
         for _ in 0..<testCount {
             let config = self.immediateExitProcess(withExitCode: 0)
-            let spawnResult = try config.spawn(
+            let spawnResult = try await config.spawn(
                 withInput: self.devNullInputPipe(),
                 outputPipe: self.devNullOutputPipe(),
                 errorPipe: self.devNullOutputPipe()


### PR DESCRIPTION
Introduce `runOnBackgroundThread()` to run closures on a background thread without blocking the Swift Concurrency thread pool.

On Darwin, `runOnBackgroundThread()` uses `DispatchQueue`; on Linux and Windows, it uses a single thread in the work loop.

Resolves: https://github.com/swiftlang/swift-subprocess/issues/85