### PR TITLE
Add nullability specifier to pthread_t pointer in process_shims.h

### DIFF
--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -41,7 +41,11 @@ extern "C" {
 #endif
 
 int _subprocess_pthread_create(
+#if TARGET_OS_MAC
+    pthread_t _Nullable * _Nonnull ptr,
+#else
     pthread_t * _Nonnull ptr,
+#endif
     pthread_attr_t const * _Nullable attr,
     void * _Nullable (* _Nonnull start)(void * _Nullable),
     void * _Nullable context


### PR DESCRIPTION
Fix nullability warning in `_subprocess_pthread_create` by adding `_Nullable` specifier to the `pthread_t` pointer parameter on Darwin platforms.

On Darwin, `pthread_t` is a pointer type (`struct _opaque_pthread_t *`), so the parameter is a pointer-to-pointer requiring nullability on both levels. On Linux, `pthread_t` is `unsigned long int`, so nullability doesn't apply.

Fixes #217