### PR TITLE
Enable Android CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,6 +38,7 @@ jobs:
       macos_xcode_versions: '["16.3"]'
       macos_build_command: 'xcrun swift-format lint -s -r --configuration ./.swift-format . && xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits'
       enable_linux_static_sdk_build: true
+      enable_android_sdk_build: true
       linux_static_sdk_versions: '["6.1", "nightly-6.2"]'
       linux_static_sdk_build_command: |
         for triple in aarch64-swift-linux-musl x86_64-swift-linux-musl ; do


### PR DESCRIPTION
This will prevent Android builds from regressing.