### PR TITLE
Fix Windows test failures: use Write-Output and bypass execution policy

### DIFF
--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -97,7 +97,7 @@ extension SubprocessWindowsTests {
         let sameConsoleResult = try await Subprocess.run(
             .name("powershell.exe"),
             arguments: [
-                "-File", windowsTester.string,
+                "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                 "-mode", "get-console-window",
             ],
             output: .string(limit: .max)
@@ -116,7 +116,7 @@ extension SubprocessWindowsTests {
         let differentConsoleResult = try await Subprocess.run(
             .name("powershell.exe"),
             arguments: [
-                "-File", windowsTester.string,
+                "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
@@ -138,7 +138,7 @@ extension SubprocessWindowsTests {
         let detachConsoleResult = try await Subprocess.run(
             .name("powershell.exe"),
             arguments: [
-                "-File", windowsTester.string,
+                "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
@@ -162,7 +162,7 @@ extension SubprocessWindowsTests {
         let newConsoleResult = try await Subprocess.run(
             .name("powershell.exe"),
             arguments: [
-                "-File", windowsTester.string,
+                "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
@@ -241,7 +241,7 @@ extension SubprocessWindowsTests {
             var checkResult = try await Subprocess.run(
                 .name("powershell.exe"),
                 arguments: [
-                    "-File", windowsTester.string,
+                    "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                     "-mode", "is-process-suspended",
                     "-processID", "\(subprocess.processIdentifier.value)",
                 ],
@@ -258,7 +258,7 @@ extension SubprocessWindowsTests {
             checkResult = try await Subprocess.run(
                 .name("powershell.exe"),
                 arguments: [
-                    "-File", windowsTester.string,
+                    "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                     "-mode", "is-process-suspended",
                     "-processID", "\(subprocess.processIdentifier.value)",
                 ],

--- a/Tests/TestResources/Resources/windows-tester.ps1
+++ b/Tests/TestResources/Resources/windows-tester.ps1
@@ -25,7 +25,7 @@ Add-Type @"
 
 function GetConsoleWindow {
     $consoleHandle = [NativeMethods]::GetConsoleWindow()
-    Write-Host $consoleHandle
+    Write-Output $consoleHandle
 }
 
 function IsProcessSuspended {
@@ -34,17 +34,17 @@ function IsProcessSuspended {
         $threads = $process.Threads
         $suspendedThreadCount = ($threads | Where-Object { $_.WaitReason -eq 'Suspended' }).Count
         if ($threads.Count -eq $suspendedThreadCount) {
-            Write-Host "true"
+            Write-Output "true"
         } else {
-            Write-Host "false"
+            Write-Output "false"
         }
     } else {
-        Write-Host "Process not found."
+        Write-Output "Process not found."
     }
 }
 
 switch ($mode) {
     'get-console-window' { GetConsoleWindow }
     'is-process-suspended' { IsProcessSuspended -processID $processID }
-    default { Write-Host "Invalid mode specified: [$mode]" }
+    default { Write-Output "Invalid mode specified: [$mode]" }
 }


### PR DESCRIPTION
The PowerShell test helper (windows-tester.ps1) used Write-Host which writes directly to the console, bypassing stdout pipe redirection. Tests that capture stdout via pipes received empty output, causing spurious failures when a console was present.

- Replace Write-Host with Write-Output in windows-tester.ps1 so output goes to stdout (stream 1) and is captured by the pipe
- Add -ExecutionPolicy Bypass to all powershell.exe invocations to prevent script execution policy from blocking test runs