### PR TITLE
Enable ExistentialAny, MemberImportVisibility, and InternalImportsByDefault

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,11 @@ dep.append(
 let defaultTraits: Set<String> = ["SubprocessFoundation"]
 
 let packageSwiftSettings: [SwiftSetting] = [
-    .define("SUBPROCESS_ASYNCIO_DISPATCH", .when(platforms: [.macOS, .custom("freebsd"), .openbsd]))
+    .define("SUBPROCESS_ASYNCIO_DISPATCH", .when(platforms: [.macOS, .custom("freebsd"), .openbsd])),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .swiftLanguageMode(.v6),
 ]
 
 let package = Package(
@@ -77,7 +81,8 @@ let package = Package(
             path: "Tests/TestResources",
             resources: [
                 .copy("Resources")
-            ]
+            ],
+            swiftSettings: packageSwiftSettings
         ),
 
         .target(

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
+public import SystemPackage
 #endif
 
 // MARK: - Collected Result

--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -17,6 +17,18 @@ import SystemPackage
 
 #if !os(Windows)
 internal import Dispatch
+
+#if SubprocessFoundation
+
+#if canImport(Darwin)
+// On Darwin always prefer system Foundation
+internal import Foundation
+#else
+// On other platforms prefer FoundationEssentials
+internal import FoundationEssentials
+#endif
+
+#endif
 #endif
 
 /// An asynchronous sequence of buffers that streams output from a subprocess.

--- a/Sources/Subprocess/Buffer.swift
+++ b/Sources/Subprocess/Buffer.swift
@@ -13,6 +13,18 @@
 
 #if canImport(Darwin) || canImport(Glibc) || canImport(Android) || canImport(Musl)
 @preconcurrency internal import Dispatch
+
+#if SubprocessFoundation
+
+#if canImport(Darwin)
+// On Darwin always prefer system Foundation
+internal import Foundation
+#else
+// On other platforms prefer FoundationEssentials
+internal import FoundationEssentials
+#endif
+
+#endif
 #endif
 
 extension AsyncBufferSequence {

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
+public import SystemPackage
 #endif
 
 #if canImport(Darwin)
@@ -24,7 +24,7 @@ import Glibc
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WinSDK)
-@preconcurrency import WinSDK
+@preconcurrency public import WinSDK
 #endif
 
 internal import Dispatch

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -18,13 +18,13 @@ import Glibc
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WinSDK)
-@preconcurrency import WinSDK
+@preconcurrency public import WinSDK
 #endif
 
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
+public import SystemPackage
 #endif
 
 /// An error thrown by a subprocess operation.

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
+public import SystemPackage
 #endif
 
 #if canImport(WinSDK)

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(System)
-import System
+public import System
 #else
-import SystemPackage
+public import SystemPackage
 #endif
 
 #if canImport(WinSDK)

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -11,7 +11,7 @@
 
 #if canImport(Darwin)
 
-import Darwin
+public import Darwin
 internal import Dispatch
 #if canImport(System)
 import System
@@ -25,10 +25,10 @@ import _SubprocessCShims
 
 #if canImport(Darwin)
 // On Darwin always prefer system Foundation
-import Foundation
+public import Foundation
 #else
 // On other platforms prefer FoundationEssentials
-import FoundationEssentials
+public import FoundationEssentials
 #endif
 
 #endif // SubprocessFoundation

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -22,11 +22,11 @@ import _SubprocessCShims
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Android)
-import Android
+public import Android
 #elseif canImport(Glibc)
-import Glibc
+public import Glibc
 #elseif canImport(Musl)
-import Musl
+public import Musl
 #endif
 
 @preconcurrency internal import Dispatch
@@ -407,6 +407,21 @@ internal typealias PlatformFileDescriptor = CInt
 // MARK: - Spawning
 
 #if !canImport(Darwin)
