### PR TITLE
Adopt NonisolatedNonsendingByDefault and rename .standardOutput and .standardError output types to .currentStandardOutput and .currentStandardError

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,6 +53,7 @@ let package = Package(
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("Lifetimes"),
+                .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
             ] + packageSwiftSettings
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For the collected-result API, you must specify how to capture standard output.
 | --- | --- |
 | `.discarded` | Discard output |
 | `.fileDescriptor(_:closeAfterSpawningProcess:)` | Write to a file descriptor |
-| `.standardOutput` or `.standardError` | Write to the parent process's standard output or standard error |
+| `.currentStandardOutput` or `.currentStandardError` | Write to the parent process's standard output or standard error |
 | `.string(limit:)` or `.string(limit:encoding:)` | Collect as `String?` |
 | `.bytes(limit:)` | Collect as `[UInt8]` |
 | `.data(limit:)` | Collect as `Data` (requires `SubprocessFoundation`) |

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -132,7 +132,6 @@ public func run<
     input: Input = .none,
     output: Output = .discarded,
     error: Error = .discarded,
-    isolation: isolated (any Actor)? = #isolation,
     body: (_ execution: Execution) async throws -> Result
 ) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
     let configuration = Configuration(
@@ -147,7 +146,6 @@ public func run<
         input: input,
         output: output,
         error: error,
-        isolation: isolation,
         body: body
     )
 }
@@ -183,7 +181,6 @@ public func run<Result, Input: InputProtocol, Error: ErrorOutputProtocol>(
     input: Input = .none,
     error: Error = .discarded,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ outputSequence: AsyncBufferSequence
@@ -201,7 +198,6 @@ public func run<Result, Input: InputProtocol, Error: ErrorOutputProtocol>(
         input: input,
         error: error,
         preferredBufferSize: preferredBufferSize,
-        isolation: isolation,
         body: body
     )
 }
@@ -237,7 +233,6 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
     input: Input = .none,
     output: Output,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ errorSequence: AsyncBufferSequence
@@ -255,7 +250,6 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
         input: input,
         output: output,
         preferredBufferSize: preferredBufferSize,
-        isolation: isolation,
         body: body
     )
 }
@@ -290,7 +284,6 @@ public func run<Result, Error: ErrorOutputProtocol>(
     platformOptions: PlatformOptions = PlatformOptions(),
     error: Error = .discarded,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,
@@ -308,7 +301,6 @@ public func run<Result, Error: ErrorOutputProtocol>(
         configuration,
         error: error,
         preferredBufferSize: preferredBufferSize,
-        isolation: isolation,
         body: body
     )
 }
@@ -343,7 +335,6 @@ public func run<Result, Output: OutputProtocol>(
     platformOptions: PlatformOptions = PlatformOptions(),
     output: Output,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,
@@ -361,7 +352,6 @@ public func run<Result, Output: OutputProtocol>(
         configuration,
         output: output,
         preferredBufferSize: preferredBufferSize,
-        isolation: isolation,
         body: body
     )
 }
@@ -396,7 +386,6 @@ public func run<Result>(
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,
@@ -414,7 +403,6 @@ public func run<Result>(
     return try await run(
         configuration,
         preferredBufferSize: preferredBufferSize,
-        isolation: isolation,
         body: body
     )
 }
@@ -607,7 +595,6 @@ public func run<
     input: Input = .none,
     output: Output = .discarded,
     error: Error = .discarded,
-    isolation: isolated (any Actor)? = #isolation,
     body: (_ execution: Execution) async throws -> Result
 ) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
     let inputPipe = try input.createPipe()
@@ -668,7 +655,6 @@ public func run<
     input: Input = .none,
     error: Error = .discarded,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ outputSequence: AsyncBufferSequence
@@ -736,7 +722,6 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
     input: Input = .none,
     output: Output,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ errorSequence: AsyncBufferSequence
