### PR TITLE
Update GitHub Workflow to use soundness.yml for Format Checking

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,16 +10,20 @@ on:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_swift_versions: '["6.1", "nightly-main"]'
       linux_pre_build_command: |
         if command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
-          apt-get update -y
-
           # Test dependencies
-          apt-get install -y procps
+          if command -v sudo &> /dev/null && [ "$EUID" -ne 0 ]; then
+            sudo apt-get update -y
+            sudo apt-get install -y procps
+          else
+            apt-get update -y
+            apt-get install -y procps
+          fi
         elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
           dnf update -y
 
@@ -31,7 +35,7 @@ jobs:
           # Test dependencies
           yum install -y procps
         fi
-      linux_build_command: 'swift-format lint -s -r --configuration ./.swift-format . && swift test && swift test -c release && swift test --disable-default-traits'
+      linux_build_command: 'swift test && swift test -c release && swift test --disable-default-traits'
       windows_swift_versions: '["6.1", "nightly-main"]'
       windows_build_command: |
         Invoke-Program swift test
@@ -39,7 +43,7 @@ jobs:
         Invoke-Program swift test --disable-default-traits
       enable_macos_checks: true
       macos_xcode_versions: '["16.3"]'
-      macos_build_command: 'xcrun swift-format lint -s -r --configuration ./.swift-format . && xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits'
+      macos_build_command: 'xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits'
       enable_linux_static_sdk_build: true
       enable_android_sdk_build: true
       android_ndk_versions: '["r27d", "r29"]'
@@ -53,11 +57,11 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.6
     with:
       license_header_check_project_name: "Swift.org"
       docs_check_enabled: false
-      format_check_enabled: false
+      format_check_enabled: true
       unacceptable_language_check_enabled: false
       api_breakage_check_enabled: false
 


### PR DESCRIPTION
The current setup involves invoking swift-format directly through the linux_build_command. To improve consistency and reliability, we should transition to using the built-in format check provided by soundness.yml.

Additionally, update the workflow dependency to version 0.0.6.