### PR TITLE
Support Windows `toProcessGroup` teardown

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -65,6 +65,17 @@ extension Configuration {
         let errorReadFileDescriptor: IODescriptor? = errorPipe.readFileDescriptor()
         let errorWriteFileDescriptor: IODescriptor? = errorPipe.writeFileDescriptor()
 
+        // Create the Job Object up front. It persists across all candidate path
+        // attempts, and is owned by this function until ownership transfers to
+        // the `ProcessIdentifier` on the success path.
+        let jobHandle = try Self.createJobObject()
+        var jobHandleOwned = true
+        defer {
+            if jobHandleOwned {
+                _ = CloseHandle(jobHandle)
+            }
+        }
+
         // CreateProcessW supports using `lpApplicationName` as well as `lpCommandLine` to
         // specify executable path. However, only `lpCommandLine` supports PATH looking up,
         // whereas `lpApplicationName` does not. In general we should rely on `lpCommandLine`'s
@@ -114,52 +125,77 @@ extension Configuration {
 
             var createProcessFlags = self.generateCreateProcessFlag()
 
-            let (created, processInfo, windowsError) = try await self.withStartupInfoEx(
-                inputRead: inputReadFileDescriptor,
-                inputWrite: inputWriteFileDescriptor,
-                outputRead: outputReadFileDescriptor,
-                outputWrite: outputWriteFileDescriptor,
-                errorRead: errorReadFileDescriptor,
-                errorWrite: errorWriteFileDescriptor
-            ) { startupInfo throws(SubprocessError) in
-                // Give calling process a chance to modify flag and startup info
-                if let configurator = self.platformOptions.preSpawnProcessConfigurator {
-                    try configurator(&createProcessFlags, &startupInfo.pointer(to: \.StartupInfo)!.pointee)
-                }
+            let (created, processInfo, windowsError, userManagesResume): (Bool, PROCESS_INFORMATION, DWORD, Bool)
+            do {
+                (created, processInfo, windowsError, userManagesResume) = try await self.withStartupInfoEx(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                ) { startupInfo throws(SubprocessError) in
+                    // Give calling process a chance to modify flag and startup info
+                    if let configurator = self.platformOptions.preSpawnProcessConfigurator {
+                        try configurator(&createProcessFlags, &startupInfo.pointer(to: \.StartupInfo)!.pointee)
+                    }
 
-                // Spawn!
-                let spawnContext = SpawnContext(
-                    startupInfo: startupInfo,
-                    createProcessFlags: createProcessFlags
-                )
-                return try await runOnBackgroundThread { () throws(SubprocessError) in
-                    return try applicationName.withOptionalNTPathRepresentation { applicationNameW throws(SubprocessError) in
-                        try commandAndArgs._withCString(
-                            encodedAs: UTF16.self
-                        ) { commandAndArgsW throws(SubprocessError) in
-                            try environment._withCString(
+                    // If the configurator set `CREATE_SUSPENDED`, the user has
+                    // explicitly opted into managing the child's initial
+                    // resume themselves. Otherwise, Subprocess resumes the
+                    // child after assigning it to the Job Object.
+                    let userManagesResume = (createProcessFlags & DWORD(CREATE_SUSPENDED)) != 0
+
+                    // Subprocess assigns every spawned child to a Job Object
+                    // before any user code runs in the child. `CREATE_SUSPENDED`
+                    // makes the assignment atomic, so it is always set
+                    // regardless of what the configurator did.
+                    createProcessFlags |= DWORD(CREATE_SUSPENDED)
+
+                    // Spawn!
+                    let spawnContext = SpawnContext(
+                        startupInfo: startupInfo,
+                        createProcessFlags: createProcessFlags
+                    )
+                    return try await runOnBackgroundThread { () throws(SubprocessError) in
+                        return try applicationName.withOptionalNTPathRepresentation { applicationNameW throws(SubprocessError) in
+                            try commandAndArgs._withCString(
                                 encodedAs: UTF16.self
-                            ) { environmentW throws(SubprocessError) in
-                                try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW throws(SubprocessError) in
-                                    var processInfo = PROCESS_INFORMATION()
-                                    let result = CreateProcessW(
-                                        applicationNameW,
-                                        UnsafeMutablePointer<WCHAR>(mutating: commandAndArgsW),
-                                        nil, // lpProcessAttributes
-                                        nil, // lpThreadAttributes
-                                        true, // bInheritHandles
-                                        spawnContext.createProcessFlags,
-                                        UnsafeMutableRawPointer(mutating: environmentW),
-                                        intendedWorkingDirW,
-                                        spawnContext.startupInfo.pointer(to: \.StartupInfo)!,
-                                        &processInfo
-                                    )
-                                    return (result, processInfo, GetLastError())
+                            ) { commandAndArgsW throws(SubprocessError) in
+                                try environment._withCString(
+                                    encodedAs: UTF16.self
+                                ) { environmentW throws(SubprocessError) in
+                                    try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW throws(SubprocessError) in
+                                        var processInfo = PROCESS_INFORMATION()
+                                        let result = CreateProcessW(
+                                            applicationNameW,
+                                            UnsafeMutablePointer<WCHAR>(mutating: commandAndArgsW),
+                                            nil, // lpProcessAttributes
+                                            nil, // lpThreadAttributes
+                                            true, // bInheritHandles
+                                            spawnContext.createProcessFlags,
+                                            UnsafeMutableRawPointer(mutating: environmentW),
+                                            intendedWorkingDirW,
+                                            spawnContext.startupInfo.pointer(to: \.StartupInfo)!,
+                                            &processInfo
+                                        )
+                                        return (result, processInfo, GetLastError(), userManagesResume)
+                                    }
                                 }
                             }
                         }
                     }
                 }
+            } catch {
+                try self.safelyCloseMultiple(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                )
+                throw error
             }
 
             guard created else {
@@ -191,10 +227,32 @@ extension Configuration {
                 )
             }
 
+            do {
+                try Self.assignChildToJobObjectAndResume(
+                    jobHandle: jobHandle,
+                    processInfo: processInfo,
+                    resumeThread: !userManagesResume
+                )
+            } catch {
+                try self.safelyCloseMultiple(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                )
+                throw error
+            }
+
+            // Transfer ownership of the job handle to the `ProcessIdentifier`.
+            jobHandleOwned = false
+
             let pid = ProcessIdentifier(
                 value: processInfo.dwProcessId,
                 processDescriptor: processInfo.hProcess,
-                threadHandle: processInfo.hThread
+                threadHandle: processInfo.hThread,
+                jobHandle: jobHandle
             )
 
             do {
@@ -259,6 +317,17 @@ extension Configuration {
         let errorReadFileDescriptor: IODescriptor? = _errorPipe.readFileDescriptor()
         let errorWriteFileDescriptor: IODescriptor? = _errorPipe.writeFileDescriptor()
 
+        // Create the Job Object up front. It persists across all candidate path
+        // attempts, and is owned by this function until ownership transfers to
+        // the `ProcessIdentifier` on the success path.
+        let jobHandle = try Self.createJobObject()
+        var jobHandleOwned = true
+        defer {
+            if jobHandleOwned {
+                _ = CloseHandle(jobHandle)
+            }
+        }
+
         // CreateProcessW supports using `lpApplicationName` as well as `lpCommandLine` to
         // specify executable path. However, only `lpCommandLine` supports PATH looking up,
         // whereas `lpApplicationName` does not. In general we should rely on `lpCommandLine`'s
@@ -309,57 +378,72 @@ extension Configuration {
 
             var createProcessFlags = self.generateCreateProcessFlag()
 
-            let (created, processInfo, windowsError) = try await self.withStartupInfoEx(
-                inputRead: inputReadFileDescriptor,
-                inputWrite: inputWriteFileDescriptor,
-                outputRead: outputReadFileDescriptor,
-                outputWrite: outputWriteFileDescriptor,
-                errorRead: errorReadFileDescriptor,
-                errorWrite: errorWriteFileDescriptor
-            ) { startupInfo throws(SubprocessError) in
-                // Give calling process a chance to modify flag and startup info
-                if let configurator = self.platformOptions.preSpawnProcessConfigurator {
-                    try configurator(&createProcessFlags, &startupInfo.pointer(to: \.StartupInfo)!.pointee)
-                }
+            let (created, processInfo, windowsError, userManagesResume): (Bool, PROCESS_INFORMATION, DWORD, Bool)
+            do {
+                (created, processInfo, windowsError, userManagesResume) = try await self.withStartupInfoEx(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                ) { startupInfo throws(SubprocessError) in
+                    // Give calling process a chance to modify flag and startup info
+                    if let configurator = self.platformOptions.preSpawnProcessConfigurator {
+                        try configurator(&createProcessFlags, &startupInfo.pointer(to: \.StartupInfo)!.pointee)
+                    }
 
-                let spawnContext = SpawnContext(
-                    startupInfo: startupInfo,
-                    createProcessFlags: createProcessFlags
-                )
-                // Spawn (featuring pyramid!)
-                return try await runOnBackgroundThread { () throws(SubprocessError) in
-                    return try userCredentials.username._withCString(
-                        encodedAs: UTF16.self
-                    ) { usernameW throws(SubprocessError) in
-                        try userCredentials.password._withCString(
+                    // If the configurator set `CREATE_SUSPENDED`, the user has
+                    // explicitly opted into managing the child's initial
+                    // resume themselves. Otherwise, Subprocess resumes the
+                    // child after assigning it to the Job Object.
+                    let userManagesResume = (createProcessFlags & DWORD(CREATE_SUSPENDED)) != 0
+
+                    // Subprocess assigns every spawned child to a Job Object
+                    // before any user code runs in the child. `CREATE_SUSPENDED`
+                    // makes the assignment atomic, so it is always set
+                    // regardless of what the configurator did.
+                    createProcessFlags |= DWORD(CREATE_SUSPENDED)
+
+                    let spawnContext = SpawnContext(
+                        startupInfo: startupInfo,
+                        createProcessFlags: createProcessFlags
+                    )
+                    // Spawn (featuring pyramid!)
+                    return try await runOnBackgroundThread { () throws(SubprocessError) in
+                        return try userCredentials.username._withCString(
                             encodedAs: UTF16.self
-                        ) { passwordW throws(SubprocessError) in
-                            try userCredentials.domain.withOptionalCString(
+                        ) { usernameW throws(SubprocessError) in
+                            try userCredentials.password._withCString(
                                 encodedAs: UTF16.self
-                            ) { domainW throws(SubprocessError) in
-                                try applicationName.withOptionalNTPathRepresentation { applicationNameW throws(SubprocessError) in
-                                    try commandAndArgs._withCString(
-                                        encodedAs: UTF16.self
-                                    ) { commandAndArgsW throws(SubprocessError) in
-                                        try environment._withCString(
+                            ) { passwordW throws(SubprocessError) in
+                                try userCredentials.domain.withOptionalCString(
+                                    encodedAs: UTF16.self
+                                ) { domainW throws(SubprocessError) in
+                                    try applicationName.withOptionalNTPathRepresentation { applicationNameW throws(SubprocessError) in
+                                        try commandAndArgs._withCString(
                                             encodedAs: UTF16.self
-                                        ) { environmentW throws(SubprocessError) in
-                                            try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW throws(SubprocessError) in
-                                                var processInfo = PROCESS_INFORMATION()
-                                                let created = CreateProcessWithLogonW(
-                                                    usernameW,
-                                                    domainW,
-                                                    passwordW,
-                                                    DWORD(LOGON_WITH_PROFILE),
-                                                    applicationNameW,
-                                                    UnsafeMutablePointer<WCHAR>(mutating: commandAndArgsW),
-                                                    spawnContext.createProcessFlags,
-                                                    UnsafeMutableRawPointer(mutating: environmentW),
-                                                    intendedWorkingDirW,
-                                                    spawnContext.startupInfo.pointer(to: \.StartupInfo)!,
-                                                    &processInfo
-                                                )
-                                                return (created, processInfo, GetLastError())
+                                        ) { commandAndArgsW throws(SubprocessError) in
+                                            try environment._withCString(
+                                                encodedAs: UTF16.self
+                                            ) { environmentW throws(SubprocessError) in
+                                                try intendedWorkingDir.withOptionalNTPathRepresentation { intendedWorkingDirW throws(SubprocessError) in
+                                                    var processInfo = PROCESS_INFORMATION()
+                                                    let created = CreateProcessWithLogonW(
+                                                        usernameW,
+                                                        domainW,
+                                                        passwordW,
+                                                        DWORD(LOGON_WITH_PROFILE),
+                                                        applicationNameW,
+                                                        UnsafeMutablePointer<WCHAR>(mutating: commandAndArgsW),
+                                                        spawnContext.createProcessFlags,
+                                                        UnsafeMutableRawPointer(mutating: environmentW),
+                                                        intendedWorkingDirW,
+                                                        spawnContext.startupInfo.pointer(to: \.StartupInfo)!,
+                                                        &processInfo
+                                                    )
+                                                    return (created, processInfo, GetLastError(), userManagesResume)
+                                                }
                                             }
                                         }
                                     }
@@ -368,6 +452,16 @@ extension Configuration {
                         }
                     }
                 }
+            } catch {
+                try self.safelyCloseMultiple(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                )
+                throw error
             }
 
             guard created else {
@@ -398,10 +492,32 @@ extension Configuration {
                 )
             }
 
+            do {
+                try Self.assignChildToJobObjectAndResume(
+                    jobHandle: jobHandle,
+                    processInfo: processInfo,
+                    resumeThread: !userManagesResume
+                )
+            } catch {
+                try self.safelyCloseMultiple(
+                    inputRead: inputReadFileDescriptor,
+                    inputWrite: inputWriteFileDescriptor,
+                    outputRead: outputReadFileDescriptor,
+                    outputWrite: outputWriteFileDescriptor,
+                    errorRead: errorReadFileDescriptor,
+                    errorWrite: errorWriteFileDescriptor
+                )
+                throw error
+            }
+
+            // Transfer ownership of the job handle to the `ProcessIdentifier`.
+            jobHandleOwned = false
+
             let pid = ProcessIdentifier(
                 value: processInfo.dwProcessId,
                 processDescriptor: processInfo.hProcess,
-                threadHandle: processInfo.hThread
+                threadHandle: processInfo.hThread,
+                jobHandle: jobHandle
             )
 
             do {
@@ -562,6 +678,24 @@ public struct PlatformOptions: Sendable {
     /// modification of the `dwCreationFlags` creation flag
     /// and startup info `STARTUPINFOW` before
     /// they are sent to `CreateProcessW()`.
+    ///
+    /// - Important: Subprocess assigns every spawned child to
+    /// an internal Job Object before any user code runs in the child,
+    /// so teardown sequences targeting the process group can terminate
+    /// the child and all of its descendants together. To make this
+    /// assignment atomic, Subprocess always spawns children with
+    /// `CREATE_SUSPENDED` set in `dwCreationFlags`, regardless of the
+    /// value the configurator leaves in `dwCreationFlags`. By default,
+    /// Subprocess resumes the child after the assignment completes.
+    /// If the configurator sets `CREATE_SUSPENDED` in `dwCreationFlags`,
+    /// Subprocess treats this as a signal that user code will resume
+    /// the child explicitly, and therefore skips the internal `ResumeThread`
+    /// call. In that case the caller is responsible for calling
+    /// `ResumeThread` on the thread handle exposed through
+    /// `Execution.processIdentifier.threadHandle`. Otherwise, the child
+    /// will remain suspended indefinitely. If user code separately
+    /// assigns the child to its own Job Object after spawn, that
+    /// user-supplied job is nested inside Subprocess's job.
     public var preSpawnProcessConfigurator:
         (
             @Sendable (
@@ -670,13 +804,31 @@ internal func reapProcess(
 
 extension Execution {
     /// Terminate the current subprocess with the given exit code
-    /// - Parameter exitCode: The exit code to use for the subprocess.
-    public func terminate(withExitCode exitCode: DWORD) throws(SubprocessError) {
-        guard TerminateProcess(self.processIdentifier.processDescriptor, exitCode) else {
-            throw SubprocessError.processControlFailed(
-                .terminate,
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
-            )
+    /// - Parameters:
+    ///   - exitCode: The exit code to use for the subprocess.
+    ///   - toProcessGroup: When `true`, terminates the subprocess and any
+    ///   descendants by terminating the Job Object that contains them. The
+    ///   exit code is propagated to every process in the job. When `false`
+    ///   (the default), terminates only the immediate child process, leaving
+    ///   descendants unaffected.
+    public func terminate(
+        withExitCode exitCode: DWORD,
+        toProcessGroup: Bool = false
+    ) throws(SubprocessError) {
+        if toProcessGroup {
+            guard TerminateJobObject(self.processIdentifier.jobHandle, exitCode) else {
+                throw SubprocessError.processControlFailed(
+                    .terminate,
+                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                )
+            }
+        } else {
+            guard TerminateProcess(self.processIdentifier.processDescriptor, exitCode) else {
+                throw SubprocessError.processControlFailed(
+                    .terminate,
+                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                )
+            }
         }
     }
 
@@ -971,11 +1123,19 @@ public struct ProcessIdentifier: Sendable, Hashable {
     public nonisolated(unsafe) let processDescriptor: HANDLE
     /// The main thread handle for this execution.
     public nonisolated(unsafe) let threadHandle: HANDLE
+    /// The Job Object handle that contains this process and any descendants.
+    internal nonisolated(unsafe) let jobHandle: HANDLE
 
-    internal init(value: DWORD, processDescriptor: HANDLE, threadHandle: HANDLE) {
+    internal init(
+        value: DWORD,
+        processDescriptor: HANDLE,
+        threadHandle: HANDLE,
+        jobHandle: HANDLE
+    ) {
         self.value = value
         self.processDescriptor = processDescriptor
         self.threadHandle = threadHandle
+        self.jobHandle = jobHandle
     }
 
     internal func close() {
@@ -984,6 +1144,9 @@ public struct ProcessIdentifier: Sendable, Hashable {
         }
         guard CloseHandle(self.processDescriptor) else {
             fatalError("Failed to close process HANDLE: \(SubprocessError.WindowsError(rawValue: GetLastError()))")
+        }
+        guard CloseHandle(self.jobHandle) else {
+            fatalError("Failed to close job HANDLE: \(SubprocessError.WindowsError(rawValue: GetLastError()))")
         }
     }
 }
@@ -1195,6 +1358,79 @@ extension Configuration {
             info.lpAttributeList = attributeList
         }
         return try await body(&info)
+    }
+
+    /// Creates a Job Object that will contain a spawned child process and
+    /// any descendants.
+    ///
+    /// - Important: The handle is created with default security attributes,
+    /// which makes it non-inheritable. Descendants must not receive a duplicate
+    /// of the handle, so the parent can retain exclusive control over the job's
+    /// lifetime.
+    private static func createJobObject() throws(SubprocessError) -> HANDLE {
+        guard let jobHandle = CreateJobObjectW(nil, nil),
+            jobHandle != INVALID_HANDLE_VALUE
+        else {
+            throw SubprocessError.spawnFailed(
+                withUnderlyingError: SubprocessError.WindowsError(rawValue: GetLastError()),
+                reason: "Failed to create Job Object"
+            )
+        }
+        return jobHandle
+    }
+
+    /// Assigns the child process to the Job Object and, if requested, resumes
+    /// the child process thread.
+    ///
+    /// When `resumeThread` is `false`, the caller is responsible for resuming
+    /// the child using `ResumeThread` on the thread handle exposed through
+    /// `Execution.processIdentifier.threadHandle`. The child remains
+    /// suspended until then.
+    private static func assignChildToJobObjectAndResume(
+        jobHandle: HANDLE,
+        processInfo: PROCESS_INFORMATION,
+        resumeThread: Bool
+    ) throws(SubprocessError) {
+        // `CreateProcessW` succeeded. The child is suspended. Assign it to
+        // the Job Object before resuming, so it cannot run any user code
+        // outside the job.
+        guard AssignProcessToJobObject(jobHandle, processInfo.hProcess) else {
+            let assignError = SubprocessError.WindowsError(rawValue: GetLastError())
+            _ = TerminateProcess(processInfo.hProcess, 1)
+            _ = CloseHandle(processInfo.hThread)
+            _ = CloseHandle(processInfo.hProcess)
+
+            // Detect the most common cause of assignment failure: the parent
+            // process itself is in a non-nestable Job Object.
+            var isParentInJob: WindowsBool = false
+            var reason: String = "Failed to assign child process to Job Object"
+            if IsProcessInJob(GetCurrentProcess(), nil, &isParentInJob),
+                isParentInJob.boolValue
+            {
+                reason += " (likely because the parent process is in a Job Object that does not allow nesting)"
+            }
+
+            throw SubprocessError.spawnFailed(
+                withUnderlyingError: assignError,
+                reason: reason
+            )
+        }
+
+        guard resumeThread else {
+            // The user opted into managing the resume themselves.
+            return
+        }
+
+        guard ResumeThread(processInfo.hThread) != DWORD(bitPattern: -1) else {
+            let resumeError = SubprocessError.WindowsError(rawValue: GetLastError())
+            _ = TerminateProcess(processInfo.hProcess, 1)
+            _ = CloseHandle(processInfo.hThread)
+            _ = CloseHandle(processInfo.hProcess)
+            throw SubprocessError.spawnFailed(
+                withUnderlyingError: resumeError,
+                reason: "Failed to resume child process thread after Job Object assignment"
+            )
+        }
     }
 
     private func generateWindowsCommandAndArguments(

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -220,7 +220,8 @@ extension Execution {
             case .kill:
                 #if os(Windows)
                 try? self.terminate(
-                    withExitCode: 0
+                    withExitCode: 0,
+                    toProcessGroup: killProcessGroup
                 )
                 #else
                 try? self.send(signal: .kill, toProcessGroup: killProcessGroup)

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -357,7 +357,8 @@ private var _currentPID: ProcessIdentifier {
     return ProcessIdentifier(
         value: GetCurrentProcessId(),
         processDescriptor: GetCurrentProcess(),
-        threadHandle: GetCurrentThread()
+        threadHandle: GetCurrentThread(),
+        jobHandle: INVALID_HANDLE_VALUE
     )
     #elseif os(Linux) || os(Android) || os(FreeBSD)
     return ProcessIdentifier(

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -207,7 +207,10 @@ extension SubprocessProcessMonitoringTests {
         #if os(Windows)
         let underlying = SubprocessError.WindowsError(rawValue: DWORD(ERROR_INVALID_PARAMETER))
         let processIdentifier = ProcessIdentifier(
-            value: .max, processDescriptor: INVALID_HANDLE_VALUE, threadHandle: INVALID_HANDLE_VALUE
+            value: .max,
+            processDescriptor: INVALID_HANDLE_VALUE,
+            threadHandle: INVALID_HANDLE_VALUE,
+            jobHandle: INVALID_HANDLE_VALUE
         )
         #elseif os(Linux) || os(Android) || os(FreeBSD) || os(OpenBSD)
         let underlying = Errno(rawValue: ECHILD)

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -14,6 +14,7 @@
 @preconcurrency import WinSDK
 import Foundation
 import Testing
+import Synchronization
 
 #if canImport(System)
 import System
@@ -278,7 +279,9 @@ extension SubprocessWindowsTests {
         #expect(stuckProcess.terminationStatus.isSuccess)
     }
 
-    /// Tests a use case for Windows platform handles by assigning the newly created process to a Job Object
+    /// Tests a use case for Windows platform handles by assigning the newly
+    /// created process to a user-supplied Job Object, nested inside
+    /// Subprocess's internal job.
     /// - see: https://devblogs.microsoft.com/oldnewthing/20131209-00/
     @Test func testPlatformHandles() async throws {
         let hJob = CreateJobObjectW(nil, nil)
@@ -287,25 +290,148 @@ extension SubprocessWindowsTests {
         info.BasicLimitInformation.LimitFlags = DWORD(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)
         #expect(SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &info, DWORD(MemoryLayout<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>.size)))
 
+        let result = try await Subprocess.run(
+            self.cmdExe,
+            arguments: ["/c", "echo"],
+            input: .none,
+            output: .discarded,
+            error: .discarded
+        ) { execution in
+            // Nest the child inside a user-supplied Job Object. Subprocess
+            // already assigned it to its internal job. This nests further.
+            guard AssignProcessToJobObject(hJob, execution.processIdentifier.processDescriptor) else {
+                throw SubprocessError.WindowsError(rawValue: GetLastError())
+            }
+        }
+        #expect(result.terminationStatus.isSuccess)
+    }
+}
+
+// MARK: - Job Object Termination Tests
+extension SubprocessWindowsTests {
+    @Test func testTerminateToProcessGroupKillsJobMembers() async throws {
+        _ = try await Subprocess.run(
+            self.cmdExe,
+            arguments: ["/c", "ping -n 60 127.0.0.1 > nul"],
+            input: .none,
+            output: .sequence,
+            error: .discarded
+        ) { execution in
+            let grandchildPid = try #require(
+                await Self.waitForChildPid(of: execution.processIdentifier.value, named: "ping.exe"),
+                "ping.exe did not appear as a child of cmd.exe"
+            )
+            let grandchildHandle = try #require(
+                OpenProcess(
+                    DWORD(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION),
+                    false,
+                    grandchildPid
+                ),
+                "Failed to open handle to grandchild process"
+            )
+            defer { _ = CloseHandle(grandchildHandle) }
+
+            #expect(Self.isProcessAlive(handle: grandchildHandle))
+
+            // Terminate the immediate child and any job members.
+            try execution.terminate(withExitCode: 0, toProcessGroup: true)
+
+            let exited = await Self.waitForProcessExit(handle: grandchildHandle)
+            #expect(exited, "Grandchild should have been terminated by TerminateJobObject")
+
+            for try await _ in execution.standardOutput {}
+        }
+    }
+
+    @Test func testTerminateWithoutProcessGroupLeavesJobMembers() async throws {
+        // The complement of `testTerminateToProcessGroupKillsJobMembers`.
+        // With `toProcessGroup: false`, `TerminateProcess` only affects the
+        // immediate child. Other job members, including grandchildren the
+        // child spawned, must survive and remain in the Job Object.
+        var grandchildHandleToCleanup: HANDLE?
+        defer {
+            if let handle = grandchildHandleToCleanup {
+                _ = TerminateProcess(handle, 0)
+                _ = CloseHandle(handle)
+            }
+        }
+
+        _ = try await Subprocess.run(
+            self.cmdExe,
+            arguments: ["/c", "ping -n 60 127.0.0.1 > nul"],
+            input: .none,
+            output: .sequence,
+            error: .discarded
+        ) { execution in
+            let grandchildPid = try #require(
+                await Self.waitForChildPid(of: execution.processIdentifier.value, named: "ping.exe"),
+                "ping.exe did not appear as a child of cmd.exe"
+            )
+            let grandchildHandle = try #require(
+                OpenProcess(
+                    DWORD(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE),
+                    false,
+                    grandchildPid
+                ),
+                "Failed to open handle to grandchild process"
+            )
+            grandchildHandleToCleanup = grandchildHandle
+
+            #expect(Self.isProcessAlive(handle: grandchildHandle))
+
+            // Terminate only the immediate child.
+            try execution.terminate(withExitCode: 0, toProcessGroup: false)
+
+            // Give Windows a moment, then verify the grandchild is still alive
+            // and still a member of a Job Object. Membership confirms that
+            // Subprocess's internal job survived the per-process termination
+            // and continues to track descendants.
+            try await Task.sleep(for: .milliseconds(250))
+            #expect(
+                Self.isProcessAlive(handle: grandchildHandle),
+                "Grandchild should remain alive after toProcessGroup: false termination"
+            )
+
+            var inJob: WindowsBool = false
+            #expect(
+                IsProcessInJob(grandchildHandle, nil, &inJob),
+                "IsProcessInJob failed"
+            )
+            #expect(
+                inJob.boolValue,
+                "Grandchild should still be a job member after toProcessGroup: false termination"
+            )
+
+            for try await _ in execution.standardOutput {}
+        }
+    }
+
+    @Test func testPreSpawnConfiguratorCanOptIntoManualResume() async throws {
+        // Setting `CREATE_SUSPENDED` from `preSpawnProcessConfigurator`
+        // signals that user code will resume the child explicitly.
+        // Subprocess itself must not call `ResumeThread` in that case.
+        //
+        // Verify this by calling `ResumeThread` from the body closure and
+        // check the previous suspend count it returns. `1` means the child
+        // was still suspended (correct), and `0` means Subprocess has already
+        // resumed it (incorrect).
         var platformOptions = PlatformOptions()
-        platformOptions.preSpawnProcessConfigurator = { (createProcessFlags, startupInfo) in
-            createProcessFlags |= DWORD(CREATE_SUSPENDED)
+        platformOptions.preSpawnProcessConfigurator = { creationFlags, _ in
+            creationFlags |= DWORD(CREATE_SUSPENDED)
         }
 
         let result = try await Subprocess.run(
             self.cmdExe,
-            arguments: ["/c", "echo"],
+            arguments: ["/c", "echo hello"],
             platformOptions: platformOptions,
             input: .none,
             output: .discarded,
             error: .discarded
         ) { execution in
-            guard AssignProcessToJobObject(hJob, execution.processIdentifier.processDescriptor) else {
-                throw SubprocessError.WindowsError(rawValue: GetLastError())
-            }
-            guard ResumeThread(execution.processIdentifier.threadHandle) != DWORD(bitPattern: -1) else {
-                throw SubprocessError.WindowsError(rawValue: GetLastError())
-            }
+            let previousSuspendCount = ResumeThread(execution.processIdentifier.threadHandle)
+            // Expect `1` since a greater suspend count means someone
+            // suspended the thread twice, and that should not happen.
+            #expect(previousSuspendCount == 1)
         }
         #expect(result.terminationStatus.isSuccess)
     }
@@ -409,6 +535,211 @@ extension SubprocessWindowsTests {
         // Okay the below is intentional because
         // `isAdmin` is a `WindowsBool` and we need `Bool`
         return isAdmin.boolValue
+    }
+
+    /// Finds the PID of a child of the given parent PID, optionally filtered
+    /// by executable name (case-insensitive), and returns the first match.
+    private static func findChildPid(
+        of parentPid: DWORD,
+        named name: String? = nil
+    ) throws -> DWORD? {
+        guard let snapshot = CreateToolhelp32Snapshot(DWORD(TH32CS_SNAPPROCESS), 0),
+            snapshot != INVALID_HANDLE_VALUE
+        else {
+            throw SubprocessError.WindowsError(rawValue: GetLastError())
+        }
+        defer { _ = CloseHandle(snapshot) }
+
+        var entry = PROCESSENTRY32W()
+        entry.dwSize = DWORD(MemoryLayout<PROCESSENTRY32W>.size)
+
+        guard Process32FirstW(snapshot, &entry) else {
+            return nil
+        }
+        repeat {
+            if entry.th32ParentProcessID == parentPid {
+                if let name = name {
+                    let exeName = withUnsafePointer(to: entry.szExeFile) {
+                        $0.withMemoryRebound(
+                            to: WCHAR.self,
+                            capacity: Int(MAX_PATH)
+                        ) { ptr in
+                            String(decodingCString: ptr, as: UTF16.self)
+                        }
+                    }
+                    if exeName.lowercased() == name.lowercased() {
+                        return entry.th32ProcessID
+                    }
+                } else {
+                    return entry.th32ProcessID
+                }
+            }
+        } while Process32NextW(snapshot, &entry)
+
+        return nil
+    }
+
+    /// Polls until a child of the given parent PID appears, or the timeout
+    /// elapses.
+    private static func waitForChildPid(
+        of parentPid: DWORD,
+        named name: String? = nil,
+        timeout: Duration = .seconds(5)
+    ) async throws -> DWORD? {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let pid = try findChildPid(of: parentPid, named: name) {
+                return pid
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return nil
+    }
+
+    /// Returns `true` if `WaitForSingleObject` on the handle reports the
+    /// process as still running.
+    private static func isProcessAlive(handle: HANDLE) -> Bool {
+        return WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    }
+
+    /// Asynchronously waits for the process referenced by the given handle
+    /// to exit, or for the given timeout to elapse. Returns `true` if the
+    /// process exited within the timeout.
+    private static func waitForProcessExit(
+        handle: HANDLE,
+        timeout: Duration = .seconds(5)
+    ) async -> Bool {
+        let handleBits = Int(bitPattern: handle)
+        return await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask {
+                let handle = HANDLE(bitPattern: handleBits)!
+                await waitForHandleSignal(handle: handle)
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return false
+            }
+            // First child task to finish wins. Cancel the other.
+            // `waitForHandleSignal` honors task cancellation and unwinds
+            // promptly so the group can return.
+            let first = await group.next()!
+            group.cancelAll()
+            return first
+        }
+    }
+
+    /// Asynchronously waits for the given handle to be signaled, using
+    /// `RegisterWaitForSingleObject`. Honors task cancellation by
+    /// unregistering the wait synchronously.
+    private static func waitForHandleSignal(handle: HANDLE) async {
+        // `Storage` holds Win32 pointer values whose provenance the region
+        // checker cannot verify, so it is `@unchecked Sendable`. All access
+        // is serialized through the `Mutex` that holds it.
+        struct Storage: @unchecked Sendable {
+            var waitHandle: HANDLE?
+            var contextRetained: UnsafeMutableRawPointer?
+        }
+        final class State: Sendable {
+            let storage = Mutex(Storage())
+            let continuation: AsyncStream<Void>.Continuation
+
+            init(continuation: AsyncStream<Void>.Continuation) {
+                self.continuation = continuation
+            }
+
+            /// Releases the retained `Unmanaged` context if it hasn't been
+            /// released yet, then finishes the stream. Idempotent.
+            func finishOnce() {
+                let context = self.storage.withLock { storage -> UnsafeMutableRawPointer? in
+                    let context = storage.contextRetained
+                    storage.contextRetained = nil
+                    return context
+                }
+                if let context {
+                    Unmanaged<AnyObject>.fromOpaque(context).release()
+                }
+                self.continuation.finish()
+            }
+        }
+
+        let (stream, streamContinuation) = AsyncStream.makeStream(of: Void.self)
+        let state = State(continuation: streamContinuation)
+
+        await withTaskCancellationHandler {
+            // Retain a reference to `state` for the C callback. The callback
+            // releases this retain after yielding.
+            let context = Unmanaged.passRetained(state).toOpaque()
+            state.storage.withLock { storage in
+                storage.contextRetained = context
+            }
+
+            let callback: WAITORTIMERCALLBACK = { context, _ in
+                let state = Unmanaged<State>.fromOpaque(context!)
+                    .takeRetainedValue()
+                // Clear `contextRetained` since we just consumed our own
+                // retain with `takeRetainedValue()`.
+                state.storage.withLock { storage in
+                    storage.contextRetained = nil
+                }
+                state.continuation.yield()
+                state.continuation.finish()
+            }
+
+            var waitHandle: HANDLE?
+            let flags = ULONG(WT_EXECUTEONLYONCE | WT_EXECUTELONGFUNCTION)
+            guard
+                RegisterWaitForSingleObject(
+                    &waitHandle,
+                    handle,
+                    callback,
+                    context,
+                    INFINITE,
+                    flags
+                )
+            else {
+                // Registration failed. Finish the stream immediately. The
+                // caller's timeout path handles the apparent non-exit.
+                state.finishOnce()
+                // Wait for the iteration below to observe the finish.
+                for await _ in stream {}
+                return
+            }
+
+            state.storage.withLock { storage in
+                storage.waitHandle = waitHandle
+            }
+
+            // Wait for either the callback to yield, or for cancellation
+            // to finish the stream. Either way, the iteration ends after
+            // observing the (single) yielded value or the finish.
+            for await _ in stream { break }
+
+            // Unregister the wait. `INVALID_HANDLE_VALUE` tells
+            // `UnregisterWaitEx` to wait synchronously for any in-flight
+            // callbacks.
+            let waitHandleToUnregister = state.storage.withLock { storage -> HANDLE? in
+                let handle = storage.waitHandle
+                storage.waitHandle = nil
+                return handle
+            }
+            if let waitHandleToUnregister {
+                _ = UnregisterWaitEx(waitHandleToUnregister, INVALID_HANDLE_VALUE)
+            }
+        } onCancel: {
+            // Cancellation path. Unregister the wait synchronously, then
+            // finish the stream so the awaiting `for await` returns.
+            let waitHandleToUnregister = state.storage.withLock { storage -> HANDLE? in
+                let handle = storage.waitHandle
+                storage.waitHandle = nil
+                return handle
+            }
+            if let waitHandleToUnregister {
+                _ = UnregisterWaitEx(waitHandleToUnregister, INVALID_HANDLE_VALUE)
+            }
+            state.finishOnce()
+        }
     }
 }
 


### PR DESCRIPTION
Post-merge updates:

- Every Windows child is now assigned to a Job Object at spawn, so Subprocess always passes `CREATE_SUSPENDED` to `CreateProcessW`. Subprocess always resumes the child once it's in the job, unless a `preSpawnProcessConfigurator` sets `CREATE_SUSPENDED` itself; that signals that the caller will resume the child, so Subprocess skips its own `ResumeThread` and leaves the thread suspended for the caller to resume via `Execution.processIdentifier.threadHandle`.

The original PR description is below. Please see the review comments for more information regarding the design changes.

---

This PR expands the Unix child process teardown implemented in #243 to Windows.

## Motivation

#243 added a `toProcessGroup: Bool` parameter to `send()` and `gracefulShutDown()` on `TeardownStep`, with the final `kill` inheriting `toProcessGroup` from the last user-supplied step. On Windows, the final `kill` step ignored that parameter and only terminated the immediate child, leaving descendants unaffected. This PR closes that gap.

## Design

Windows has no direct equivalent of Unix process groups, but [Job Objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) provide a similar grouping mechanism. A process assigned to a job, along with all of its descendants, can be terminated together using [`TerminateJobObject`](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-terminatejobobject).

Job Objects fit cleanly into the final `kill` step. Other teardown steps already propagate along different axes and don't benefit from Job Objects: `WM_CLOSE` is per-window, `CTRL_C_EVENT` is per-console, and `CTRL_BREAK_EVENT` targets the Windows process group that was set up at spawn.

To make `TerminateJobObject` available at teardown time, every Windows child process is assigned to a job object at spawn. The job is created in `spawnDirect()` and `spawnAsUser()` on `Configuration`, and lives for the duration of the `Execution`.

### Atomic assignment using `CREATE_SUSPENDED`

`Configuration.generateCreateProcessFlag()` now always sets `CREATE_SUSPENDED`.  After running `preSpawnProcessConfigurator`, both spawn paths verify that the flag is still set and throw `spawnFailed` if a user-supplied configurator removed it. `CREATE_SUSPENDED` makes the assignment atomic with respect to the child, ensuring that between `CreateProcessW` and `AssignProcessToJobObject`, no user code runs in the child and it cannot spawn descendants outside the job. Once the assignment succeeds, `ResumeThread` lets the child begin execution.

In practice, the suspension period is imperceptible, but this constitutes a small behavioral change. Users who explicitly clear `CREATE_SUSPENDED` will now receive an error.

A possible alternative is `PROC_THREAD_ATTRIBUTE_JOB_LIST`, which assigns the job at process creation time without the suspend-then-resume requirement. This requires `lpStartupInfo` to be `STARTUPINFOEX` and the `EXTENDED_STARTUPINFO_PRESENT` process creation flag to be present in `dwCreationFlags`.

[`CreateProcessW` documentation](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) explicitly supports both `STARTUPINFO` and `STARTUPINFOEX`, but [`CreateProcessWithLogonW` documentation](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createprocesswithlogonw) specifies support for only `STARTUPINFO`. Since `spawnAsUser()` calls `CreateProcessWithLogonW`, using `PROC_THREAD_ATTRIBUTE_JOB_LIST` would require two implementations of the same behavior. The suspend-and-resume pattern works uniformly for both paths.

### Handle inheritance

The Job Object handle is created with `nil` security attributes, which makes it non-inheritable. As [Raymond Chen notes](https://devblogs.microsoft.com/oldnewthing/20131209-00/?p=2433):

> We must therefore be careful not to allow this handle to be inherited, because that would create another handle that needs to be closed before the job is terminated.

The [`CreateJobObjectW` documentation](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-createjobobjectw) confirms this approach:

> If `lpJobAttributes` is `NULL`, the job object gets a default security descriptor and the handle cannot be inherited.

`Configuration.createJobObject()` is the single point of creation and enforces this behavior.

### Termination

`Execution.terminate(withExitCode:)` now also accepts `toProcessGroup: Bool`, defaulting to `false`. When `true`, it calls `TerminateJobObject` against the subprocess's Job Object, terminating the child and all its descendants. When `false`, it retains its existing per-process behavior using `TerminateProcess`. This mirrors the shape of the Unix `send(signal:toProcessGroup:)` API for cross-platform consistency.

The Windows branch of the `kill` case in `Execution.runTeardownSequence()` now passes the existing `killProcessGroup` value through to `terminate(withExitCode:toProcessGroup:)`.

`ProcessIdentifier` now also stores the Job Object handle alongside the process and thread handles, and closes it as part of `close()`.

### Nested job behavior

Subprocess assigns each spawned child to its own Job Object regardless of whether the parent process itself is in one. [The Nested Jobs documentation](https://learn.microsoft.com/en-us/windows/win32/procthread/nested-jobs) explains that on Windows 8+:

> If a process that is already in a job is added to another job, the jobs are nested by default if the system can form a valid job hierarchy and neither job sets UI limits.

If those conditions are not met, `AssignProcessToJobObject` fails and Subprocess throws a `spawnFailed` error identifying the parent's job as the likely cause. See the "Future directions" section for a planned opt-in fallback.

## Future directions

The following may be natural follow-up PRs, but are worth their own discussion. I could open subsequent PRs for any or all of these.

- `KILL_ON_JOB_CLOSE`: A flag that automatically terminates everything in a Job Object when the last handle to it closes. This would offer orphan protection if the parent crashes, but changes the current behavior of parent-exit not killing the child.
- `JOB_OBJECT_LIMIT_BREAKAWAY_OK`: A flag that enables descendants to escape the job. This changes the current behavior where every descendant of the spawned process stays in the job.
- User opt-in fallback for environments where job assignment fails (see "Nested job behavior" above): A follow-up PR could add an opt-in fallback that proceeds with descendant-tracking disabled, accepting that `toProcessGroup: true` and process-group teardown will be unavailable for that subprocess.

## Testing

The full test suite passes on `windows-latest` using GitHub Actions.