### PR TITLE
Executable.resolveExecutablePath should be async

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -290,9 +290,11 @@ public struct Executable: Sendable, Hashable {
         return .init(_config: .path(filePath))
     }
     /// Resolves the full executable path using the given environment.
-    public func resolveExecutablePath(in environment: Environment) throws(SubprocessError) -> FilePath {
-        let path = try self.resolveExecutablePath(withPathValue: environment.pathValue())
-        return FilePath(path)
+    public func resolveExecutablePath(in environment: Environment) async throws(SubprocessError) -> FilePath {
+        try await runOnBackgroundThread { () throws(SubprocessError) -> FilePath in
+            let path = try self.resolveExecutablePath(withPathValue: environment.pathValue())
+            return FilePath(path)
+        }
     }
 }
 

--- a/Tests/SubprocessTests/LinterTests.swift
+++ b/Tests/SubprocessTests/LinterTests.swift
@@ -18,14 +18,14 @@ import SystemPackage
 #endif
 @testable import Subprocess
 
-private func enableLintingTest() -> Bool {
+private func enableLintingTest() async -> Bool {
     guard CommandLine.arguments.first(where: { $0.contains("/.build/") }) != nil else {
         return false
     }
     #if os(macOS)
     // Use xcrun
     do {
-        _ = try Executable.path("/usr/bin/xcrun")
+        _ = try await Executable.path("/usr/bin/xcrun")
             .resolveExecutablePath(in: .inherit)
         return true
     } catch {
@@ -34,7 +34,7 @@ private func enableLintingTest() -> Bool {
     #else
     // Use swift-format directly
     do {
-        _ = try Executable.name("swift-format")
+        _ = try await Executable.name("swift-format")
             .resolveExecutablePath(in: .inherit)
         return true
     } catch {

--- a/Tests/SubprocessTests/TestSupport.swift
+++ b/Tests/SubprocessTests/TestSupport.swift
@@ -89,8 +89,10 @@ extension Trait where Self == ConditionTrait {
     /// This test requires bash to run (instead of sh)
     static var requiresBash: Self {
         enabled(
-            if: (try? Executable.name("bash").resolveExecutablePath(in: .inherit)) != nil,
-            "This test requires bash (install `bash` package on Linux/BSD)"
+            "This test requires bash (install `bash` package on Linux/BSD)",
+            {
+                (try? await Executable.name("bash").resolveExecutablePath(in: .inherit)) != nil
+            }
         )
     }
 }

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -120,8 +120,10 @@ extension SubprocessUnixTests {
             "This test requires root privileges"
         ),
         .enabled(
-            if: (try? Executable.name("ps").resolveExecutablePath(in: .inherit)) != nil,
-            "This test requires ps (install procps package on Debian or RedHat Linux distros)"
+            "This test requires ps (install procps package on Debian or RedHat Linux distros)",
+            {
+                (try? await Executable.name("ps").resolveExecutablePath(in: .inherit)) != nil
+            }
         )
     )
     func testSubprocessPlatformOptionsProcessGroupID() async throws {
@@ -145,8 +147,10 @@ extension SubprocessUnixTests {
 
     @Test(
         .enabled(
-            if: (try? Executable.name("ps").resolveExecutablePath(in: .inherit)) != nil,
-            "This test requires ps (install procps package on Debian or RedHat Linux distros)"
+            "This test requires ps (install procps package on Debian or RedHat Linux distros)",
+            {
+                (try? await Executable.name("ps").resolveExecutablePath(in: .inherit)) != nil
+            }
         )
     )
     func testSubprocessPlatformOptionsCreateSession() async throws {


### PR DESCRIPTION
This method requires hitting the filesystem and should therefore be async as it can block

Closes #263