### PR TITLE
Update package name to swift-subprocess to match the rest of the ecosystem

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let packageSwiftSettings: [SwiftSetting] = [
 ]
 
 let package = Package(
-    name: "Subprocess",
+    name: "swift-subprocess",
     platforms: [.macOS(.v13), .iOS("99.0")],
     products: [
         .library(


### PR DESCRIPTION
Resolves: https://github.com/swiftlang/swift-subprocess/issues/184