### PR TITLE
Retroactively conform DispatchData to Sendable when building with older macOS SDKs in Swift CI

### DIFF
--- a/Sources/Subprocess/IO/AsyncIO+Dispatch.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Dispatch.swift
@@ -166,8 +166,16 @@ final class AsyncIO: Sendable {
     }
 }
 
-#if !canImport(Darwin)
+#if canImport(Darwin)
+// Dispatch has a -user-module-version of 54 in the macOS 15.3 SDK
+#if canImport(Dispatch, _version: "54")
+// DispatchData is annotated as Sendable
+#else
+// Retroactively conform DispatchData to Sendable
 extension DispatchData: @retroactive @unchecked Sendable {}
-#endif
+#endif // canImport(Dispatch, _version: "54")
+#else
+extension DispatchData: @retroactive @unchecked Sendable {}
+#endif // canImport(Darwin)
 
-#endif
+#endif // SUBPROCESS_ASYNCIO_DISPATCH


### PR DESCRIPTION
Swift CI builds with a macOS 15.2 SDK in some jobs, causing Subprocess to fail to build as part of the toolchain because DispatchData was not annotated for Sendability in that SDK. Introduce a retroactive conformance only when building against a conformance that doesn't have it, similar to the handling of non-Apple platforms