### PR TITLE
CMake fixes to allow use in dependent projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,5 @@ add_subdirectory(Sources)
 export(EXPORT SwiftSubprocessTargets
   FILE "cmake/SwiftSubprocess/SwiftSubprocessTargets.cmake"
   NAMESPACE "SwiftSubprocess::")
+
+add_subdirectory(cmake/modules)

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -41,13 +41,13 @@ elseif(APPLE)
     Platforms/Subprocess+Darwin.swift
     Platforms/Subprocess+Unix.swift)
   target_compile_options(Subprocess PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-D SUBPROCESS_ASYNCIO_DISPATCH>")
+    "$<$<COMPILE_LANGUAGE:Swift>:-DSUBPROCESS_ASYNCIO_DISPATCH>")
 elseif(FREEBSD OR OPENBSD)
   target_sources(Subprocess PRIVATE
     Platforms/Subprocess+BSD.swift
     Platforms/Subprocess+Unix.swift)
   target_compile_options(Subprocess PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-D SUBPROCESS_ASYNCIO_DISPATCH>")
+    "$<$<COMPILE_LANGUAGE:Swift>:-DSUBPROCESS_ASYNCIO_DISPATCH>")
 endif()
 
 target_compile_options(Subprocess PRIVATE

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -40,10 +40,14 @@ elseif(APPLE)
     Platforms/Subprocess+BSD.swift
     Platforms/Subprocess+Darwin.swift
     Platforms/Subprocess+Unix.swift)
+  target_compile_options(Subprocess PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-D SUBPROCESS_ASYNCIO_DISPATCH>")
 elseif(FREEBSD OR OPENBSD)
   target_sources(Subprocess PRIVATE
     Platforms/Subprocess+BSD.swift
     Platforms/Subprocess+Unix.swift)
+  target_compile_options(Subprocess PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-D SUBPROCESS_ASYNCIO_DISPATCH>")
 endif()
 
 target_compile_options(Subprocess PRIVATE

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
+configure_file(SwiftSubprocessConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftSubprocessConfig.cmake)
+

--- a/cmake/modules/SwiftSubprocessConfig.cmake.in
+++ b/cmake/modules/SwiftSubprocessConfig.cmake.in
@@ -1,0 +1,12 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
+include(${CMAKE_CURRENT_BINARY_DIR}/../SwiftSubprocess/SwiftSubprocessTargets.cmake)


### PR DESCRIPTION
1. Define SUBPROCESS_ASYNCIO_DISPATCH on macOS/BSDs to fix a build failure
2. Create SwiftSubprocessConfig.cmake to allow dependent CMake projects to find exported targets