### PR TITLE
Target process group during teardown when configured

### DIFF
--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -31,9 +31,9 @@ import Musl
 public struct TeardownStep: Sendable, Hashable {
     internal enum Storage: Sendable, Hashable {
         #if !os(Windows)
-        case sendSignal(Signal, allowedDuration: Duration)
+        case sendSignal(Signal, toProcessGroup: Bool, allowedDuration: Duration)
         #endif
-        case gracefulShutDown(allowedDuration: Duration)
+        case gracefulShutDown(toProcessGroup: Bool, allowedDuration: Duration)
         case kill
     }
     var storage: Storage
@@ -43,13 +43,22 @@ public struct TeardownStep: Sendable, Hashable {
     /// before proceeding to the next step.
     ///
     /// The final step in the sequence always sends a `.kill` signal.
+    ///
+    /// - Important: When sending the signal to the process group, unless you
+    /// also set `createSession` to `true`, or `processGroupID` to a
+    /// non-inherited value, the targeted process group includes the parent
+    /// process. This is almost never what you want. Pair `toProcessGroup`
+    /// with `createSession` to isolate the subprocess and its descendants in
+    /// their own session.
     public static func send(
         signal: Signal,
+        toProcessGroup: Bool = false,
         allowedDurationToNextStep: Duration
     ) -> Self {
         return Self(
             storage: .sendSignal(
                 signal,
+                toProcessGroup: toProcessGroup,
                 allowedDuration: allowedDurationToNextStep
             )
         )
@@ -64,11 +73,22 @@ public struct TeardownStep: Sendable, Hashable {
     ///   1. Sends `WM_CLOSE` if the child process is a GUI process.
     ///   2. Sends `CTRL_C_EVENT` to the console.
     ///   3. Sends `CTRL_BREAK_EVENT` to the process group.
+    ///
+    /// - Important: On Unix, when sending the signal to the process group,
+    /// unless you also set `createSession` to `true`, or `processGroupID`
+    /// to a non-inherited value, the targeted process group includes the parent
+    /// process. This is almost never what you want. Pair `toProcessGroup`
+    /// with `createSession` to isolate the subprocess and its descendants in
+    /// their own session. On Windows, the `toProcessGroup` parameter has no
+    /// effect; `WM_CLOSE` and `CTRL_C_EVENT` have no process-group equivalent,
+    /// and `CTRL_BREAK_EVENT` is always sent to the process group.
     public static func gracefulShutDown(
+        toProcessGroup: Bool = false,
         allowedDurationToNextStep: Duration
     ) -> Self {
         return Self(
             storage: .gracefulShutDown(
+                toProcessGroup: toProcessGroup,
                 allowedDuration: allowedDurationToNextStep
             )
         )
@@ -95,6 +115,7 @@ internal enum TeardownStepCompletion {
 
 extension Execution {
     internal func gracefulShutDown(
+        toProcessGroup: Bool,
         allowedDurationToNextStep duration: Duration
     ) async {
         #if os(Windows)
@@ -129,7 +150,7 @@ extension Execution {
         // Send SIGTERM
         try? self.send(
             signal: .terminate,
-            toProcessGroup: false
+            toProcessGroup: toProcessGroup
         )
         #endif
     }
@@ -137,8 +158,22 @@ extension Execution {
     internal func runTeardownSequence(
         _ sequence: some Sequence<TeardownStep> & Sendable
     ) async {
-        // First insert the `.kill` step
-        let finalSequence = sequence + [TeardownStep(storage: .kill)]
+        // The implicit final `.kill` inherits `toProcessGroup` from the last
+        // explicit step in the sequence. This matches user intent: A sequence
+        // configured to target the process group should have its terminal kill
+        // also target the group, so descendants don't leak after teardown.
+        let steps = Array(sequence)
+        let killProcessGroup: Bool = {
+            guard let last = steps.last else { return false }
+            switch last.storage {
+            #if !os(Windows)
+            case .sendSignal(_, let toProcessGroup, _): return toProcessGroup
+            #endif
+            case .gracefulShutDown(let toProcessGroup, _): return toProcessGroup
+            case .kill: return false
+            }
+        }()
+        let finalSequence = steps + [TeardownStep(storage: .kill)]
         for step in finalSequence {
             let stepCompletion: TeardownStepCompletion
             guard self.isPotentiallyStillAlive() else {
@@ -147,7 +182,7 @@ extension Execution {
             }
 
             switch step.storage {
-            case .gracefulShutDown(let allowedDuration):
+            case .gracefulShutDown(let toProcessGroup, let allowedDuration):
                 stepCompletion = await withTaskGroup(of: TeardownStepCompletion.self) { group in
                     group.addTask {
                         do {
@@ -160,12 +195,13 @@ extension Execution {
                         }
                     }
                     await self.gracefulShutDown(
+                        toProcessGroup: toProcessGroup,
                         allowedDurationToNextStep: allowedDuration
                     )
                     return await group.next()!
                 }
             #if !os(Windows)
-            case .sendSignal(let signal, let allowedDuration):
+            case .sendSignal(let signal, let toProcessGroup, let allowedDuration):
                 stepCompletion = await withTaskGroup(of: TeardownStepCompletion.self) { group in
                     group.addTask {
                         do {
@@ -177,7 +213,7 @@ extension Execution {
                             return .processHasExited
                         }
                     }
-                    try? self.send(signal: signal, toProcessGroup: false)
+                    try? self.send(signal: signal, toProcessGroup: toProcessGroup)
                     return await group.next()!
                 }
             #endif // !os(Windows)
@@ -187,7 +223,7 @@ extension Execution {
                     withExitCode: 0
                 )
                 #else
-                try? self.send(signal: .kill, toProcessGroup: false)
+                try? self.send(signal: .kill, toProcessGroup: killProcessGroup)
                 #endif
                 stepCompletion = .killedTheProcess
             }

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -389,6 +389,82 @@ extension SubprocessUnixTests {
         }
     }
 
+    @Test(.requiresBash)
+    func testTeardownSignalsProcessGroup() async throws {
+        do {
+            try await withThrowingTaskGroup { group in
+                let (readyStream, readyContinuation) = AsyncStream.makeStream(of: Void.self)
+
+                group.addTask {
+                    var platformOptions = PlatformOptions()
+                    // Creating a new session puts the shell (and its descendants,
+                    // absent further setsid calls) in their own process group, so
+                    // the teardown signal reaches everything spawned from the shell.
+                    platformOptions.createSession = true
+                    platformOptions.teardownSequence = [
+                        .send(signal: .terminate, toProcessGroup: true, allowedDurationToNextStep: .milliseconds(200))
+                    ]
+                    let result = try await Subprocess.run(
+                        .name("bash"),
+                        arguments: [
+                            "-c",
+                            """
+                            set -e
+                            # Spawn a grandchild that would otherwise outlive the shell.
+                            # Deliberately install NO trap: we want to verify that the
+                            # teardown signal reaches the grandchild directly via the
+                            # process group, not that bash cooperatively cleans up.
+                            /usr/bin/yes "Runaway process from \(#function), please file a SwiftSubprocess bug." > /dev/null &
+                            child_pid=$!
+                            echo "$child_pid"
+                            wait $child_pid
+                            """,
+                        ],
+                        platformOptions: platformOptions,
+                        error: .fileDescriptor(.standardError, closeAfterSpawningProcess: false),
+                        preferredBufferSize: 1
+                    ) { _, standardOutput in
+                        var grandChildPid: pid_t?
+                        for try await line in standardOutput.strings() {
+                            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if let pid = pid_t(trimmed) {
+                                grandChildPid = pid
+                                readyContinuation.finish()
+                            }
+                        }
+                        return grandChildPid
+                    }
+                    #expect(result.terminationStatus == .signaled(SIGTERM))
+                    let grandChildPid = try #require(result.value)
+                    // Grandchild should have been signalled via the process group.
+                    // Allow a few iterations for signal propagation and reaping.
+                    for _ in 0..<10 {
+                        if kill(grandChildPid, 0) != 0 { break }
+                        try await Task.sleep(for: .milliseconds(100))
+                    }
+                    let finalRC = kill(grandChildPid, 0)
+                    let capturedError = errno
+                    #expect(finalRC != 0)
+                    #expect(capturedError == ESRCH)
+                }
+                group.addTask {
+                    for await _ in readyStream {}
+                }
+                // Wait for the ready signal
+                _ = try await group.next()
+                // Cancel child process to trigger teardown
+                group.cancelAll()
+                try await group.waitForAll()
+            }
+        } catch {
+            if error is CancellationError {
+                // We intentionally cancelled the task
+                return
+            }
+            throw error
+        }
+    }
+
     @Test func testSubprocessDoesNotInheritVeryHighFileDescriptors() async throws {
         var openedFileDescriptors: [CInt] = []
         // Open /dev/null to use as source for duplication


### PR DESCRIPTION
Post-merge updates:

- Teardown configuration is no longer controlled through `PlatformOptions`, but rather through `TeardownStep.send()` and `TeardownStep.gracefulShutDown()`, which both gain a new `toProcessGroup: Bool` parameter (default `false`).
-  When `toProcessGroup` is `true`, that step's signal targets the subprocess's entire process group instead of only the subprocess itself, so backgrounded grandchildren aren't orphaned.
-  The implicit final SIGKILL inherits toProcessGroup from the last step in the sequence.
Because the subprocess inherits the parent's process group by default, pair toProcessGroup with createSession (or a non-inherited processGroupID) so the group-targeted signals don't also reach the parent process.

The original PR description is below. Please see the review comments for more information regarding the design changes.

---

Add `sendTeardownSignalsToProcessGroup` to Unix `PlatformOptions`, allowing signals emitted during teardown (including the final `.kill`) to target the subprocess's entire process group, rather than only the subprocess itself.

## Motivation

`Execution.send(signal:toProcessGroup:)` exposes the ability to signal either a single process or its entire process group. This flexibility matters when a subprocess spawns descendants of its own. Signaling only the leader leaves backgrounded grandchildren orphaned and still running.

`TeardownStep` offers no equivalent control. Every signal path inside `runTeardownSequence()` hard-codes `toProcessGroup: false`. A user who configures `teardownSequence` expecting robust termination of a subprocess tree gets group-unaware signaling with no way to opt in.

The workaround is to abandon `teardownSequence` entirely and reimplement the timeout/grace-period escalation pattern manually, which defeats the point of the abstraction.

This was reported as #67 in June 2025 and assigned to the Post-1.0 milestone.

## Design

`sendTeardownSignalsToProcessGroup` is a Boolean on Unix `PlatformOptions`. Windows isn't affected, since its final teardown step is `TerminateProcess` with no group concept.

I considered an alternative of adding `toProcessGroup: Bool` as a parameter on `TeardownStep.send()` and `gracefulShutDown()`, but decided against it for two reasons. First, `runTeardownSequence()` always appends an implicit final `.kill` step that has no user-visible construction site to which to attach a per-step flag, so the setting would have to either default to a hard-coded value or be specified on the teardown call itself. Second, scoping the option at `PlatformOptions` parallels the existing `teardownSequence` property. I could revise the PR if the per-step approach is preferred.

## Testing

Added `testTeardownSignalsProcessGroup()` in `UnixTests`, paired with the existing `testRunawayProcess()`.

No other tests needed changes, and all pass when run locally.