@@ -801,7 +786,6 @@ public func run<Result, Error: ErrorOutputProtocol>(
     _ configuration: Configuration,
     error: Error = .discarded,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,
@@ -852,7 +836,6 @@ public func run<Result, Output: OutputProtocol>(
     _ configuration: Configuration,
     output: Output,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,
@@ -898,7 +881,6 @@ public func run<Result, Output: OutputProtocol>(
 public func run<Result>(
     _ configuration: Configuration,
     preferredBufferSize: Int? = nil,
-    isolation: isolated (any Actor)? = #isolation,
     body: (
         _ execution: Execution,
         _ inputWriter: StandardInputWriter,

--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -50,7 +50,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
         }
 
         /// Retrieves the next buffer in the sequence, or `nil` if the sequence ended.
-        public mutating func next() async throws -> Buffer? {
+        public mutating func next(isolation actor: isolated (any Actor)?) async throws -> Buffer? {
             // If we have more left in buffer, use that
             guard self.buffer.isEmpty else {
                 return self.buffer.removeFirst()
@@ -80,6 +80,11 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
             }
             self.buffer = createdBuffers
             return self.buffer.removeFirst()
+        }
+
+        /// Retrieves the next buffer in the sequence, or `nil` if the sequence ended.
+        public mutating func next() async throws -> AsyncBufferSequence.Buffer? {
+            return try await self.next(isolation: nil)
         }
     }
 
@@ -176,14 +181,14 @@ extension AsyncBufferSequence {
             }
 
             /// Retrieves the next line, or `nil` if the sequence ended.
-            public mutating func next() async throws -> String? {
+            public mutating func next(isolation actor: isolated (any Actor)?) async throws -> String? {
 
                 func loadBuffer() async throws -> [Encoding.CodeUnit]? {
                     guard !self.eofReached else {
                         return nil
                     }
 
-                    guard let buffer = try await self.source.next() else {
+                    guard let buffer = try await self.source.next(isolation: actor) else {
                         self.eofReached = true
                         return nil
                     }
@@ -347,6 +352,11 @@ extension AsyncBufferSequence {
                     return yield()
                 }
                 return nil
+            }
+
+            /// Retrieves the next line, or `nil` if the sequence ended.
+            public mutating func next() async throws -> String? {
+                return try await self.next(isolation: nil)
             }
         }
 

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -90,7 +90,6 @@ public struct Configuration: Sendable {
         input: consuming CreatedPipe,
         output: consuming CreatedPipe,
         error: consuming CreatedPipe,
-        isolation: isolated (any Actor)? = #isolation,
         _ body: (
             (
                 Execution,
@@ -1196,7 +1195,6 @@ extension Optional where Wrapped == String {
 internal func withAsyncTaskCleanupHandler<Result: Sendable>(
     _ body: () async throws -> Result,
     onCleanup handler: @Sendable @escaping () async -> Void,
-    isolation: isolated (any Actor)? = #isolation
 ) async throws -> Result {
     let (runCancellationHandlerStream, runCancellationHandlerContinuation) = AsyncThrowingStream.makeStream(of: Void.self)
     return try await withThrowingTaskGroup(
@@ -1327,9 +1325,8 @@ extension HANDLE {
 /// Many standard library functions such as `withCheckedThrowingContinuation`
 /// does not support typed throw yet. This method casts `any Error` thrown by
 /// those methods back to `SubprocessError`
-@Sendable internal func _castError<Success: Sendable>(
+internal func _castError<Success: Sendable>(
     _ body: () async throws -> Success,
-    isolation: isolated (any Actor)? = #isolation
 ) async throws(SubprocessError) -> Success {
     do {
         return try await body()
@@ -1338,7 +1335,7 @@ extension HANDLE {
     }
 }
 
-@Sendable internal func _castError<Success: Sendable>(
+internal func _castError<Success: Sendable>(
     _ body: () throws -> Success
 ) throws(SubprocessError) -> Success {
     do {

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -174,7 +174,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
 }
 
 /// A concrete `Output` type for subprocesses that redirects the child output to
-/// the `.standardOutput` (a sequence) or `.standardError` property of
+/// the `.currentStandardOutput` (a sequence) or `.currentStandardError` property of
 /// `Execution`. This output type is only applicable to the `run()` family that
 /// takes a custom closure.
 internal struct SequenceOutput: OutputProtocol {
@@ -204,7 +204,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
     /// Creates a subprocess output that writes to the current process's standard output.
     ///
     /// The file descriptor isn't closed afterwards.
-    public static var standardOutput: Self {
+    public static var currentStandardOutput: Self {
         return Self.fileDescriptor(
             .standardOutput,
             closeAfterSpawningProcess: false
@@ -214,7 +214,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
     /// Creates a subprocess output that writes to the current process's standard error.
     ///
     /// The file descriptor isn't closed afterwards.
-    public static var standardError: Self {
+    public static var currentStandardError: Self {
         return Self.fileDescriptor(
             .standardError,
             closeAfterSpawningProcess: false


### PR DESCRIPTION
Renaming `.standardOutput` and `.standardError` to `.currentStandardOutput` and `.currentStandardError` makes it more clear that the output is written to the parent process's' standard output rather than the child process's.