+
+#if canImport(Android)
+public typealias pid_t = Android.pid_t
+public typealias uid_t = Android.uid_t
+public typealias gid_t = Android.gid_t
+#elseif canImport(Glibc)
+public typealias pid_t = Glibc.pid_t
+public typealias uid_t = Glibc.uid_t
+public typealias gid_t = Glibc.gid_t
+#elseif canImport(Musl)
+public typealias pid_t = Musl.pid_t
+public typealias uid_t = Musl.uid_t
+public typealias gid_t = Musl.gid_t
+#endif
+
 extension Configuration {
 
     // @unchecked Sendable because we need to capture UnsafePointers

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -11,7 +11,7 @@
 
 #if canImport(WinSDK)
 
-@preconcurrency import WinSDK
+@preconcurrency public import WinSDK
 internal import Dispatch
 #if canImport(System)
 import System

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -13,10 +13,10 @@
 
 #if canImport(Darwin)
 // On Darwin always prefer system Foundation
-import Foundation
+public import Foundation
 #else
 // On other platforms prefer FoundationEssentials
-import FoundationEssentials
+public import FoundationEssentials
 #endif // canImport(Darwin)
 
 #if canImport(System)

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -13,10 +13,10 @@
 
 #if canImport(Darwin)
 // On Darwin always prefer system Foundation
-import Foundation
+public import Foundation
 #else
 // On other platforms prefer FoundationEssentials
-import FoundationEssentials
+public import FoundationEssentials
 #endif
 
 /// An output type that collects the subprocess's output as `Data`.

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -71,7 +71,7 @@ private struct BackgroundWorkItem {
 
     init<Result>(
         _ body: @Sendable @escaping () throws -> Result,
-        continuation: CheckedContinuation<Result, Error>
+        continuation: CheckedContinuation<Result, any Error>
     ) {
         self.work = {
             do {

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -3026,7 +3026,7 @@ extension FileDescriptor {
     /// If `body` throws an error
     /// or an error occurs while closing the file descriptor,
     /// this method rethrows that error.
-    public func closeAfter<R>(_ body: () async throws -> R) async throws -> R {
+    func closeAfter<R>(_ body: () async throws -> R) async throws -> R {
         // No underscore helper, since the closure's throw isn't necessarily typed.
         let result: R
         do {

--- a/Tests/SubprocessTests/LinterTests.swift
+++ b/Tests/SubprocessTests/LinterTests.swift
@@ -10,6 +10,12 @@
 //===----------------------------------------------------------------------===//
 
 import Testing
+import Foundation
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
 @testable import Subprocess
 
 private func enableLintingTest() -> Bool {

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -204,7 +204,7 @@ extension SubprocessProcessMonitoringTests {
         let processIdentifier = ProcessIdentifier(
             value: .max, processDescriptor: INVALID_HANDLE_VALUE, threadHandle: INVALID_HANDLE_VALUE
         )
-        #elseif os(Linux) || os(Android) || os(FreeBSD)
+        #elseif os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
         let underlying = Errno(rawValue: ECHILD)
         let processIdentifier = ProcessIdentifier(
             value: .max, processDescriptor: -1

--- a/Tests/SubprocessTests/TestSupport.swift
+++ b/Tests/SubprocessTests/TestSupport.swift
@@ -9,14 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(Darwin)
-// On Darwin always prefer system Foundation
 import Foundation
-#else
-// On other platforms prefer FoundationEssentials
-import FoundationEssentials
-#endif
-
 import Testing
 import Subprocess
 
@@ -94,7 +87,7 @@ internal func directory(_ lhs: String, isSameAs rhs: String) -> Bool {
 
 extension Trait where Self == ConditionTrait {
     /// This test requires bash to run (instead of sh)
-    public static var requiresBash: Self {
+    static var requiresBash: Self {
         enabled(
             if: (try? Executable.name("bash").resolveExecutablePath(in: .inherit)) != nil,
             "This test requires bash (install `bash` package on Linux/BSD)"

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -10,14 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin) || canImport(Glibc)
-
-#if canImport(Darwin)
-// On Darwin always prefer system Foundation
 import Foundation
-#else
-// On other platforms prefer FoundationEssentials
-import FoundationEssentials
-#endif
 
 #if canImport(Glibc)
 import Glibc

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -12,7 +12,7 @@
 #if canImport(WinSDK)
 
 @preconcurrency import WinSDK
-import FoundationEssentials
+import Foundation
 import Testing
 import Dispatch
 

--- a/Tests/TestResources/TestResources.swift
+++ b/Tests/TestResources/TestResources.swift
@@ -17,9 +17,9 @@
 import Foundation
 
 #if canImport(System)
-import System
+package import System
 #else
-import SystemPackage
+package import SystemPackage
 #endif
 
 package var prideAndPrejudice: FilePath {


### PR DESCRIPTION
Add upcoming Swift features to Package.swift and fix all resulting
compile errors: add missing Foundation imports for DispatchData
extensions, upgrade imports to public where types are exposed in
public API, and adjust test access levels accordingly.

As a desirable side effect, _SubprocessCShims is no longer exported
via the public API.