### PR TITLE
Various bug fixes throughout the code base

### DIFF
--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -1337,22 +1337,19 @@ extension SubprocessIntegrationTests {
             options: .create,
             permissions: [.ownerReadWrite, .groupReadWrite]
         )
-        let echoResult = try await outputFile.closeAfter {
-            let echoResult = try await _run(
-                setup,
-                input: .none,
-                output: .fileDescriptor(
-                    outputFile,
-                    closeAfterSpawningProcess: false
-                ),
-                error: .fileDescriptor(
-                    outputFile,
-                    closeAfterSpawningProcess: false
-                )
+        let echoResult = try await _run(
+            setup,
+            input: .none,
+            output: .fileDescriptor(
+                outputFile,
+                closeAfterSpawningProcess: true
+            ),
+            error: .fileDescriptor(
+                outputFile,
+                closeAfterSpawningProcess: true
             )
-            #expect(echoResult.terminationStatus.isSuccess)
-            return echoResult
-        }
+        )
+        #expect(echoResult.terminationStatus.isSuccess)
         let outputData: Data = try Data(
             contentsOf: URL(filePath: outputFilePath.string)
         )


### PR DESCRIPTION
- Instead of calling `[UInt8].removeFirst` on `LineSequence`’s `underlyingBuffer`, we now use an index-based approach. This change improves overall streaming performance by eliminating the `O(n)` `.removeFirst()` operation.
- The `safelyCloseMultiple` function has been updated to handle cases where the same `IODescriptor` is passed to multiple input/outputs.
- On Linux, `_highest_possibly_open_fd_dir_linux()` has been updated to `_close_open_fd_linux()` to more efficiently emulate `POSIX_SPAWN_CLOEXEC_DEFAULT`.

Resolves: https://github.com/swiftlang/swift-subprocess/issues/165, https://github.com/swiftlang/swift-subprocess/issues/160, https://github.com/swiftlang/swift-subprocess/issues/159