### PR TITLE
Fix Android builds with NDK r28 and later

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,6 +39,7 @@ jobs:
       macos_build_command: 'xcrun swift-format lint -s -r --configuration ./.swift-format . && xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits'
       enable_linux_static_sdk_build: true
       enable_android_sdk_build: true
+      android_ndk_version: '["r27d", "r29"]'
       linux_static_sdk_versions: '["6.1", "nightly-6.2"]'
       linux_static_sdk_build_command: |
         for triple in aarch64-swift-linux-musl x86_64-swift-linux-musl ; do

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -307,29 +307,16 @@ internal func pthread_create(
             self.body = body
         }
     }
-    #if canImport(Darwin)
-    func proc(_ context: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
-        (Unmanaged<AnyObject>.fromOpaque(context).takeRetainedValue() as! Context).body()
-        return context
-    }
-    #elseif canImport(Glibc) || canImport(Musl)
     func proc(_ context: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
         (Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Context).body()
         return context
     }
-    #elseif canImport(Bionic)
-    func proc(_ context: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-        (Unmanaged<AnyObject>.fromOpaque(context).takeRetainedValue() as! Context).body()
-        return context
-    }
-    #endif
-
     #if canImport(Glibc) || canImport(Bionic)
     var thread = pthread_t()
     #else
     var thread: pthread_t?
     #endif
-    let rc = pthread_create(
+    let rc = _subprocess_pthread_create(
         &thread,
         nil,
         proc,

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -15,6 +15,7 @@
 #include "target_conditionals.h"
 
 #if !TARGET_OS_WINDOWS
+#include <pthread.h>
 #include <unistd.h>
 
 #if _POSIX_SPAWN
@@ -38,6 +39,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+int _subprocess_pthread_create(
+    pthread_t * _Nonnull ptr,
+    pthread_attr_t const * _Nullable attr,
+    void * _Nullable (* _Nonnull start)(void * _Nullable),
+    void * _Nullable context
+);
 
 #if __has_include(<mach/vm_page_size.h>)
 vm_size_t _subprocess_vm_size(void);

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -79,6 +79,15 @@ int _was_process_suspended(int status) {
     return WIFSTOPPED(status);
 }
 
+int _subprocess_pthread_create(
+    pthread_t * _Nonnull ptr,
+    pthread_attr_t const * _Nullable attr,
+    void * _Nullable (* _Nonnull start)(void * _Nullable),
+    void * _Nullable context
+) {
+    return pthread_create(ptr, attr, start, context);
+}
+
 #endif
 
 #if __has_include(<mach/vm_page_size.h>)


### PR DESCRIPTION
The nullability annotations of many POSIX functions changed in r28. Also switch the CI to test with both the latest LTS version (r27d) and the latest stable version (r29).