### PR TITLE
Add a test for a custom OutputProtocol-conforming type

### DIFF
--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -62,7 +62,9 @@ public struct NoInput: InputProtocol {
 
     /// Writes the input to the subprocess asynchronously.
     public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
+        // Intentional no-op
+        // NoInput redirects stdin to /dev/null, so there is no
+        // data to write to the subprocess.
     }
 
     internal init() {}
@@ -93,7 +95,9 @@ public struct FileDescriptorInput: InputProtocol {
 
     /// Writes the input to the subprocess asynchronously.
     public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
+        // Intentional no-op
+        // FileDescriptorInput reads from a pre-existing file
+        // descriptor, so there is no data to write to the subprocess.
     }
 
     internal init(
@@ -148,7 +152,9 @@ internal struct CustomWriteInput: InputProtocol {
     /// Asynchronously write the input to the subprocess using the
     /// write file descriptor.
     public func write(with writer: StandardInputWriter) async throws {
-        fatalError("Unexpected call to \(#function)")
+        // Intentional no-op
+        // CustomWriteInput exposes the StandardInputWriter directly
+        // to the caller's closure, so writing is handled there instead.
     }
 
     internal init() {}

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -24,9 +24,6 @@ internal import Dispatch
 // MARK: - Output
 
 /// A type that serves as the output target for a subprocess.
-///
-/// Instead of creating custom implementations of ``OutputProtocol``, use the
-/// built-in implementations provided by the `Subprocess` library.
 public protocol OutputProtocol: Sendable, ~Copyable {
     associatedtype OutputType: Sendable
 

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -163,7 +163,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
 
     /// Creates an array from a ``RawSpan``.
     public func output(from span: RawSpan) throws -> [UInt8] {
-        span.withUnsafeBytes { Arra($0) }
+        span.withUnsafeBytes { Array($0) }
     }
 
     internal init(limit: Int) {

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -111,12 +111,10 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
 
     /// Creates a string from a raw span.
     public func output(from span: RawSpan) throws -> String? {
-        // FIXME: Span to String
-        var array: [UInt8] = []
-        for index in 0..<span.byteCount {
-            array.append(span.unsafeLoad(fromByteOffset: index, as: UInt8.self))
+        span.withUnsafeBytes { ptr in
+            let array = Array(ptr)
+            return String(decodingBytes: array, as: Encoding.self)
         }
-        return String(decodingBytes: array, as: Encoding.self)
     }
 
     internal init(limit: Int, encoding: Encoding.Type) {
@@ -165,7 +163,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
 
     /// Creates an array from a ``RawSpan``.
     public func output(from span: RawSpan) throws -> [UInt8] {
-        fatalError("Not implemented")
+        span.withUnsafeBytes { Arra($0) }
     }
 
     internal init(limit: Int) {
@@ -378,7 +376,8 @@ extension OutputProtocol where OutputType == Void {
 
     /// Converts the output from a raw span to the expected output type.
     public func output(from span: RawSpan) throws {
-        fatalError("Unexpected call to \(#function)")
+        // When OutputType is Void, there is no output to process,
+        // So this is effectively a no-op.
     }
 }
 

--- a/Tests/SubprocessTests/ProtocolConformanceTests.swift
+++ b/Tests/SubprocessTests/ProtocolConformanceTests.swift
@@ -25,19 +25,12 @@ struct ProtocolConformanceTests {
         struct JSONOutput<T: Decodable & Sendable>: OutputProtocol {
             typealias OutputType = T
 
-            #if SubprocessSpan
             func output(from span: RawSpan) throws -> T {
                 try span.withUnsafeBytes { buffer in
                     let data = Data(bytes: buffer.baseAddress!, count: buffer.count)
                     return try JSONDecoder().decode(T.self, from: data)
                 }
             }
-            #else
-            func output(from buffer: some Sequence<UInt8>) throws -> T {
-                let data = Data(Array(buffer))
-                return try JSONDecoder().decode(T.self, from: data)
-            }
-            #endif
         }
 
         struct Item: Codable, Sendable, Equatable {

--- a/Tests/SubprocessTests/ProtocolConformanceTests.swift
+++ b/Tests/SubprocessTests/ProtocolConformanceTests.swift
@@ -41,8 +41,8 @@ struct ProtocolConformanceTests {
 
         #if os(Windows)
         let result = try await Subprocess.run(
-            .name("cmd.exe"),
-            arguments: ["/c", "echo", json],
+            .name("powershell.exe"),
+            arguments: ["-Command", "Write-Output '\(json)'"],
             output: JSONOutput<Item>(),
             error: .discarded
         )

--- a/Tests/SubprocessTests/ProtocolConformanceTests.swift
+++ b/Tests/SubprocessTests/ProtocolConformanceTests.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Subprocess
+
+#if canImport(Darwin)
+import Foundation
+#else
+import FoundationEssentials
+#endif
+
+@Suite(.serialized)
+struct ProtocolConformanceTests {
+
+    @Test func customOutputJSON() async throws {
+        struct JSONOutput<T: Decodable & Sendable>: OutputProtocol {
+            typealias OutputType = T
+
+            #if SubprocessSpan
+            func output(from span: RawSpan) throws -> T {
+                try span.withUnsafeBytes { buffer in
+                    let data = Data(bytes: buffer.baseAddress!, count: buffer.count)
+                    return try JSONDecoder().decode(T.self, from: data)
+                }
+            }
+            #else
+            func output(from buffer: some Sequence<UInt8>) throws -> T {
+                let data = Data(Array(buffer))
+                return try JSONDecoder().decode(T.self, from: data)
+            }
+            #endif
+        }
+
+        struct Item: Codable, Sendable, Equatable {
+            let title: String
+        }
+
+        let json = #"{"title":"Hello from Subprocess"}"#
+
+        #if os(Windows)
+        let result = try await Subprocess.run(
+            .name("cmd.exe"),
+            arguments: ["/c", "echo", json],
+            output: JSONOutput<Item>(),
+            error: .discarded
+        )
+        #else
+        let result = try await Subprocess.run(
+            .name("echo"),
+            arguments: [json],
+            output: JSONOutput<Item>(),
+            error: .discarded
+        )
+        #endif
+
+        #expect(result.terminationStatus.isSuccess)
+        #expect(result.standardOutput == Item(title: "Hello from Subprocess"))
+        #expect(result.standardOutput.title == "Hello from Subprocess")
+    }
+
+}


### PR DESCRIPTION
- Implement unimplemented functions. Replace fatalError wtih comments explaining why the function is no-op
- Add a test for custom output type
- Remove the comment that discourages providing a custom Output type
