### PR TITLE
Rename AsyncBufferSequence.LineSequence to StringSequence and add custom Unicode scalar separator support

### DIFF
--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -99,35 +99,68 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
         )
     }
 
-    /// Creates a line sequence that iterates through this buffer sequence line by line.
-    public func lines() -> LineSequence<UTF8> {
-        return LineSequence(
+    /// Splits the buffer into strings using the specified separator.
+    ///
+    /// - Parameters:
+    ///   - separator: The delimiter to split on. The default
+    ///     value is `.lineBreaks`.
+    ///   - bufferingPolicy: The strategy for handling
+    ///     back-pressure. The default value is
+    ///     `.maxLineLength(128 * 1024)`.
+    /// - Returns: A ``StringSequence`` that iterates through
+    ///   the buffer contents as strings.
+    public func strings(
+        separatedBy separator: StringSequence<UTF8>.Separator = .lineBreaks,
+        bufferingPolicy: StringSequence<UTF8>.BufferingPolicy = .maxLineLength(128 * 1024),
+    ) -> StringSequence<UTF8> {
+        return StringSequence(
             underlying: self,
             encoding: UTF8.self,
-            bufferingPolicy: .maxLineLength(128 * 1024)
+            bufferingPolicy: bufferingPolicy,
+            separator: separator
         )
     }
 
-    /// Creates a line sequence that iterates through this buffer sequence line by line.
+    /// Splits the buffer into strings with the given encoding
+    /// and separator.
+    ///
     /// - Parameters:
-    ///   - encoding: The target encoding for strings.
-    ///   - bufferingPolicy: The strategy for handling back-pressure.
-    /// - Returns: A ``LineSequence`` that iterates through this buffer sequence line by line.
-    public func lines<Encoding: _UnicodeEncoding>(
-        encoding: Encoding.Type,
-        bufferingPolicy: LineSequence<Encoding>.BufferingPolicy = .maxLineLength(128 * 1024)
-    ) -> LineSequence<Encoding> {
-        return LineSequence(underlying: self, encoding: encoding, bufferingPolicy: bufferingPolicy)
+    ///   - separator: The delimiter to split on. The default
+    ///     value is `.lineBreaks`.
+    ///   - bufferingPolicy: The strategy for handling
+    ///     back-pressure. The default value is
+    ///     `.maxLineLength(128 * 1024)`.
+    ///   - encoding: The Unicode encoding to decode with.
+    /// - Returns: A ``StringSequence`` that iterates through
+    ///   the buffer contents as strings.
+    public func strings<Encoding: _UnicodeEncoding>(
+        separatedBy separator: StringSequence<Encoding>.Separator = .lineBreaks,
+        bufferingPolicy: StringSequence<Encoding>.BufferingPolicy = .maxLineLength(128 * 1024),
+        as encoding: Encoding.Type,
+    ) -> StringSequence<Encoding> {
+        return StringSequence(
+            underlying: self,
+            encoding: encoding,
+            bufferingPolicy: bufferingPolicy,
+            separator: separator
+        )
     }
 }
 
 @available(*, unavailable)
 extension AsyncBufferSequence.Iterator: Sendable {}
 
-// MARK: - LineSequence
+// MARK: - StringSequence
 extension AsyncBufferSequence {
-    /// Line sequence parses and splits an asynchronous sequence of buffers into lines.
-    /// The following list of Unicode characters are considered as paragraph separators (new lines):
+    /// An asynchronous sequence of strings parsed from a buffer
+    /// sequence.
+    ///
+    /// By default, the sequence splits on Unicode line break
+    /// characters. You can supply a custom separator with the
+    /// ``Separator/unicodeScalarSequence(_:)`` factory method.
+    ///
+    /// The following Unicode characters are recognized as line
+    /// breaks:
     /// ```
     /// LF:    Line Feed, U+000A
     /// VT:    Vertical Tab, U+000B
@@ -138,18 +171,23 @@ extension AsyncBufferSequence {
     /// LS:    Line Separator, U+2028
     /// PS:    Paragraph Separator, U+2029
     /// ```
-    /// These newline characters are not included in the lines returned,
-    /// similar to how `.split(separator:)` works.
     ///
-    /// `LineSequence` is the preferred method to convert `Buffer` to `String`
-    public struct LineSequence<Encoding: _UnicodeEncoding>: AsyncSequence, Sendable {
+    /// The separator characters aren't included in the returned
+    /// strings, similar to how `.split(separator:)` works.
+    ///
+    /// When you use a custom separator created with
+    /// ``Separator/unicodeScalarSequence(_:)``, the sequence performs a
+    /// code-unit-level comparison without Unicode normalization.
+    /// See ``Separator/unicodeScalarSequence(_:)`` for details.
+    public struct StringSequence<Encoding: _UnicodeEncoding>: AsyncSequence, Sendable {
         /// The element type for the asynchronous sequence.
         public typealias Element = String
 
         private let base: AsyncBufferSequence
         private let bufferingPolicy: BufferingPolicy
+        private let separator: Separator
 
-        /// The iterator for line sequence.
+        /// An iterator for ``StringSequence``.
         public struct AsyncIterator: AsyncIteratorProtocol {
             /// The element type for this Iterator.
             public typealias Element = String
@@ -161,10 +199,13 @@ extension AsyncBufferSequence {
             private var leftover: Encoding.CodeUnit?
             private var eofReached: Bool
             private let bufferingPolicy: BufferingPolicy
+            private let separator: Separator
+            private let separatorCodeUnits: [Encoding.CodeUnit]
 
             internal init(
                 underlyingIterator: AsyncBufferSequence.AsyncIterator,
-                bufferingPolicy: BufferingPolicy
+                bufferingPolicy: BufferingPolicy,
+                separator: Separator
             ) {
                 self.source = underlyingIterator
                 self.buffer = []
@@ -173,6 +214,29 @@ extension AsyncBufferSequence {
                 self.leftover = nil
                 self.eofReached = false
                 self.bufferingPolicy = bufferingPolicy
+                self.separator = separator
+                // Pre-compute separator code unit sequences for
+                // .unicodeScalarSequence cases.
+                // Both use the same buffer-tail matching algorithm:
+                // encode each separator into its code unit representation,
+                // then suffix-match against the buffer on each incoming
+                // code unit. This is correct because UTF-8 and UTF-16
+                // are self-synchronizing encodings: a valid encoded
+                // sequence can never appear as a sub-alignment of
+                // another sequence.
+                switch separator.storage {
+                case .lineBreaks:
+                    // Line breaks uses builtin separators
+                    self.separatorCodeUnits = []
+                case .unicodeScalarSequence(let customScalars):
+                    var result: [Encoding.CodeUnit] = []
+                    for scalar in customScalars {
+                        if let encoded = Encoding.encode(scalar) {
+                            result.append(contentsOf: encoded)
+                        }
+                    }
+                    self.separatorCodeUnits = result
+                }
             }
 
             /// Retrieves the next line, or `nil` if the sequence ended.
@@ -218,7 +282,7 @@ extension AsyncBufferSequence {
                         self.buffer.removeAll(keepingCapacity: true)
                     }
                     if self.buffer.isEmpty {
-                        return nil
+                        return ""
                     }
                     return String(decoding: self.buffer, as: Encoding.self)
                 }
@@ -292,52 +356,79 @@ extension AsyncBufferSequence {
                         throw SubprocessError.outputLimitExceeded(limit: maxLength)
                     }
 
-                    buffer.append(first)
-                    switch first {
-                    case carriageReturn:
-                        // Swallow up any subsequent LF
-                        guard let next = try await nextFromSource() else {
-                            return yield() // if we ran out of bytes, the last byte was a CR
-                        }
-                        buffer.append(next)
-                        guard next == lineFeed else {
-                            // if the next character was not an LF, save it for the next iteration and still return a line
-                            leftover = buffer.removeLast()
+                    switch self.separator.storage {
+                    case .lineBreaks:
+                        switch first {
+                        case carriageReturn:
+                            // Swallow up any subsequent LF
+                            guard let next = try await nextFromSource() else {
+                                return yield() // if we ran out of bytes, the last byte was a CR
+                            }
+                            guard next == lineFeed else {
+                                // if the next character was not an LF, save it for the next iteration and still return a line
+                                leftover = next
+                                return yield()
+                            }
                             return yield()
-                        }
-                        return yield()
-                    case newLine1 where Encoding.CodeUnit.self is UInt8.Type: // this may be used to compose other UTF8 characters
-                        guard let next = try await nextFromSource() else {
-                            // technically invalid UTF8 but it should be repaired to "\u{FFFD}"
+                        case newLine1 where Encoding.CodeUnit.self is UInt8.Type: // this may be used to compose other UTF8 characters
+                            guard let next = try await nextFromSource() else {
+                                // technically invalid UTF8 but it should be repaired to "\u{FFFD}"
+                                buffer.append(first)
+                                return yield()
+                            }
+                            guard next == newLine2 else {
+                                // This character is not a valid newLine. Treat it as normal character
+                                buffer.append(first)
+                                buffer.append(next)
+                                continue
+                            }
                             return yield()
-                        }
-                        buffer.append(next)
-                        guard next == newLine2 else {
+                        case lineSeparator1 where Encoding.CodeUnit.self is UInt8.Type,
+                            paragraphSeparator1 where Encoding.CodeUnit.self is UInt8.Type:
+                            // Try to read: 80 [A8 | A9].
+                            // If we can't, then we put the byte in the buffer for error correction
+                            guard let next = try await nextFromSource() else {
+                                buffer.append(first)
+                                return yield()
+                            }
+                            guard next == lineSeparator2 || next == paragraphSeparator2 else {
+                                // Invalid lineSeparator. Treat it as normal charcter.
+                                buffer.append(first)
+                                buffer.append(next)
+                                continue
+                            }
+                            guard let fin = try await nextFromSource() else {
+                                // Invalid lineSeparator. Treat it as normal charcter.
+                                buffer.append(first)
+                                buffer.append(next)
+                                return yield()
+                            }
+                            guard fin == lineSeparator3 || fin == paragraphSeparator3 else {
+                                // Invalid lineSeparator. Treat it as normal charcter.
+                                buffer.append(first)
+                                buffer.append(next)
+                                buffer.append(fin)
+                                continue
+                            }
+                            return yield()
+                        case lineFeed..<carriageReturn, newLine1, lineSeparator1, paragraphSeparator1:
+                            return yield()
+                        default:
+                            buffer.append(first)
                             continue
                         }
-                        return yield()
-                    case lineSeparator1 where Encoding.CodeUnit.self is UInt8.Type,
-                        paragraphSeparator1 where Encoding.CodeUnit.self is UInt8.Type:
-                        // Try to read: 80 [A8 | A9].
-                        // If we can't, then we put the byte in the buffer for error correction
-                        guard let next = try await nextFromSource() else {
-                            return yield()
-                        }
-                        buffer.append(next)
-                        guard next == lineSeparator2 || next == paragraphSeparator2 else {
+                    case .unicodeScalarSequence:
+                        // Suffix match against the precomputed separator code units
+                        buffer.append(first)
+                        guard buffer.count >= self.separatorCodeUnits.count else {
                             continue
                         }
-                        guard let fin = try await nextFromSource() else {
+                        if buffer.suffix(
+                            self.separatorCodeUnits.count
+                        ).elementsEqual(self.separatorCodeUnits) {
+                            buffer.removeLast(self.separatorCodeUnits.count)
                             return yield()
                         }
-                        buffer.append(fin)
-                        guard fin == lineSeparator3 || fin == paragraphSeparator3 else {
-                            continue
-                        }
-                        return yield()
-                    case lineFeed..<carriageReturn, newLine1, lineSeparator1, paragraphSeparator1:
-                        return yield()
-                    default:
                         continue
                     }
                 }
@@ -350,29 +441,32 @@ extension AsyncBufferSequence {
             }
         }
 
-        /// Creates an iterator for this line sequence.
+        /// Creates an iterator for this string sequence.
         public func makeAsyncIterator() -> AsyncIterator {
             return AsyncIterator(
                 underlyingIterator: self.base.makeAsyncIterator(),
-                bufferingPolicy: self.bufferingPolicy
+                bufferingPolicy: self.bufferingPolicy,
+                separator: self.separator
             )
         }
 
         internal init(
             underlying: AsyncBufferSequence,
             encoding: Encoding.Type,
-            bufferingPolicy: BufferingPolicy
+            bufferingPolicy: BufferingPolicy,
+            separator: Separator
         ) {
             self.base = underlying
             self.bufferingPolicy = bufferingPolicy
+            self.separator = separator
         }
     }
 }
 
 @available(*, unavailable)
-extension AsyncBufferSequence.LineSequence.AsyncIterator: Sendable {}
+extension AsyncBufferSequence.StringSequence.AsyncIterator: Sendable {}
 
-extension AsyncBufferSequence.LineSequence {
+extension AsyncBufferSequence.StringSequence {
     /// A strategy for handling buffer capacity.
     public enum BufferingPolicy: Sendable {
         /// Adds to the buffer without imposing a limit on line length.
@@ -381,6 +475,76 @@ extension AsyncBufferSequence.LineSequence {
         ///
         /// The subprocess throws an error if a line exceeds this limit.
         case maxLineLength(Int)
+    }
+
+    /// A delimiter that determines where a ``StringSequence``
+    /// splits its input.
+    public struct Separator: Sendable, Hashable {
+        internal enum Storage: Sendable, Hashable {
+            case lineBreaks
+            case unicodeScalarSequence(Array<Unicode.Scalar>)
+        }
+
+        internal let storage: Storage
+
+        internal init(_ storage: Storage) {
+            self.storage = storage
+        }
+
+        /// Splits on Unicode line break characters.
+        /// The following Unicode characters are recognized as line
+        /// breaks:
+        /// ```
+        /// LF:    Line Feed, U+000A
+        /// VT:    Vertical Tab, U+000B
+        /// FF:    Form Feed, U+000C
+        /// CR:    Carriage Return, U+000D
+        /// CR+LF: CR (U+000D) followed by LF (U+000A)
+        /// NEL:   Next Line, U+0085
+        /// LS:    Line Separator, U+2028
+        /// PS:    Paragraph Separator, U+2029
+        /// ```
+        public static var lineBreaks: Self { .init(.lineBreaks) }
+
+        /// Splits on a custom sequence of Unicode scalars.
+        ///
+        /// ``StringSequence`` encodes the scalars into their code unit
+        /// representation and matches against the raw bytes in the
+        /// buffer. Unlike `String` comparison, this match doesn't
+        /// apply Unicode normalization. For example, "é" encoded
+        /// as U+00E9 (precomposed) doesn't match "é" encoded as
+        /// U+0065 U+0301 (decomposed). Make sure the separator
+        /// scalars use the same representation as the input data.
+        ///
+        /// - Parameter separators: The scalars that form
+        ///   the delimiter.
+        /// - Returns: A separator that matches the given
+        ///   scalar sequence.
+        public static func unicodeScalarSequence(
+            _ separators: some Sequence<Unicode.Scalar>
+        ) -> Self {
+            return .init(.unicodeScalarSequence(Array(separators)))
+        }
+
+        /// Splits on a custom sequence of Unicode scalars.
+        ///
+        /// ``StringSequence`` encodes the scalars into their code unit
+        /// representation and matches against the raw bytes in the
+        /// buffer. Unlike `String` comparison, this match doesn't
+        /// apply Unicode normalization. For example, "é" encoded
+        /// as U+00E9 (precomposed) doesn't match "é" encoded as
+        /// U+0065 U+0301 (decomposed). Make sure the separator
+        /// scalars use the same representation as the input data.
+        ///
+        /// - Parameter separators: The scalars that form
+        ///   the delimiter.
+        /// - Returns: A separator that matches the given
+        ///   scalar sequence.
+        public static func unicodeScalarSequence(
+            _ separators: Array<Unicode.Scalar>
+        ) -> Self {
+            return .init(.unicodeScalarSequence(separators))
+        }
     }
 }
 

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -1862,7 +1862,7 @@ extension SubprocessIntegrationTests {
             error: .discarded,
             preferredBufferSize: 1
         ) { execution, standardOutput in
-            for try await line in standardOutput.lines() {
+            for try await line in standardOutput.strings() {
                 // If we use default buffer size this test will hang
                 // because Subprocess is stuck on waiting 16k worth of
                 // output when there are only 3.
@@ -2031,7 +2031,7 @@ extension SubprocessIntegrationTests {
             error: .combinedWithOutput
         ) { execution, standardOutput in
             var output: String = ""
-            for try await line in standardOutput.lines() {
+            for try await line in standardOutput.strings() {
                 output += line
             }
             #expect(output.contains("Hello Stdout"))
@@ -2084,7 +2084,7 @@ extension SubprocessIntegrationTests {
         #endif
     }
 
-    @Test func testLineSequence() async throws {
+    @Test func testStringSequence() async throws {
         typealias TestCase = (value: String, count: Int, newLine: String)
         enum TestCaseSize: CaseIterable {
             case large // (1.0 ~ 2.0) * buffer size
@@ -2203,11 +2203,11 @@ extension SubprocessIntegrationTests {
             error: .discarded
         ) { execution, standardOutput in
             var index = 0
-            for try await line in standardOutput.lines(encoding: UTF8.self) {
+            for try await line in standardOutput.strings(as: UTF8.self) {
                 defer { index += 1 }
                 try #require(index < testCases.count, "Received more lines than expected")
                 #expect(
-                    line == testCases[index].value,
+                    line == testCases[index].value.trimmingCharacters(in: .newlines),
                     """
                     Found mismatching line at index \(index)
                     Expected: [\(testCases[index].value)]
@@ -2363,14 +2363,14 @@ extension SubprocessIntegrationTests {
                 }
                 group.addTask {
                     var result = ""
-                    for try await line in standardOutput.lines() {
+                    for try await line in standardOutput.strings() {
                         result += line
                     }
                     return .standardOutputCaptured(result.trimmingNewLineAndQuotes())
                 }
                 group.addTask {
                     var result = ""
-                    for try await line in standardError.lines() {
+                    for try await line in standardError.strings() {
                         result += line
                     }
                     return .standardErrorCaptured(result.trimmingNewLineAndQuotes())
@@ -2552,7 +2552,77 @@ extension SubprocessIntegrationTests {
         }
     }
 
-    @Test func testLineSequenceNoNewLines() async throws {
+    @Test func testStringSequencePreserveEmptyLine() async throws {
+        #if os(Windows)
+        enum Separator: String, CaseIterable {
+            case lineFeed = "[char]0x000A"
+            case verticalTab = "[char]0x000B"
+            case formFeed = "[char]0x000C"
+            case carriageReturn = "[char]0x000D"
+            case carriageReturnAndLineFeed = "[char]0x000D+[char]0x000A"
+            case nextLine = "[char]0x0085"
+            case lineSeparator = "[char]0x2028"
+            case paragraphSeparator = "[char]0x2029"
+        }
+        #else
+        enum Separator: String, CaseIterable {
+            case lineFeed = "\n"
+            case verticalTab = "\u{000B}"
+            case formFeed = "\u{000C}"
+            case carriageReturn = "\r"
+            case carriageReturnAndLineFeed = "\r\n"
+            case nextLine = "\u{0085}"
+            case lineSeparator = "\u{2028}"
+            case paragraphSeparator = "\u{2029}"
+        }
+        #endif
+
+        for delimiter in Separator.allCases {
+            var string = ""
+            #if os(Windows)
+            var segments: [String] = []
+            for index in 1..<5 {
+                var characters = ["\"\(index)\""]
+                for _ in 0..<index {
+                    characters.append(delimiter.rawValue)
+                }
+                segments.append(characters.joined(separator: "+"))
+            }
+            string = segments.joined(separator: "+")
+
+            let setup = TestSetup(
+                executable: .name("powershell.exe"),
+                arguments: ["/c", "[Console]::Write(\(string))"]
+            )
+            #else
+            for index in 1..<5 {
+                string += "\(index)"
+                string += String(
+                    repeating: Character(delimiter.rawValue),
+                    count: index
+                )
+            }
+
+            let setup = TestSetup(
+                executable: .path("/bin/sh"),
+                arguments: [
+                    "-c", "printf %s '\(string)'",
+                ]
+            )
+            #endif
+
+            _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+                var output: [String] = []
+                for try await line in standardOutput.strings(separatedBy: .lineBreaks) {
+                    output.append(line)
+                }
+
+                #expect(output == ["1", "2", "", "3", "", "", "4", "", "", ""])
+            }
+        }
+    }
+
+    @Test func testStringSequenceNoNewLines() async throws {
         #if os(Windows)
         let setup = TestSetup(
             executable: .name("cmd.exe"),
@@ -2572,21 +2642,225 @@ extension SubprocessIntegrationTests {
 
                 group.addTask {
                     var result = ""
-                    for try await line in standardOutput.lines() {
+                    for try await line in standardOutput.strings() {
                         result += line
                     }
-                    #expect(result.trimmingNewLineAndQuotes() == "x")
+                    #expect(result.trimmingCharacters(in: .whitespaces) == "x")
                 }
 
                 group.addTask {
                     var result = ""
-                    for try await line in standardError.lines() {
+                    for try await line in standardError.strings() {
                         result += line
                     }
-                    #expect(result.trimmingNewLineAndQuotes() == "y")
+                    #expect(result.trimmingCharacters(in: .whitespaces) == "y")
                 }
                 try await group.waitForAll()
             }
+        }
+    }
+
+    @Test func testStringSequenceSingleScalarSeparator() async throws {
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-Command",
+                """
+                [Console]::Write(`
+                    "1" + [char]0 +`
+                    "2" + [char]0 + [char]0 +`
+                    "3" + [char]0 + [char]0 + [char]0 +`
+                    "4" + [char]0 + [char]0 + [char]0 + [char]0)
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf '1\\0002\\000\\0003\\000\\000\\0004\\000\\000\\000\\000'",
+            ]
+        )
+        #endif
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings(separatedBy: .unicodeScalarSequence(["\0"])) {
+                output.append(line)
+            }
+
+            #expect(output == ["1", "2", "", "3", "", "", "4", "", "", ""])
+        }
+    }
+
+    @Test func testStringSequenceMultipleScalarsSeparator() async throws {
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-Command",
+                """
+                [Console]::Write("1?:2?:?:3?:?:?:4?:?:?:?:")
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf '1?:2?:?:3?:?:?:4?:?:?:?:'",
+            ]
+        )
+        #endif
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings(separatedBy: .unicodeScalarSequence(["?", ":"])) {
+                output.append(line)
+            }
+
+            #expect(output == ["1", "2", "", "3", "", "", "4", "", "", ""])
+        }
+    }
+
+    @Test func testStringSequenceUnicodeScalarsSeparatorMultiByte() async throws {
+        // U+2022 BULLET = E2 80 A2 in UTF-8
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-NoProfile",
+                "-Command",
+                """
+                [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
+                [Console]::OpenStandardOutput().Write([byte[]](0x61, 0xe2, 0x80, 0xa2, 0x62, 0xe2, 0x80, 0xa2, 0x63), 0, 9)
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf 'a\\342\\200\\242b\\342\\200\\242c'",
+            ]
+        )
+        #endif
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings(separatedBy: .unicodeScalarSequence(["\u{2022}"])) {
+                output.append(line)
+            }
+
+            #expect(output == ["a", "b", "c"])
+        }
+    }
+
+    @Test func testStringSequenceUnicodeScalarsSeparatorPreservesMultiByteContent() async throws {
+        // Split on pipe, but content contains multi-byte Unicode characters
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-NoProfile",
+                "-Command",
+                """
+                [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
+                $b=[byte[]](0x63,0x61,0x66,0xc3,0xa9,0x7c,0x6e,0x61,0xc3,0xaf,0x76,0x65,0x7c,0x72,0xc3,0xa9,0x73,0x75,0x6d,0xc3,0xa9);
+                [Console]::OpenStandardOutput().Write($b, 0, $b.Length)
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf 'caf\\303\\251|na\\303\\257ve|r\\303\\251sum\\303\\251'",
+            ]
+        )
+        #endif
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings(separatedBy: .unicodeScalarSequence(["|"])) {
+                output.append(line)
+            }
+
+            #expect(output == ["caf\u{00E9}", "na\u{00EF}ve", "r\u{00E9}sum\u{00E9}"])
+        }
+    }
+
+    @Test func testStringSequenceUnicodeScalarsSeparatorLeadingAndTrailing() async throws {
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-Command",
+                """
+                [Console]::Write("|1|2|3|")
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf '|1|2|3|'",
+            ]
+        )
+        #endif
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings(separatedBy: .unicodeScalarSequence(["|"])) {
+                output.append(line)
+            }
+
+            #expect(output == ["", "1", "2", "3"])
+        }
+    }
+
+    @Test func testStringSequenceLineBreaksPreservesMultiByteCharacters() async throws {
+        // These multi-byte characters shares the same prefix as newLine and paragraphSeparator
+        // "100°C\n32—x\n€5"
+        // ° = U+00B0 = 0xC2 0xB0       →  \302\260
+        // — = U+2014 = 0xE2 0x80 0x94  →  \342\200\224
+        // € = U+20AC = 0xE2 0x82 0xAC  →  \342\202\254
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-NoProfile",
+                "-Command",
+                """
+                [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
+                [byte[]]$b = @(
+                    0x31, 0x30, 0x30,             # 100
+                    0xC2, 0xB0,                   # ° (U+00B0, UTF-8)
+                    0x43,                         # C
+                    0x0A,                         # \n
+                    0x33, 0x32,                   # 32
+                    0xE2, 0x80, 0x94,             # — (U+2014, UTF-8)
+                    0x78,                         # x
+                    0x0A,                         # \n
+                    0xE2, 0x82, 0xAC,             # € (U+20AC, UTF-8)
+                    0x35                          # 5
+                )
+                [Console]::OpenStandardOutput().Write($b, 0, $b.Length)
+                """,
+            ]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: [
+                "-c", "printf '100\\302\\260C\\n32\\342\\200\\224x\\n\\342\\202\\2545'",
+            ]
+        )
+        #endif
+
+        _ = try await _run(setup) { execution, inputWriter, standardOutput, standardError in
+            var output: [String] = []
+            for try await line in standardOutput.strings() {
+                output.append(line)
+            }
+            #expect(output == ["100°C", "32—x", "€5"])
         }
     }
 }

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -189,7 +189,7 @@ extension SubprocessUnixTests {
                 }
                 group.addTask {
                     var outputs: [String] = []
-                    for try await line in standardOutput.lines() {
+                    for try await line in standardOutput.strings() {
                         outputs.append(line.trimmingCharacters(in: .newlines))
                     }
                     #expect(outputs == ["saw SIGQUIT", "saw SIGTERM", "saw SIGINT"])


### PR DESCRIPTION
This PR generalizes `AsyncBufferSequence.LineSequence` to `StringSequence` that splits the buffer into Strings according to custom separator sequence in addition to line breaks. Developers could use this API to perform custom line splitting, similar to `String.split`.

Resolves: https://github.com/swiftlang/swift-subprocess/issues/212