### PR TITLE
[POC] Introduce OutputMethod and ErrorOutputMethod to replace OutputProtocol and ErrorProtocol

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -31,8 +31,8 @@ import SystemPackage
 /// - Returns: a `ExecutionRecord` containing the result of the run.
 public func run<
     Input: InputProtocol,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ executable: Executable,
     arguments: Arguments = [],
@@ -40,8 +40,8 @@ public func run<
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input = .none,
-    output: Output,
-    error: Error = .discarded
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
     let configuration = Configuration(
         executable: executable,
@@ -73,8 +73,8 @@ public func run<
 /// - Returns: a ExecutionRecord containing the result of the run.
 public func run<
     InputElement: BitwiseCopyable,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ executable: Executable,
     arguments: Arguments = [],
@@ -82,8 +82,8 @@ public func run<
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: borrowing Span<InputElement>,
-    output: Output,
-    error: Error = .discarded
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
     let configuration = Configuration(
         executable: executable,
@@ -104,7 +104,7 @@ public func run<
 // MARK: - Custom Execution Body
 
 /// Run an executable with given parameters and a custom closure
-/// to manage the running subprocess’ lifetime.
+/// to manage the running subprocess' lifetime.
 /// - Parameters:
 ///   - executable: The executable to run.
 ///   - arguments: The arguments to pass to the executable.
@@ -119,9 +119,7 @@ public func run<
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
 public func run<
     Result,
-    Input: InputProtocol,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Input: InputProtocol
 >(
     _ executable: Executable,
     arguments: Arguments = [],
@@ -129,11 +127,11 @@ public func run<
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input = .none,
-    output: Output = .discarded,
-    error: Error = .discarded,
+    output: OutputMethod<Void> = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let configuration = Configuration(
         executable: executable,
         arguments: arguments,
@@ -169,18 +167,18 @@ public func run<
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process.
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Input: InputProtocol, Error: ErrorOutputProtocol>(
+public func run<Result, Input: InputProtocol>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input = .none,
-    error: Error = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let configuration = Configuration(
         executable: executable,
         arguments: arguments,
@@ -216,18 +214,18 @@ public func run<Result, Input: InputProtocol, Error: ErrorOutputProtocol>(
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
+public func run<Result, Input: InputProtocol>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input = .none,
-    output: Output,
+    output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Output.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let configuration = Configuration(
         executable: executable,
         arguments: arguments,
@@ -262,17 +260,17 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process
 /// - Returns: An `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Error: ErrorOutputProtocol>(
+public func run<Result>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    error: Error = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let configuration = Configuration(
         executable: executable,
         arguments: arguments,
@@ -306,17 +304,17 @@ public func run<Result, Error: ErrorOutputProtocol>(
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process
 /// - Returns: An `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Output: OutputProtocol>(
+public func run<Result>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    output: Output,
+    output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Output.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let configuration = Configuration(
         executable: executable,
         arguments: arguments,
@@ -334,7 +332,7 @@ public func run<Result, Output: OutputProtocol>(
 }
 
 /// Run an executable with given parameters and a custom closure
-/// to manage the running subprocess’ lifetime, write to its
+/// to manage the running subprocess' lifetime, write to its
 /// standard input, and stream its standard output and standard error.
 /// - Parameters:
 ///   - executable: The executable to run.
@@ -395,34 +393,36 @@ public func run<Result>(
 /// - Returns a ExecutionRecord containing the result of the run.
 public func run<
     InputElement: BitwiseCopyable,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ configuration: Configuration,
     input: borrowing Span<InputElement>,
-    output: Output,
-    error: Error = .discarded
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
     typealias RunResult = (
         processIdentifier: ProcessIdentifier,
-        standardOutput: Output.OutputType,
-        standardError: Error.OutputType
+        standardOutput: Output,
+        standardError: Error
     )
 
     let customInput = CustomWriteInput()
+    let outputPipe = try output._createPipe()
+    let errorPipe = try error._createPipe(outputPipe)
 
     let result = try await configuration.run(
         input: try customInput.createPipe(),
-        output: try output.createPipe(),
-        error: try error.createPipe(),
+        output: outputPipe,
+        error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
         var inputIOBox: IOChannel? = consume inputIO
         var outputIOBox: IOChannel? = consume outputIO
         var errorIOBox: IOChannel? = consume errorIO
 
         // Write input, capture output and error in parallel
-        async let stdout = try output.captureOutput(from: outputIOBox.take())
-        async let stderr = try error.captureOutput(from: errorIOBox.take())
+        async let stdout = try output._captureOutput(outputIOBox.take())
+        async let stderr = try error._captureOutput(errorIOBox.take())
         // Write span at the same isolation
         if let writeFd = inputIOBox.take() {
             let writer = StandardInputWriter(diskIO: writeFd)
@@ -456,22 +456,22 @@ public func run<
 /// - Returns: a `ExecutionRecord` containing the result of the run.
 public func run<
     Input: InputProtocol,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ configuration: Configuration,
     input: Input = .none,
-    output: Output,
-    error: Error = .discarded
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
     typealias RunResult = (
         processIdentifier: ProcessIdentifier,
-        standardOutput: Output.OutputType,
-        standardError: Error.OutputType
+        standardOutput: Output,
+        standardError: Error
     )
     let inputPipe = try input.createPipe()
-    let outputPipe = try output.createPipe()
-    let errorPipe = try error.createPipe(from: outputPipe)
+    let outputPipe = try output._createPipe()
+    let errorPipe = try error._createPipe(outputPipe)
 
     let result = try await configuration.run(
         input: inputPipe,
@@ -483,7 +483,7 @@ public func run<
         var outputIOBox: IOChannel? = consume outputIO
         var errorIOBox: IOChannel? = consume errorIO
         return try await withThrowingTaskGroup(
-            of: OutputCapturingState<Output.OutputType, Error.OutputType>?.self,
+            of: OutputCapturingState<Output, Error>?.self,
             returning: RunResult.self
         ) { group in
             var inputIOContainer: IOChannel? = inputIOBox.take()
@@ -498,21 +498,21 @@ public func run<
                 return nil
             }
             group.addTask {
-                let stdout = try await output.captureOutput(
-                    from: outputIOContainer.take()
+                let stdout = try await output._captureOutput(
+                    outputIOContainer.take()
                 )
                 return .standardOutputCaptured(stdout)
             }
             group.addTask {
-                let stderr = try await error.captureOutput(
-                    from: errorIOContainer.take()
+                let stderr = try await error._captureOutput(
+                    errorIOContainer.take()
                 )
                 return .standardErrorCaptured(stderr)
             }
 
             do {
-                var stdout: Output.OutputType!
-                var stderror: Error.OutputType!
+                var stdout: Output!
+                var stderror: Error!
                 while let state = try await group.next() {
                     switch state {
                     case .standardOutputCaptured(let output):
@@ -562,20 +562,18 @@ public func run<
 ///     of the closure.
 public func run<
     Result,
-    Input: InputProtocol,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Input: InputProtocol
 >(
     _ configuration: Configuration,
     input: Input = .none,
-    output: Output = .discarded,
-    error: Error = .discarded,
+    output: OutputMethod<Void> = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let inputPipe = try input.createPipe()
-    let outputPipe = try output.createPipe()
-    let errorPipe = try error.createPipe(from: outputPipe)
+    let outputPipe = try output._createPipe()
+    let errorPipe = try error._createPipe(outputPipe)
 
     return try await configuration.run(
         input: inputPipe,
@@ -621,20 +619,18 @@ public func run<
 ///     of the closure.
 public func run<
     Result,
-    Input: InputProtocol,
-    Error: ErrorOutputProtocol
+    Input: InputProtocol
 >(
     _ configuration: Configuration,
     input: Input = .none,
-    error: Error = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
-    let output = SequenceOutput()
+) async throws -> ExecutionOutcome<Result> {
+    let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
     let inputPipe = try input.createPipe()
-    let outputPipe = try output.createPipe()
-    let errorPipe = try error.createPipe(from: outputPipe)
+    let errorPipe = try error._createPipe(outputPipe)
 
     return try await configuration.run(
         input: inputPipe,
@@ -685,20 +681,21 @@ public func run<
 ///   - body: The custom execution body to manually control the running process
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
-public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
+public func run<Result, Input: InputProtocol>(
     _ configuration: Configuration,
     input: Input = .none,
-    output: Output,
+    output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Output.OutputType == Void {
-    let error = SequenceOutput()
+) async throws -> ExecutionOutcome<Result> {
+    let outputPipe = try output._createPipe()
+    let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
         input: try input.createPipe(),
-        output: try output.createPipe(),
-        error: try error.createPipe(),
+        output: outputPipe,
+        error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
         var inputIOBox: IOChannel? = consume inputIO
         var errorIOBox: IOChannel? = consume errorIO
@@ -744,18 +741,17 @@ public func run<Result, Input: InputProtocol, Output: OutputProtocol>(
 ///   - body: The custom execution body to manually control the running process
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
-public func run<Result, Error: ErrorOutputProtocol>(
+public func run<Result>(
     _ configuration: Configuration,
-    error: Error = .discarded,
+    error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let input = CustomWriteInput()
-    let output = SequenceOutput()
+    let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
     let inputPipe = try input.createPipe()
-    let outputPipe = try output.createPipe()
-    let errorPipe = try error.createPipe(from: outputPipe)
+    let errorPipe = try error._createPipe(outputPipe)
 
     return try await configuration.run(
         input: inputPipe,
@@ -787,20 +783,20 @@ public func run<Result, Error: ErrorOutputProtocol>(
 ///   - body: The custom execution body to manually control the running process
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
-public func run<Result, Output: OutputProtocol>(
+public func run<Result>(
     _ configuration: Configuration,
-    output: Output,
+    output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Output.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     let input = CustomWriteInput()
-    let error = SequenceOutput()
+    let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
         input: try input.createPipe(),
-        output: try output.createPipe(),
-        error: try error.createPipe(),
+        output: try output._createPipe(),
+        error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
         let writer = StandardInputWriter(diskIO: inputIO!)
         let errorSequence = AsyncBufferSequence(
@@ -834,19 +830,19 @@ public func run<Result>(
         (
             Execution,
             StandardInputWriter,
-            AsyncBufferSequence,
-            AsyncBufferSequence
+            _ output: AsyncBufferSequence,
+            _ error: AsyncBufferSequence
         ) async throws -> Result
     )
 ) async throws -> ExecutionOutcome<Result> {
     let input = CustomWriteInput()
-    let output = SequenceOutput()
-    let error = SequenceOutput()
+    let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
+    let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
         input: try input.createPipe(),
-        output: try output.createPipe(),
-        error: try error.createPipe()
+        output: outputPipe,
+        error: errorPipe
     ) { execution, inputIO, outputIO, errorIO in
         let writer = StandardInputWriter(diskIO: inputIO!)
         let outputSequence = AsyncBufferSequence(

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -30,7 +30,6 @@ import SystemPackage
 ///   - error: The method to use for redirecting the standard error.
 /// - Returns: a `ExecutionRecord` containing the result of the run.
 public func run<
-    Input: InputProtocol,
     Output: Sendable,
     Error: Sendable
 >(
@@ -39,7 +38,7 @@ public func run<
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Output>,
     error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
@@ -118,15 +117,14 @@ public func run<
 ///   - body: The custom execution body to manually control the running process
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
 public func run<
-    Result,
-    Input: InputProtocol
+    Result
 >(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Void> = .discarded,
     error: ErrorOutputMethod<Void> = .discarded,
     isolation: isolated (any Actor)? = #isolation,
@@ -167,13 +165,13 @@ public func run<
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process.
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Input: InputProtocol>(
+public func run<Result>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    input: Input = .none,
+    input: InputMethod = .none,
     error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
@@ -214,13 +212,13 @@ public func run<Result, Input: InputProtocol>(
 ///   - isolation: the isolation context to run the body closure.
 ///   - body: The custom execution body to manually control the running process
 /// - Returns: an `ExecutableResult` type containing the return value of the closure.
-public func run<Result, Input: InputProtocol>(
+public func run<Result>(
     _ executable: Executable,
     arguments: Arguments = [],
     environment: Environment = .inherit,
     workingDirectory: FilePath? = nil,
     platformOptions: PlatformOptions = PlatformOptions(),
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
@@ -407,12 +405,12 @@ public func run<
         standardError: Error
     )
 
-    let customInput = CustomWriteInput()
+    let customInput: InputMethod = ._customWrite
     let outputPipe = try output._createPipe()
     let errorPipe = try error._createPipe(outputPipe)
 
     let result = try await configuration.run(
-        input: try customInput.createPipe(),
+        input: try customInput._createPipe(),
         output: outputPipe,
         error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
@@ -455,12 +453,11 @@ public func run<
 ///   - error: The method to use for redirecting the standard error.
 /// - Returns: a `ExecutionRecord` containing the result of the run.
 public func run<
-    Input: InputProtocol,
     Output: Sendable,
     Error: Sendable
 >(
     _ configuration: Configuration,
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Output>,
     error: ErrorOutputMethod<Error> = .discarded
 ) async throws -> ExecutionRecord<Output, Error> {
@@ -469,7 +466,7 @@ public func run<
         standardOutput: Output,
         standardError: Error
     )
-    let inputPipe = try input.createPipe()
+    let inputPipe = try input._createPipe()
     let outputPipe = try output._createPipe()
     let errorPipe = try error._createPipe(outputPipe)
 
@@ -492,7 +489,7 @@ public func run<
             group.addTask {
                 if let writeFd = inputIOContainer.take() {
                     let writer = StandardInputWriter(diskIO: writeFd)
-                    try await input.write(with: writer)
+                    try await input._write(writer)
                     try await writer.finish()
                 }
                 return nil
@@ -561,17 +558,16 @@ public func run<
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
 public func run<
-    Result,
-    Input: InputProtocol
+    Result
 >(
     _ configuration: Configuration,
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Void> = .discarded,
     error: ErrorOutputMethod<Void> = .discarded,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution) async throws -> Result)
 ) async throws -> ExecutionOutcome<Result> {
-    let inputPipe = try input.createPipe()
+    let inputPipe = try input._createPipe()
     let outputPipe = try output._createPipe()
     let errorPipe = try error._createPipe(outputPipe)
 
@@ -589,7 +585,7 @@ public func run<
             group.addTask {
                 if let inputIO = inputIOContainer.take() {
                     let writer = StandardInputWriter(diskIO: inputIO)
-                    try await input.write(with: writer)
+                    try await input._write(writer)
                     try await writer.finish()
                 }
             }
@@ -618,18 +614,17 @@ public func run<
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
 public func run<
-    Result,
-    Input: InputProtocol
+    Result
 >(
     _ configuration: Configuration,
-    input: Input = .none,
+    input: InputMethod = .none,
     error: ErrorOutputMethod<Void> = .discarded,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
 ) async throws -> ExecutionOutcome<Result> {
     let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
-    let inputPipe = try input.createPipe()
+    let inputPipe = try input._createPipe()
     let errorPipe = try error._createPipe(outputPipe)
 
     return try await configuration.run(
@@ -648,7 +643,7 @@ public func run<
             group.addTask {
                 if let inputIO = inputIOContainer.take() {
                     let writer = StandardInputWriter(diskIO: inputIO)
-                    try await input.write(with: writer)
+                    try await input._write(writer)
                     try await writer.finish()
                 }
             }
@@ -681,9 +676,9 @@ public func run<
 ///   - body: The custom execution body to manually control the running process
 /// - Returns an executableResult type containing the return value
 ///     of the closure.
-public func run<Result, Input: InputProtocol>(
+public func run<Result>(
     _ configuration: Configuration,
-    input: Input = .none,
+    input: InputMethod = .none,
     output: OutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     isolation: isolated (any Actor)? = #isolation,
@@ -693,7 +688,7 @@ public func run<Result, Input: InputProtocol>(
     let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
-        input: try input.createPipe(),
+        input: try input._createPipe(),
         output: outputPipe,
         error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
@@ -708,7 +703,7 @@ public func run<Result, Input: InputProtocol>(
             group.addTask {
                 if let inputIO = inputIOContainer.take() {
                     let writer = StandardInputWriter(diskIO: inputIO)
-                    try await input.write(with: writer)
+                    try await input._write(writer)
                     try await writer.finish()
                 }
             }
@@ -748,9 +743,9 @@ public func run<Result>(
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
 ) async throws -> ExecutionOutcome<Result> {
-    let input = CustomWriteInput()
+    let input: InputMethod = ._customWrite
     let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
-    let inputPipe = try input.createPipe()
+    let inputPipe = try input._createPipe()
     let errorPipe = try error._createPipe(outputPipe)
 
     return try await configuration.run(
@@ -790,11 +785,11 @@ public func run<Result>(
     isolation: isolated (any Actor)? = #isolation,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
 ) async throws -> ExecutionOutcome<Result> {
-    let input = CustomWriteInput()
+    let input: InputMethod = ._customWrite
     let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
-        input: try input.createPipe(),
+        input: try input._createPipe(),
         output: try output._createPipe(),
         error: errorPipe,
     ) { execution, inputIO, outputIO, errorIO in
@@ -835,12 +830,12 @@ public func run<Result>(
         ) async throws -> Result
     )
 ) async throws -> ExecutionOutcome<Result> {
-    let input = CustomWriteInput()
+    let input: InputMethod = ._customWrite
     let outputPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
     let errorPipe = try CreatedPipe(closeWhenDone: true, purpose: .output)
 
     return try await configuration.run(
-        input: try input.createPipe(),
+        input: try input._createPipe(),
         output: outputPipe,
         error: errorPipe
     ) { execution, inputIO, outputIO, errorIO in

--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -35,8 +35,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
     #endif
 
     /// Iterator for `AsyncBufferSequence`.
-    @_nonSendable
-    public struct Iterator: AsyncIteratorProtocol {
+    public struct Iterator: AsyncIteratorProtocol, Sendable {
         /// The element type for the iterator.
         public typealias Element = Buffer
 

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -31,25 +31,113 @@ import FoundationEssentials
 
 #endif // SubprocessFoundation
 
-// MARK: - Input
+// MARK: - InputMethod
 
-/// InputProtocol defines a type that serves as the input source for a subprocess.
+/// Specifies how a subprocess should receive its standard input.
 ///
-/// The protocol defines the `write(with:)` method that a type must
-/// implement to serve as the input source.
-public protocol InputProtocol: Sendable, ~Copyable {
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor
-    func write(with writer: StandardInputWriter) async throws
+/// Use the provided static factory methods (`.none`, `.string(_:)`,
+/// `.array(_:)`, `.fileDescriptor(_:closeAfterSpawningProcess:)`) to create
+/// input configurations.
+public struct InputMethod: Sendable {
+    internal let _createPipe: @Sendable () throws -> CreatedPipe
+    internal let _write: @Sendable (StandardInputWriter) async throws -> Void
+
+    internal init(
+        createPipe: @escaping @Sendable () throws -> CreatedPipe,
+        write: @escaping @Sendable (StandardInputWriter) async throws -> Void
+    ) {
+        self._createPipe = createPipe
+        self._write = write
+    }
 }
 
-/// A concrete input type for subprocesses that indicates the absence
-/// of input to the subprocess.
-///
-/// On Unix-like systems, `NoInput` redirects the standard input of the subprocess to /dev/null,
-/// while on Windows, it redirects to `NUL`.
-public struct NoInput: InputProtocol {
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
+extension InputMethod {
+    /// Create a Subprocess input that specifies there is no input.
+    ///
+    /// On Unix-like systems, this redirects the standard input of the subprocess
+    /// to `/dev/null`, while on Windows, it redirects to `NUL`.
+    public static var none: InputMethod {
+        let inner = NoInput()
+        return InputMethod(
+            createPipe: { try inner.createPipe() },
+            write: { _ in }
+        )
+    }
+
+    /// Create a Subprocess input from a `FileDescriptor` and
+    /// specify whether the `FileDescriptor` should be closed
+    /// after the process is spawned.
+    public static func fileDescriptor(
+        _ fd: FileDescriptor,
+        closeAfterSpawningProcess: Bool
+    ) -> InputMethod {
+        let inner = FileDescriptorInput(
+            fileDescriptor: fd,
+            closeAfterSpawningProcess: closeAfterSpawningProcess
+        )
+        return InputMethod(
+            createPipe: { try inner.createPipe() },
+            write: { _ in }
+        )
+    }
+
+    /// Create a Subprocess input that reads from the standard input of
+    /// current process.
+    ///
+    /// The file descriptor isn't closed afterwards.
+    public static var standardInput: InputMethod {
+        return .fileDescriptor(
+            .standardInput,
+            closeAfterSpawningProcess: false
+        )
+    }
+
+    /// Create a Subprocess input from a type that conforms to `StringProtocol`.
+    public static func string(
+        _ string: some StringProtocol & Sendable
+    ) -> InputMethod {
+        let inner = StringInput(string: string, encoding: UTF8.self)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
+    }
+
+    /// Create a Subprocess input from a type that conforms to `StringProtocol`
+    /// with a specified encoding.
+    public static func string<Encoding: Unicode.Encoding>(
+        _ string: some StringProtocol & Sendable,
+        using encoding: Encoding.Type
+    ) -> InputMethod {
+        let inner = StringInput(string: string, encoding: encoding)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
+    }
+
+    /// Create a Subprocess input from an `Array` of `UInt8`.
+    public static func array(_ array: [UInt8]) -> InputMethod {
+        let inner = ArrayInput(array: array)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
+    }
+
+    /// Internal: creates a pipe for custom write (body-closure and Span overloads).
+    internal static var _customWrite: InputMethod {
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { _ in }
+        )
+    }
+}
+
+// MARK: - Internal Concrete Input Types
+
+internal struct NoInput {
+    func createPipe() throws(SubprocessError) -> CreatedPipe {
         #if os(Windows)
         let devnullFd: FileDescriptor = try .openDevNull(withAccessMode: .writeOnly)
         let devnull = HANDLE(bitPattern: _get_osfhandle(devnullFd.rawValue))!
@@ -62,24 +150,14 @@ public struct NoInput: InputProtocol {
         )
     }
 
-    /// Asynchronously write the input to the subprocess that uses the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
-    }
-
-    internal init() {}
+    init() {}
 }
 
-/// A concrete input type for subprocesses that reads input from a specified FileDescriptor.
-///
-/// Developers have the option to instruct the Subprocess to automatically close the provided
-/// FileDescriptor after the subprocess is spawned.
-public struct FileDescriptorInput: InputProtocol {
+internal struct FileDescriptorInput {
     private let fileDescriptor: FileDescriptor
     private let closeAfterSpawningProcess: Bool
 
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
+    func createPipe() throws(SubprocessError) -> CreatedPipe {
         #if canImport(WinSDK)
         let readFd = HANDLE(bitPattern: _get_osfhandle(self.fileDescriptor.rawValue))!
         #else
@@ -94,13 +172,7 @@ public struct FileDescriptorInput: InputProtocol {
         )
     }
 
-    /// Asynchronously write the input to the subprocess that use the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
-    }
-
-    internal init(
+    init(
         fileDescriptor: FileDescriptor,
         closeAfterSpawningProcess: Bool
     ) {
@@ -109,127 +181,33 @@ public struct FileDescriptorInput: InputProtocol {
     }
 }
 
-/// A concrete `Input` type for subprocesses that reads input
-/// from a given type conforming to `StringProtocol`.
-/// Developers can specify the string encoding to use when
-/// encoding the string to data, which defaults to UTF-8.
-public struct StringInput<
+internal struct StringInput<
     InputString: StringProtocol & Sendable,
     Encoding: Unicode.Encoding
->: InputProtocol {
+>: Sendable {
     private let string: InputString
 
-    /// Asynchronously write the input to the subprocess that use the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws {
+    func write(with writer: StandardInputWriter) async throws {
         guard let array = self.string.byteArray(using: Encoding.self) else {
             return
         }
         _ = try await writer.write(array)
     }
 
-    internal init(string: InputString, encoding: Encoding.Type) {
+    init(string: InputString, encoding: Encoding.Type) {
         self.string = string
     }
 }
 
-/// A concrete input type for subprocesses that reads input from
-/// a given `UInt8` Array.
-public struct ArrayInput: InputProtocol {
+internal struct ArrayInput: Sendable {
     private let array: [UInt8]
 
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor
-    public func write(with writer: StandardInputWriter) async throws {
+    func write(with writer: StandardInputWriter) async throws {
         _ = try await writer.write(self.array)
     }
 
-    internal init(array: [UInt8]) {
+    init(array: [UInt8]) {
         self.array = array
-    }
-}
-
-/// A concrete input type that the run closure uses to write custom input
-/// into the subprocess.
-internal struct CustomWriteInput: InputProtocol {
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
-    }
-
-    internal init() {}
-}
-
-extension InputProtocol where Self == NoInput {
-    /// Create a Subprocess input that specifies there is no input
-    public static var none: Self { .init() }
-}
-
-extension InputProtocol where Self == FileDescriptorInput {
-    /// Create a Subprocess input from a `FileDescriptor` and
-    /// specify whether the `FileDescriptor` should be closed
-    /// after the process is spawned.
-    public static func fileDescriptor(
-        _ fd: FileDescriptor,
-        closeAfterSpawningProcess: Bool
-    ) -> Self {
-        return .init(
-            fileDescriptor: fd,
-            closeAfterSpawningProcess: closeAfterSpawningProcess
-        )
-    }
-
-    /// Create a Subprocess input that reads from the standard input of
-    /// current process.
-    ///
-    /// The file descriptor isn't closed afterwards.
-    public static var standardInput: Self {
-        return Self.fileDescriptor(
-            .standardInput,
-            closeAfterSpawningProcess: false
-        )
-    }
-}
-
-extension InputProtocol {
-    /// Create a Subprocess input from a `Array` of `UInt8`.
-    public static func array(
-        _ array: [UInt8]
-    ) -> Self where Self == ArrayInput {
-        return ArrayInput(array: array)
-    }
-
-    /// Create a Subprocess input from a type that conforms to `StringProtocol`
-    public static func string<
-        InputString: StringProtocol & Sendable
-    >(
-        _ string: InputString
-    ) -> Self where Self == StringInput<InputString, UTF8> {
-        return .init(string: string, encoding: UTF8.self)
-    }
-
-    /// Create a Subprocess input from a type that conforms to `StringProtocol`
-    public static func string<
-        InputString: StringProtocol & Sendable,
-        Encoding: Unicode.Encoding
-    >(
-        _ string: InputString,
-        using encoding: Encoding.Type
-    ) -> Self where Self == StringInput<InputString, Encoding> {
-        return .init(string: string, encoding: encoding)
-    }
-}
-
-extension InputProtocol {
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
-        if let noInput = self as? NoInput {
-            return try noInput.createPipe()
-        } else if let fdInput = self as? FileDescriptorInput {
-            return try fdInput.createPipe()
-        }
-        // Base implementation
-        return try CreatedPipe(closeWhenDone: true, purpose: .input)
     }
 }
 

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -21,15 +21,287 @@ import SystemPackage
 
 internal import Dispatch
 
-// MARK: - Output
+// MARK: - OutputMethod
 
-/// Output protocol specifies the set of methods that a type must implement to
-/// serve as the output target for a subprocess.
+/// Specifies how a subprocess should handle its standard output.
 ///
-/// Instead of developing custom implementations of `OutputProtocol`, use the
-/// default implementations provided by the `Subprocess` library to specify the
-/// output handling requirements.
-public protocol OutputProtocol: Sendable, ~Copyable {
+/// Use the provided static factory methods (`.discarded`, `.string(limit:)`,
+/// `.bytes(limit:)`, `.fileDescriptor(_:closeAfterSpawningProcess:)`) to create
+/// output configurations. Custom implementations are not supported.
+public struct OutputMethod<T: Sendable>: Sendable {
+    internal let maxSize: Int
+    internal let _createPipe: @Sendable () throws -> CreatedPipe
+    internal let _captureOutput: @Sendable (consuming IOChannel?) async throws -> T
+
+    internal init(
+        maxSize: Int,
+        createPipe: @escaping @Sendable () throws -> CreatedPipe,
+        captureOutput: @escaping @Sendable (consuming IOChannel?) async throws -> T
+    ) {
+        self.maxSize = maxSize
+        self._createPipe = createPipe
+        self._captureOutput = captureOutput
+    }
+}
+
+extension OutputMethod where T == Void {
+    /// Create a Subprocess output that discards the output.
+    ///
+    /// On Unix-like systems, this redirects the standard output of the
+    /// subprocess to `/dev/null`, while on Windows, redirects to `NUL`.
+    public static var discarded: OutputMethod<Void> {
+        let inner = DiscardedOutput()
+        return OutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { try inner.createPipe() },
+            captureOutput: { _ in }
+        )
+    }
+
+    /// Create a Subprocess output that writes output to a `FileDescriptor`
+    /// and optionally close the `FileDescriptor` once process spawned.
+    public static func fileDescriptor(
+        _ fd: FileDescriptor,
+        closeAfterSpawningProcess: Bool
+    ) -> OutputMethod<Void> {
+        let inner = FileDescriptorOutput(
+            fileDescriptor: fd,
+            closeAfterSpawningProcess: closeAfterSpawningProcess
+        )
+        return OutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { try inner.createPipe() },
+            captureOutput: { _ in }
+        )
+    }
+
+    /// Create a Subprocess output that writes output to the standard output of
+    /// current process.
+    ///
+    /// The file descriptor isn't closed afterwards.
+    public static var standardOutput: OutputMethod<Void> {
+        return .fileDescriptor(
+            .standardOutput,
+            closeAfterSpawningProcess: false
+        )
+    }
+
+    /// Create a Subprocess output that writes output to the standard error of
+    /// current process.
+    ///
+    /// The file descriptor isn't closed afterwards.
+    public static var standardError: OutputMethod<Void> {
+        return .fileDescriptor(
+            .standardError,
+            closeAfterSpawningProcess: false
+        )
+    }
+
+    /// Internal: creates a pipe for streaming output via `AsyncBufferSequence`.
+    internal static var _sequence: OutputMethod<Void> {
+        return OutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { _ in }
+        )
+    }
+}
+
+extension OutputMethod where T == String? {
+    /// Create a `Subprocess` output that collects output as UTF8 String
+    /// with a buffer limit in bytes. Subprocess throws an error if the
+    /// child process emits more bytes than the limit.
+    public static func string(limit: Int) -> OutputMethod<String?> {
+        let inner = StringOutput(limit: limit, encoding: UTF8.self)
+        return OutputMethod<String?>(
+            maxSize: limit,
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+extension OutputMethod {
+    /// Create a `Subprocess` output that collects output as
+    /// `String` using the given encoding up to limit in bytes.
+    /// Subprocess throws an error if the child process emits
+    /// more bytes than the limit.
+    public static func string<Encoding: Unicode.Encoding>(
+        limit: Int,
+        encoding: Encoding.Type
+    ) -> OutputMethod<String?> where T == String? {
+        let inner = StringOutput(limit: limit, encoding: encoding)
+        return OutputMethod<String?>(
+            maxSize: limit,
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+extension OutputMethod where T == [UInt8] {
+    /// Create a `Subprocess` output that collects output as
+    /// `[UInt8]` with a buffer limit in bytes. Subprocess throws
+    /// an error if the child process emits more bytes than the limit.
+    public static func bytes(limit: Int) -> OutputMethod<[UInt8]> {
+        let inner = BytesOutput(limit: limit)
+        return OutputMethod<[UInt8]>(
+            maxSize: limit,
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                guard let diskIO else { return [] }
+                return try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+// MARK: - ErrorOutputMethod
+
+/// Specifies how a subprocess should handle its standard error output.
+///
+/// Use the provided static factory methods (`.discarded`, `.string(limit:)`,
+/// `.bytes(limit:)`, `.combineWithOutput`, etc.) to create error output
+/// configurations. Custom implementations are not supported.
+public struct ErrorOutputMethod<T: Sendable>: Sendable {
+    internal let maxSize: Int
+    internal let _createPipe: @Sendable (borrowing CreatedPipe) throws -> CreatedPipe
+    internal let _captureOutput: @Sendable (consuming IOChannel?) async throws -> T
+
+    internal init(
+        maxSize: Int,
+        createPipe: @escaping @Sendable (borrowing CreatedPipe) throws -> CreatedPipe,
+        captureOutput: @escaping @Sendable (consuming IOChannel?) async throws -> T
+    ) {
+        self.maxSize = maxSize
+        self._createPipe = createPipe
+        self._captureOutput = captureOutput
+    }
+}
+
+extension ErrorOutputMethod where T == Void {
+    /// Create a Subprocess error output that discards the error output.
+    public static var discarded: ErrorOutputMethod<Void> {
+        let inner = DiscardedOutput()
+        return ErrorOutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { _ in try inner.createPipe() },
+            captureOutput: { _ in }
+        )
+    }
+
+    /// Creates an error output that combines standard error with standard output.
+    ///
+    /// When using `combineWithOutput`, both standard output and standard error from
+    /// the child process are merged into a single output stream. This is equivalent
+    /// to using shell redirection like `2>&1`.
+    ///
+    /// This is useful when you want to capture or redirect both output streams
+    /// together, making it possible to process all subprocess output as a unified
+    /// stream rather than handling standard output and standard error separately.
+    ///
+    /// - Returns: An `ErrorOutputMethod` that merges standard error
+    ///   with standard output.
+    public static var combineWithOutput: ErrorOutputMethod<Void> {
+        return ErrorOutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { outputPipe in
+                try CreatedPipe(duplicating: outputPipe)
+            },
+            captureOutput: { _ in }
+        )
+    }
+
+    /// Create a Subprocess error output that writes to a `FileDescriptor`
+    /// and optionally close the `FileDescriptor` once process spawned.
+    public static func fileDescriptor(
+        _ fd: FileDescriptor,
+        closeAfterSpawningProcess: Bool
+    ) -> ErrorOutputMethod<Void> {
+        let inner = FileDescriptorOutput(
+            fileDescriptor: fd,
+            closeAfterSpawningProcess: closeAfterSpawningProcess
+        )
+        return ErrorOutputMethod<Void>(
+            maxSize: 0,
+            createPipe: { _ in try inner.createPipe() },
+            captureOutput: { _ in }
+        )
+    }
+
+    /// Create a Subprocess error output that writes to the standard error of
+    /// current process.
+    ///
+    /// The file descriptor isn't closed afterwards.
+    public static var standardError: ErrorOutputMethod<Void> {
+        return .fileDescriptor(
+            .standardError,
+            closeAfterSpawningProcess: false
+        )
+    }
+}
+
+extension ErrorOutputMethod where T == String? {
+    /// Create a `Subprocess` error output that collects error output as UTF8 String
+    /// with a buffer limit in bytes. Subprocess throws an error if the
+    /// child process emits more bytes than the limit.
+    public static func string(limit: Int) -> ErrorOutputMethod<String?> {
+        let inner = StringOutput(limit: limit, encoding: UTF8.self)
+        return ErrorOutputMethod<String?>(
+            maxSize: limit,
+            createPipe: { _ in try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+extension ErrorOutputMethod {
+    /// Create a `Subprocess` error output that collects error output as
+    /// `String` using the given encoding up to limit in bytes.
+    /// Subprocess throws an error if the child process emits
+    /// more bytes than the limit.
+    public static func string<Encoding: Unicode.Encoding>(
+        limit: Int,
+        encoding: Encoding.Type
+    ) -> ErrorOutputMethod<String?> where T == String? {
+        let inner = StringOutput(limit: limit, encoding: encoding)
+        return ErrorOutputMethod<String?>(
+            maxSize: limit,
+            createPipe: { _ in try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+extension ErrorOutputMethod where T == [UInt8] {
+    /// Create a `Subprocess` error output that collects error output as
+    /// `[UInt8]` with a buffer limit in bytes. Subprocess throws
+    /// an error if the child process emits more bytes than the limit.
+    public static func bytes(limit: Int) -> ErrorOutputMethod<[UInt8]> {
+        let inner = BytesOutput(limit: limit)
+        return ErrorOutputMethod<[UInt8]>(
+            maxSize: limit,
+            createPipe: { _ in try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                guard let diskIO else { return [] }
+                return try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+// MARK: - Internal Output Protocol
+
+/// Internal protocol used by the concrete output type implementations.
+internal protocol OutputProtocol: Sendable, ~Copyable {
     associatedtype OutputType: Sendable
 
     #if SubprocessSpan
@@ -46,22 +318,15 @@ public protocol OutputProtocol: Sendable, ~Copyable {
 
 extension OutputProtocol {
     /// The max amount of data to collect for this output.
-    public var maxSize: Int { 128 * 1024 }
+    internal var maxSize: Int { 128 * 1024 }
 }
 
-/// A concrete output type for subprocesses that indicates that the
-/// subprocess should not collect or redirect output from the child
-/// process.
-///
-/// On Unix-like systems, `DiscardedOutput` redirects the
-/// standard output of the subprocess to `/dev/null`, while on Windows,
-/// redirects the output to `NUL`.
-public struct DiscardedOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The type for the output.
-    public typealias OutputType = Void
+// MARK: - Internal Concrete Output Types
 
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
+internal struct DiscardedOutput: OutputProtocol {
+    typealias OutputType = Void
 
+    func createPipe() throws(SubprocessError) -> CreatedPipe {
         #if os(Windows)
         let devnullFd: FileDescriptor = try .openDevNull(withAccessMode: .writeOnly)
         let devnull = HANDLE(bitPattern: _get_osfhandle(devnullFd.rawValue))!
@@ -74,22 +339,16 @@ public struct DiscardedOutput: OutputProtocol, ErrorOutputProtocol {
         )
     }
 
-    internal init() {}
+    init() {}
 }
 
-/// A concrete output type for subprocesses that writes output
-/// to a specified file descriptor.
-///
-/// Developers have the option to instruct the `Subprocess` to automatically
-/// close the related `FileDescriptor` after the subprocess is spawned.
-public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The type for this output.
-    public typealias OutputType = Void
+internal struct FileDescriptorOutput: OutputProtocol {
+    typealias OutputType = Void
 
     private let closeAfterSpawningProcess: Bool
     private let fileDescriptor: FileDescriptor
 
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
+    func createPipe() throws(SubprocessError) -> CreatedPipe {
         #if canImport(WinSDK)
         let writeFd = HANDLE(bitPattern: _get_osfhandle(self.fileDescriptor.rawValue))!
         #else
@@ -104,7 +363,7 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
         )
     }
 
-    internal init(
+    init(
         fileDescriptor: FileDescriptor,
         closeAfterSpawningProcess: Bool
     ) {
@@ -113,17 +372,12 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
     }
 }
 
-/// A concrete `Output` type for subprocesses that collects output
-/// from the subprocess as `String` with the given encoding.
-public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOutputProtocol {
-    /// The type for this output.
-    public typealias OutputType = String?
-    /// The max number of bytes to collect.
-    public let maxSize: Int
+internal struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol {
+    typealias OutputType = String?
+    let maxSize: Int
 
     #if SubprocessSpan
-    /// Create a string from a raw span.
-    public func output(from span: RawSpan) throws -> String? {
+    func output(from span: RawSpan) throws -> String? {
         // FIXME: Span to String
         var array: [UInt8] = []
         for index in 0..<span.byteCount {
@@ -133,27 +387,22 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
     }
     #endif
 
-    /// Create a String from a sequence of 8-bit unsigned integers.
-    public func output(from buffer: some Sequence<UInt8>) throws -> String? {
+    func output(from buffer: some Sequence<UInt8>) throws -> String? {
         // FIXME: Span to String
         let array = Array(buffer)
         return String(decodingBytes: array, as: Encoding.self)
     }
 
-    internal init(limit: Int, encoding: Encoding.Type) {
+    init(limit: Int, encoding: Encoding.Type) {
         self.maxSize = limit
     }
 }
 
-/// A concrete `Output` type for subprocesses that collects output from
-/// the subprocess as `[UInt8]`.
-public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The output type for this output option
-    public typealias OutputType = [UInt8]
-    /// The max number of bytes to collect
-    public let maxSize: Int
+internal struct BytesOutput: OutputProtocol {
+    typealias OutputType = [UInt8]
+    let maxSize: Int
 
-    internal func captureOutput(
+    func captureOutput(
         from diskIO: consuming IOChannel
     ) async throws(SubprocessError) -> [UInt8] {
         #if SUBPROCESS_ASYNCIO_DISPATCH
@@ -186,159 +435,29 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
     }
 
     #if SubprocessSpan
-    /// Create an Array from `RawSpawn`.
-    /// Not implemented
-    public func output(from span: RawSpan) throws -> [UInt8] {
+    func output(from span: RawSpan) throws -> [UInt8] {
         fatalError("Not implemented")
     }
     #endif
-    /// Create an Array from `Sequence<UInt8>`.
-    /// Not implemented
-    public func output(from buffer: some Sequence<UInt8>) throws -> [UInt8] {
+
+    func output(from buffer: some Sequence<UInt8>) throws -> [UInt8] {
         fatalError("Not implemented")
     }
 
-    internal init(limit: Int) {
+    init(limit: Int) {
         self.maxSize = limit
     }
 }
 
-/// A concrete `Output` type for subprocesses that redirects the child output to
-/// the `.standardOutput` (a sequence) or `.standardError` property of
-/// `Execution`. This output type is only applicable to the `run()` family that
-/// takes a custom closure.
 internal struct SequenceOutput: OutputProtocol {
-    /// The output type for this output option
-    public typealias OutputType = Void
-
-    internal init() {}
-}
-
-extension OutputProtocol where Self == DiscardedOutput {
-    /// Create a Subprocess output that discards the output
-    public static var discarded: Self { .init() }
-}
-
-extension OutputProtocol where Self == FileDescriptorOutput {
-    /// Create a Subprocess output that writes output to a `FileDescriptor`
-    /// and optionally close the `FileDescriptor` once process spawned.
-    public static func fileDescriptor(
-        _ fd: FileDescriptor,
-        closeAfterSpawningProcess: Bool
-    ) -> Self {
-        return .init(fileDescriptor: fd, closeAfterSpawningProcess: closeAfterSpawningProcess)
-    }
-
-    /// Create a Subprocess output that writes output to the standard output of
-    /// current process.
-    ///
-    /// The file descriptor isn't closed afterwards.
-    public static var standardOutput: Self {
-        return Self.fileDescriptor(
-            .standardOutput,
-            closeAfterSpawningProcess: false
-        )
-    }
-
-    /// Create a Subprocess output that write output to the standard error of
-    /// current process.
-    ///
-    /// The file descriptor isn't closed afterwards.
-    public static var standardError: Self {
-        return Self.fileDescriptor(
-            .standardError,
-            closeAfterSpawningProcess: false
-        )
-    }
-}
-
-extension OutputProtocol where Self == StringOutput<UTF8> {
-    /// Create a `Subprocess` output that collects output as UTF8 String
-    /// with a buffer limit in bytes. Subprocess throws an error if the
-    /// child process emits more bytes than the limit.
-    public static func string(limit: Int) -> Self {
-        return .init(limit: limit, encoding: UTF8.self)
-    }
-}
-
-extension OutputProtocol {
-    /// Create a `Subprocess` output that collects output as
-    /// `String` using the given encoding up to limit in bytes.
-    /// Subprocess throws an error if the child process emits
-    /// more bytes than the limit.
-    public static func string<Encoding: Unicode.Encoding>(
-        limit: Int,
-        encoding: Encoding.Type
-    ) -> Self where Self == StringOutput<Encoding> {
-        return .init(limit: limit, encoding: encoding)
-    }
-}
-
-extension OutputProtocol where Self == BytesOutput {
-    /// Create a `Subprocess` output that collects output as
-    /// `Buffer` with a buffer limit in bytes. Subprocess throws
-    /// an error if the child process emits more bytes than the limit.
-    public static func bytes(limit: Int) -> Self {
-        return .init(limit: limit)
-    }
-}
-
-// MARK: - ErrorOutputProtocol
-
-/// Error output protocol specifies the set of methods that a type must implement to
-/// serve as the error output target for a subprocess.
-///
-/// Instead of developing custom implementations of `ErrorOutputProtocol`, use the
-/// default implementations provided by the `Subprocess` library to specify the
-/// output handling requirements.
-public protocol ErrorOutputProtocol: OutputProtocol {}
-
-/// A concrete error output type for subprocesses that combines the standard error
-/// output with the standard output stream.
-///
-/// When `CombinedErrorOutput` is used as the error output for a subprocess, both
-/// standard output and standard error from the child process are merged into a
-/// single output stream. This is equivalent to using shell redirection like `2>&1`.
-///
-/// This output type is useful when you want to capture or redirect both output
-/// streams together, making it possible to process all subprocess output as a unified
-/// stream rather than handling standard output and standard error separately.
-public struct CombinedErrorOutput: ErrorOutputProtocol {
-    public typealias OutputType = Void
-}
-
-extension ErrorOutputProtocol {
-    internal func createPipe(from outputPipe: borrowing CreatedPipe) throws(SubprocessError) -> CreatedPipe {
-        if self is CombinedErrorOutput {
-            return try CreatedPipe(duplicating: outputPipe)
-        }
-        return try createPipe()
-    }
-}
-
-extension ErrorOutputProtocol where Self == CombinedErrorOutput {
-    /// Creates an error output that combines standard error with standard output.
-    ///
-    /// When using `combineWithOutput`, both standard output and standard error from
-    /// the child process are merged into a single output stream. This is equivalent
-    /// to using shell redirection like `2>&1`.
-    ///
-    /// This is useful when you want to capture or redirect both output streams
-    /// together, making it possible to process all subprocess output as a unified
-    /// stream rather than handling standard output and standard error separately
-    ///
-    /// - Returns: A `CombinedErrorOutput` instance that merges standard error
-    ///   with standard output.
-    public static var combineWithOutput: Self {
-        return CombinedErrorOutput()
-    }
+    typealias OutputType = Void
+    init() {}
 }
 
 // MARK: - Span Default Implementations
 #if SubprocessSpan
 extension OutputProtocol {
-    /// Create an Array from `Sequence<UInt8>`.
-    public func output(from buffer: some Sequence<UInt8>) throws -> OutputType {
+    func output(from buffer: some Sequence<UInt8>) throws -> OutputType {
         guard let rawBytes: UnsafeRawBufferPointer = buffer as? UnsafeRawBufferPointer else {
             fatalError("Unexpected input type passed: \(type(of: buffer))")
         }
@@ -348,21 +467,10 @@ extension OutputProtocol {
 }
 #endif
 
-// MARK: - Default Implementations
-extension OutputProtocol {
-    @_disfavoredOverload
-    internal func createPipe() throws(SubprocessError) -> CreatedPipe {
-        if let discard = self as? DiscardedOutput {
-            return try discard.createPipe()
-        } else if let fdOutput = self as? FileDescriptorOutput {
-            return try fdOutput.createPipe()
-        }
-        // Base pipe based implementation for everything else
-        return try CreatedPipe(closeWhenDone: true, purpose: .output)
-    }
+// MARK: - Default Capture Implementation
 
+extension OutputProtocol {
     /// Capture the output from the subprocess up to maxSize
-    @_disfavoredOverload
     internal func captureOutput(
         from diskIO: consuming IOChannel?
     ) async throws -> OutputType {
@@ -370,18 +478,10 @@ extension OutputProtocol {
             try diskIO?.safelyClose()
             return () as! OutputType
         }
-        // `diskIO` is only `nil` for any types that conform to `OutputProtocol`
-        // and have `Void` as ``OutputType` (i.e. `DiscardedOutput`). Since we
-        // made sure `OutputType` is not `Void` on the line above, `diskIO`
-        // must not be nil; otherwise, this is a programmer error.
         guard var diskIO else {
             fatalError(
                 "Internal Inconsistency Error: diskIO must not be nil when OutputType is not Void"
             )
-        }
-
-        if let bytesOutput = self as? BytesOutput {
-            return try await bytesOutput.captureOutput(from: diskIO) as! Self.OutputType
         }
 
         #if SUBPROCESS_ASYNCIO_DISPATCH
@@ -392,8 +492,6 @@ extension OutputProtocol {
         do {
             var maxLength = self.maxSize
             if maxLength != .max {
-                // If we actually have a max length, attempt to read one
-                // more byte to determine whether output exceeds the limit
                 maxLength += 1
             }
             result = try await AsyncIO.shared.read(from: diskIO, upTo: maxLength)
@@ -416,16 +514,13 @@ extension OutputProtocol {
 }
 
 extension OutputProtocol where OutputType == Void {
-    internal func captureOutput(from fileDescriptor: consuming IOChannel?) async throws {}
-
     #if SubprocessSpan
-    /// Convert the output from raw span to expected output type
-    public func output(from span: RawSpan) throws {
+    func output(from span: RawSpan) throws {
         fatalError("Unexpected call to \(#function)")
     }
     #endif
-    /// Convert the output from a sequence of 8-bit unsigned integers to expected output type.
-    public func output(from buffer: some Sequence<UInt8>) throws {
+
+    func output(from buffer: some Sequence<UInt8>) throws {
         fatalError("Unexpected call to \(#function)")
     }
 }
@@ -462,6 +557,8 @@ extension OutputProtocol {
     #endif // SUBPROCESS_ASYNCIO_DISPATCH
 }
 #endif
+
+// MARK: - Utilities
 
 extension DispatchData {
     internal func array() -> [UInt8] {

--- a/Sources/Subprocess/Result.swift
+++ b/Sources/Subprocess/Result.swift
@@ -35,23 +35,23 @@ public struct ExecutionOutcome<Result: Sendable>: Sendable {
 /// The result of a subprocess execution with its collected
 /// standard output and standard error.
 public struct ExecutionRecord<
-    Output: OutputProtocol,
-    Error: OutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >: Sendable {
     /// The process identifier for the executed subprocess
     public let processIdentifier: ProcessIdentifier
     /// The termination status of the executed subprocess
     public let terminationStatus: TerminationStatus
     /// The captured standard output of the executed subprocess.
-    public let standardOutput: Output.OutputType
+    public let standardOutput: Output
     /// The captured standard error of the executed subprocess.
-    public let standardError: Error.OutputType
+    public let standardError: Error
 
     internal init(
         processIdentifier: ProcessIdentifier,
         terminationStatus: TerminationStatus,
-        standardOutput: Output.OutputType,
-        standardError: Error.OutputType
+        standardOutput: Output,
+        standardError: Error
     ) {
         self.processIdentifier = processIdentifier
         self.terminationStatus = terminationStatus
@@ -62,12 +62,12 @@ public struct ExecutionRecord<
 
 // MARK: - ExecutionRecord Conformances
 
-extension ExecutionRecord: Equatable where Output.OutputType: Equatable, Error.OutputType: Equatable {}
+extension ExecutionRecord: Equatable where Output: Equatable, Error: Equatable {}
 
-extension ExecutionRecord: Hashable where Output.OutputType: Hashable, Error.OutputType: Hashable {}
+extension ExecutionRecord: Hashable where Output: Hashable, Error: Hashable {}
 
 extension ExecutionRecord: CustomStringConvertible
-where Output.OutputType: CustomStringConvertible, Error.OutputType: CustomStringConvertible {
+where Output: CustomStringConvertible, Error: CustomStringConvertible {
     /// A textual representation of the collected result.
     public var description: String {
         return """
@@ -82,7 +82,7 @@ where Output.OutputType: CustomStringConvertible, Error.OutputType: CustomString
 }
 
 extension ExecutionRecord: CustomDebugStringConvertible
-where Output.OutputType: CustomDebugStringConvertible, Error.OutputType: CustomDebugStringConvertible {
+where Output: CustomDebugStringConvertible, Error: CustomDebugStringConvertible {
     /// A debug-oriented textual representation of the collected result.
     public var debugDescription: String {
         return """

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -28,30 +28,26 @@ import SystemPackage
 internal import Dispatch
 
 /// A concrete input type for subprocesses that reads input from data.
-public struct DataInput: InputProtocol {
+internal struct DataInput: Sendable {
     private let data: Data
 
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
+    func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         _ = try await writer.write(self.data)
     }
 
-    internal init(data: Data) {
+    init(data: Data) {
         self.data = data
     }
 }
 
 /// A concrete input type for subprocesses that accepts input from
 /// a specified sequence of data.
-public struct DataSequenceInput<
+internal struct DataSequenceInput<
     InputSequence: Sequence & Sendable
->: InputProtocol where InputSequence.Element == Data {
+>: Sendable where InputSequence.Element == Data {
     private let sequence: InputSequence
 
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
+    func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         var buffer = Data()
         for chunk in self.sequence {
             buffer.append(chunk)
@@ -59,25 +55,23 @@ public struct DataSequenceInput<
         _ = try await writer.write(buffer)
     }
 
-    internal init(underlying: InputSequence) {
+    init(underlying: InputSequence) {
         self.sequence = underlying
     }
 }
 
 /// A concrete `Input` type for subprocesses that reads input
 /// from a given async sequence of `Data`.
-public struct DataAsyncSequenceInput<
+internal struct DataAsyncSequenceInput<
     InputSequence: AsyncSequence & Sendable
->: InputProtocol where InputSequence.Element == Data {
+>: Sendable where InputSequence.Element == Data {
     private let sequence: InputSequence
 
     private func writeChunk(_ chunk: Data, with writer: StandardInputWriter) async throws(SubprocessError) {
         _ = try await writer.write(chunk)
     }
 
-    /// Asynchronously write the input to the subprocess using the
-    /// write file descriptor.
-    public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
+    func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         do {
             for try await chunk in self.sequence {
                 try await self.writeChunk(chunk, with: writer)
@@ -92,29 +86,41 @@ public struct DataAsyncSequenceInput<
         }
     }
 
-    internal init(underlying: InputSequence) {
+    init(underlying: InputSequence) {
         self.sequence = underlying
     }
 }
 
-extension InputProtocol {
+extension InputMethod {
     /// Create a Subprocess input from a `Data`
-    public static func data(_ data: Data) -> Self where Self == DataInput {
-        return DataInput(data: data)
+    public static func data(_ data: Data) -> InputMethod {
+        let inner = DataInput(data: data)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
     }
 
     /// Create a Subprocess input from a `Sequence` of `Data`.
     public static func sequence<InputSequence: Sequence & Sendable>(
         _ sequence: InputSequence
-    ) -> Self where Self == DataSequenceInput<InputSequence> {
-        return .init(underlying: sequence)
+    ) -> InputMethod where InputSequence.Element == Data {
+        let inner = DataSequenceInput(underlying: sequence)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
     }
 
     /// Create a Subprocess input from a `AsyncSequence` of `Data`.
     public static func sequence<InputSequence: AsyncSequence & Sendable>(
         _ asyncSequence: InputSequence
-    ) -> Self where Self == DataAsyncSequenceInput<InputSequence> {
-        return .init(underlying: asyncSequence)
+    ) -> InputMethod where InputSequence.Element == Data {
+        let inner = DataAsyncSequenceInput(underlying: asyncSequence)
+        return InputMethod(
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .input) },
+            write: { writer in try await inner.write(with: writer) }
+        )
     }
 }
 

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -21,35 +21,58 @@ import FoundationEssentials
 
 /// A concrete `Output` type for subprocesses that collects output
 /// from the subprocess as data.
-public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
+internal struct DataOutput: OutputProtocol {
     /// The output type for this output option
-    public typealias OutputType = Data
+    typealias OutputType = Data
     /// The maximum number of bytes to collect.
-    public let maxSize: Int
+    let maxSize: Int
 
     #if SubprocessSpan
     /// Create data from a raw span.
-    public func output(from span: RawSpan) throws(SubprocessError) -> Data {
+    func output(from span: RawSpan) throws(SubprocessError) -> Data {
         return Data(span)
     }
     #else
     /// Create a data from sequence of 8-bit unsigned integers.
-    public func output(from buffer: some Sequence<UInt8>) throws(SubprocessError) -> Data {
+    func output(from buffer: some Sequence<UInt8>) throws(SubprocessError) -> Data {
         return Data(buffer)
     }
     #endif
 
-    internal init(limit: Int) {
+    init(limit: Int) {
         self.maxSize = limit
     }
 }
 
-extension OutputProtocol where Self == DataOutput {
+extension OutputMethod where T == Data {
     /// Create a `Subprocess` output that collects output as `Data`
     /// with given buffer limit in bytes. Subprocess throws an error
     /// if the child process emits more bytes than the limit.
-    public static func data(limit: Int) -> Self {
-        return .init(limit: limit)
+    public static func data(limit: Int) -> OutputMethod<Data> {
+        let inner = DataOutput(limit: limit)
+        return OutputMethod<Data>(
+            maxSize: limit,
+            createPipe: { try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
+    }
+}
+
+extension ErrorOutputMethod where T == Data {
+    /// Create a `Subprocess` error output that collects error output as `Data`
+    /// with given buffer limit in bytes. Subprocess throws an error
+    /// if the child process emits more bytes than the limit.
+    public static func data(limit: Int) -> ErrorOutputMethod<Data> {
+        let inner = DataOutput(limit: limit)
+        return ErrorOutputMethod<Data>(
+            maxSize: limit,
+            createPipe: { _ in try CreatedPipe(closeWhenDone: true, purpose: .output) },
+            captureOutput: { diskIO in
+                try await inner.captureOutput(from: diskIO)
+            }
+        )
     }
 }
 

--- a/Tests/SubprocessTests/DarwinTests.swift
+++ b/Tests/SubprocessTests/DarwinTests.swift
@@ -94,6 +94,19 @@ struct SubprocessDarwinTests {
             for try await _ in standardOutput {}
         }
     }
+
+    @Test func testAPI() async throws {
+        do {
+            let result = try await run(.path("/bin/cat"), output: .string(limit: .max))
+        } catch let subprocessError as SubprocessError {
+            switch subprocessError {
+            case .spawnFailed:
+                print(subprocessError)
+            default:
+                break
+            }
+        }
+    }
 }
 
 extension FileDescriptor {

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -2624,14 +2624,14 @@ struct TestSetup {
 
 func _run<
     Input: InputProtocol,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ testSetup: TestSetup,
     platformOptions: PlatformOptions = PlatformOptions(),
     input: Input,
-    output: Output,
-    error: Error
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error>
 ) async throws -> ExecutionRecord<Output, Error> {
     return try await Subprocess.run(
         testSetup.executable,
@@ -2648,13 +2648,13 @@ func _run<
 #if SubprocessSpan
 func _run<
     InputElement: BitwiseCopyable,
-    Output: OutputProtocol,
-    Error: ErrorOutputProtocol
+    Output: Sendable,
+    Error: Sendable
 >(
     _ testSetup: TestSetup,
     input: borrowing Span<InputElement>,
-    output: Output,
-    error: Error
+    output: OutputMethod<Output>,
+    error: ErrorOutputMethod<Error>
 ) async throws -> ExecutionRecord<Output, Error> {
     return try await Subprocess.run(
         testSetup.executable,
@@ -2670,15 +2670,14 @@ func _run<
 
 func _run<
     Result,
-    Input: InputProtocol,
-    Error: ErrorOutputProtocol
+    Input: InputProtocol
 >(
     _ setup: TestSetup,
     input: Input,
-    error: Error,
+    error: ErrorOutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     return try await Subprocess.run(
         setup.executable,
         arguments: setup.arguments,
@@ -2692,13 +2691,12 @@ func _run<
 }
 
 func _run<
-    Result,
-    Error: ErrorOutputProtocol
+    Result
 >(
     _ setup: TestSetup,
-    error: Error,
+    error: ErrorOutputMethod<Void>,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Error.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     return try await Subprocess.run(
         setup.executable,
         arguments: setup.arguments,
@@ -2710,13 +2708,12 @@ func _run<
 }
 
 func _run<
-    Result,
-    Output: OutputProtocol
+    Result
 >(
     _ setup: TestSetup,
-    output: Output,
+    output: OutputMethod<Void>,
     body: ((Execution, StandardInputWriter, AsyncBufferSequence) async throws -> Result)
-) async throws -> ExecutionOutcome<Result> where Output.OutputType == Void {
+) async throws -> ExecutionOutcome<Result> {
     return try await Subprocess.run(
         setup.executable,
         arguments: setup.arguments,

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -2623,13 +2623,12 @@ struct TestSetup {
 }
 
 func _run<
-    Input: InputProtocol,
     Output: Sendable,
     Error: Sendable
 >(
     _ testSetup: TestSetup,
     platformOptions: PlatformOptions = PlatformOptions(),
-    input: Input,
+    input: InputMethod,
     output: OutputMethod<Output>,
     error: ErrorOutputMethod<Error>
 ) async throws -> ExecutionRecord<Output, Error> {
@@ -2669,11 +2668,10 @@ func _run<
 #endif
 
 func _run<
-    Result,
-    Input: InputProtocol
+    Result
 >(
     _ setup: TestSetup,
-    input: Input,
+    input: InputMethod,
     error: ErrorOutputMethod<Void>,
     preferredBufferSize: Int? = nil,
     body: ((Execution, AsyncBufferSequence) async throws -> Result)

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -489,10 +489,10 @@ extension SubprocessUnixTests {
     }
 }
 
-internal func assertNewSessionCreated<Output: OutputProtocol>(
+internal func assertNewSessionCreated<Error: Sendable>(
     with result: ExecutionRecord<
-        StringOutput<UTF8>,
-        Output
+        String?,
+        Error
     >
 ) throws {
     try assertNewSessionCreated(


### PR DESCRIPTION
Added `public struct OutputMethod<Output>` to replace `OutputProtocol`. This also includes the following changes

Remove all the `OutputProtocol` conforming types. Replace them with static vars and funcs of `OutputMethod`