### PR TITLE
Add timeout to `testDoesNotReapUnrelatedChildProcess()`

### DIFF
--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -229,7 +229,8 @@ extension SubprocessProcessMonitoringTests {
         }
     }
 
-    @Test func testDoesNotReapUnrelatedChildProcess() async throws {
+    @Test(.timeLimit(.minutes(1)))
+    func testDoesNotReapUnrelatedChildProcess() async throws {
         // Make sure we don't reap child exit status that we didn't spawn
         let child1 = self.immediateExitProcess(withExitCode: 0)
         let child2 = self.immediateExitProcess(withExitCode: 0)


### PR DESCRIPTION
This PR adds a timeout to prevent non-deterministically hangs which consume the full CI job timeout with no actionable signal.

Addresses #157, which should remain open until the reason for the underlying hang is determined. I've ran this test 5,000+ times locally on macOS and haven't been able to reproduce the hang. Unfortunately I can't run it at that scale on Linux.