### PR TITLE
Add ENOTDIR as an acceptable spawn error

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -77,7 +77,8 @@ public struct PlatformOptions: Sendable {
     /// they are sent to `posix_spawn()`.
     public var preSpawnProcessConfigurator:
         (
-            @Sendable (
+            @Sendable
+            (
                 inout posix_spawnattr_t?,
                 inout posix_spawn_file_actions_t?
             ) throws -> Void
@@ -438,7 +439,7 @@ extension Configuration {
                 }
                 // Spawn error
                 if spawnError != 0 {
-                    if spawnError == ENOENT || spawnError == EACCES {
+                    if [ENOENT, EACCES, ENOTDIR].contains(spawnError) {
                         // Move on to another possible path
                         continue
                     }

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -507,7 +507,7 @@ extension Configuration {
                 }
                 // Spawn error
                 if spawnError != 0 {
-                    if spawnError == ENOENT || spawnError == EACCES {
+                    if [ENOENT, EACCES, ENOTDIR].contains(spawnError) {
                         // Move on to another possible path
                         continue
                     }

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -568,7 +568,8 @@ public struct PlatformOptions: Sendable {
     /// they are sent to `CreateProcessW()`.
     public var preSpawnProcessConfigurator:
         (
-            @Sendable (
+            @Sendable
+            (
                 inout DWORD,
                 inout STARTUPINFOW
             ) throws -> Void


### PR DESCRIPTION
The posix_spawn function currently fails with ENOTDIR instead of ENOENT when a component in the executable path is a regular file rather than a directory. This issue may occur in Subprocess if the user’s PATH value includes non-directory paths. To address this, treat ENOTDIR similarly to ENOENT by proceeding to the next available executable paths.

Resolves https://github.com/swiftlang/swift-subprocess/issues/213