### PR TITLE
Make `Configuration` introspectable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.2.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -450,6 +450,33 @@ extension Executable: CustomStringConvertible, CustomDebugStringConvertible {
     }
 }
 
+// MARK: - Executable Introspection
+
+extension Executable {
+    /// The public representation of an executable's contents.
+    ///
+    /// Use this to introspect how an ``Executable`` was constructed (for
+    /// example, to verify in tests that a configuration builder produced the
+    /// expected executable reference without launching a subprocess).
+    @frozen
+    public enum Representation: Sendable, Hashable {
+        /// The executable is referenced by name and resolved against `PATH`.
+        case name(String)
+        /// The executable is referenced by an absolute or relative file path.
+        case path(FilePath)
+    }
+
+    /// The contents of this executable.
+    public var representation: Representation {
+        switch self.storage {
+        case .executable(let name):
+            return .name(name)
+        case .path(let path):
+            return .path(path)
+        }
+    }
+}
+
 // MARK: - Arguments
 
 /// A collection of arguments to pass to the subprocess.
@@ -458,17 +485,17 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
     public typealias ArrayLiteralElement = String
 
     internal let storage: [StringOrRawBytes]
-    internal let executablePathOverride: StringOrRawBytes?
+    internal let _executablePathOverride: StringOrRawBytes?
 
     /// Creates an arguments value from the literal values you provide.
     public init(arrayLiteral elements: String...) {
         self.storage = elements.map { .string($0) }
-        self.executablePathOverride = nil
+        self._executablePathOverride = nil
     }
     /// Creates an arguments value from the array you provide.
     public init(_ array: [String]) {
         self.storage = array.map { .string($0) }
-        self.executablePathOverride = nil
+        self._executablePathOverride = nil
     }
 
     /// Creates an argument list, overriding the first element with the executable path value you provide.
@@ -482,9 +509,9 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
     public init(executablePathOverride: String?, remainingValues: [String]) {
         self.storage = remainingValues.map { .string($0) }
         if let executablePathOverride = executablePathOverride {
-            self.executablePathOverride = .string(executablePathOverride)
+            self._executablePathOverride = .string(executablePathOverride)
         } else {
-            self.executablePathOverride = nil
+            self._executablePathOverride = nil
         }
     }
     #if !os(Windows) // Windows does not support non-unicode arguments
@@ -499,15 +526,15 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
     public init(executablePathOverride: [UInt8]?, remainingValues: [[UInt8]]) {
         self.storage = remainingValues.map { .rawBytes($0) }
         if let override = executablePathOverride {
-            self.executablePathOverride = .rawBytes(override)
+            self._executablePathOverride = .rawBytes(override)
         } else {
-            self.executablePathOverride = nil
+            self._executablePathOverride = nil
         }
     }
     /// Creates an arguments value from the array you provide.
     public init(_ array: [[UInt8]]) {
         self.storage = array.map { .rawBytes($0) }
-        self.executablePathOverride = nil
+        self._executablePathOverride = nil
     }
     #endif
 }
@@ -517,7 +544,7 @@ extension Arguments: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
         var result: [String] = self.storage.map(\.description)
 
-        if let override = self.executablePathOverride {
+        if let override = self._executablePathOverride {
             result.insert("override\(override.description)", at: 0)
         }
         return result.description
@@ -525,6 +552,64 @@ extension Arguments: CustomStringConvertible, CustomDebugStringConvertible {
 
     /// A debug-oriented textual representation of the arguments.
     public var debugDescription: String { return self.description }
+}
+
+// MARK: - Arguments Introspection
+
+extension Arguments {
+    /// A single argument value, preserving the form in which it was supplied.
+    ///
+    /// On POSIX platforms, arguments may be constructed from non-Unicode
+    /// raw bytes; on Windows, only `String` values are representable.
+    @frozen
+    public enum Value: Sendable, Hashable {
+        /// A string argument.
+        case string(String)
+        #if !os(Windows)
+        /// A raw-bytes argument.
+        ///
+        /// - Note: This case is only available on POSIX platforms.
+        case rawBytes([UInt8])
+        #endif
+    }
+
+    /// The argument that overrides the executable path as `argv[0]`, or `nil`
+    /// if the executable path is used unchanged.
+    ///
+    /// This corresponds to the `executablePathOverride` parameter passed to
+    /// the initializer, and is useful for verifying configuration in tests
+    /// without launching a subprocess.
+    public var executablePathOverride: Value? {
+        self._executablePathOverride.map(Value.init)
+    }
+}
+
+extension Arguments: RandomAccessCollection {
+    public typealias Element = Value
+    public typealias Index = Int
+
+    public var startIndex: Int { self.storage.startIndex }
+    public var endIndex: Int { self.storage.endIndex }
+
+    public subscript(position: Int) -> Value {
+        Value(self.storage[position])
+    }
+}
+
+extension Arguments.Value {
+    internal init(_ storage: StringOrRawBytes) {
+        switch storage {
+        case .string(let s):
+            self = .string(s)
+        case .rawBytes(let b):
+            #if os(Windows)
+            // Unreachable: The Windows public API cannot construct rawBytes arguments.
+            fatalError("Internal inconsistency: rawBytes argument on Windows")
+            #else
+            self = .rawBytes(b)
+            #endif
+        }
+    }
 }
 
 // MARK: - Environment
@@ -665,7 +750,8 @@ extension Environment: CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 extension Environment.Key {
-    package static let path: Self = "PATH"
+    /// The well-known key for the `PATH` environment variable.
+    public static let path: Self = "PATH"
 }
 
 extension Environment.Key: CodingKeyRepresentable {}
@@ -749,6 +835,50 @@ extension Environment.Key: RawRepresentable {
 }
 
 extension Environment.Key: Sendable {}
+
+// MARK: - Environment Introspection
+
+extension Environment {
+    /// The public representation of an environment's contents.
+    ///
+    /// Use this to introspect how an ``Environment`` was constructed (for
+    /// example, to verify in tests that a configuration builder produced
+    /// the expected inherited overrides or custom values without launching a
+    /// subprocess).
+    @nonexhaustive
+    public enum Representation: Sendable, Hashable {
+        /// The environment inherits from the current process, with the given
+        /// updates applied.
+        ///
+        /// A `nil` value for a key indicates that the key is unset relative to
+        /// the inherited environment, rather than being set to an empty value.
+        case inherited(updates: [Key: String?])
+        /// The environment uses the given custom values, with no inheritance
+        /// from the current process.
+        case custom([Key: String])
+        #if !os(Windows)
+        /// The environment uses the given raw bytes, with no inheritance from
+        /// the current process.
+        ///
+        /// - Note: This case is only available on POSIX platforms.
+        case rawBytes([[UInt8]])
+        #endif
+    }
+
+    /// The contents of this environment.
+    public var representation: Representation {
+        switch self.config {
+        case .inherit(let updates):
+            return .inherited(updates: updates)
+        case .custom(let values):
+            return .custom(values)
+        #if !os(Windows)
+        case .rawBytes(let bytes):
+            return .rawBytes(bytes)
+        #endif
+        }
+    }
+}
 
 // MARK: - TerminationStatus
 

--- a/Sources/Subprocess/Documentation.docc/reference/Arguments.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Arguments.md
@@ -12,3 +12,8 @@
 
 - ``init(executablePathOverride:remainingValues:)-(String?,_)``
 - ``init(executablePathOverride:remainingValues:)-([UInt8]?,_)``
+- ``executablePathOverride``
+
+### Inspecting arguments
+
+- ``Value``

--- a/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
@@ -6,6 +6,10 @@
 
 - ``init(stringLiteral:)``
 
+### Well-known keys
+
+- ``path``
+
 ### Working with raw values
 
 - ``init(rawValue:)``

--- a/Sources/Subprocess/Documentation.docc/reference/Environment.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Environment.md
@@ -15,3 +15,8 @@
 ### Accessing environment keys
 
 - ``Key``
+
+### Inspecting an environment
+
+- ``representation``
+- ``Representation``

--- a/Sources/Subprocess/Documentation.docc/reference/Executable.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Executable.md
@@ -10,3 +10,8 @@
 ### Resolving the executable path
 
 - ``resolveExecutablePath(in:)``
+
+### Inspecting an executable
+
+- ``representation``
+- ``Representation``

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -353,7 +353,7 @@ extension Arguments {
     internal func createArgs(withExecutablePath executablePath: String) -> [UnsafeMutablePointer<CChar>?] {
         var argv: [UnsafeMutablePointer<CChar>?] = self.storage.map { $0.createRawBytes() }
         // argv[0] = executable path
-        if let override = self.executablePathOverride {
+        if let override = self._executablePathOverride {
             argv.insert(override.createRawBytes(), at: 0)
         } else {
             argv.insert(strdup(executablePath), at: 0)

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1338,7 +1338,7 @@ extension Configuration {
         }
 
         var commandLineArguments = args
-        if case .string(let overrideName) = self.arguments.executablePathOverride {
+        if case .string(let overrideName) = self.arguments._executablePathOverride {
             // Use the override as argument0 and set applicationName
             commandLineArguments.insert(overrideName, at: 0)
         } else {
@@ -1348,7 +1348,7 @@ extension Configuration {
         return (
             // Omit applicationName (and therefore rely on commandAndArgs for
             // executable path) when we don't need to override arg0.
-            applicationName: self.arguments.executablePathOverride == nil ? nil : executablePath,
+            applicationName: self.arguments._executablePathOverride == nil ? nil : executablePath,
             commandAndArgs: Self.quoteWindowsCommandLine(commandLineArguments)
         )
     }

--- a/Tests/SubprocessTests/ConfigurationIntrospectionTests.swift
+++ b/Tests/SubprocessTests/ConfigurationIntrospectionTests.swift
@@ -1,0 +1,195 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+
+import Testing
+import Subprocess
+
+@Suite("Configuration Introspection Tests")
+struct ConfigurationIntrospectionTests {}
+
+// MARK: - Arguments
+extension ConfigurationIntrospectionTests {
+    @Test func testArgumentsArrayLiteralIsIterable() {
+        let arguments: Arguments = ["--foo", "bar", "--baz"]
+
+        #expect(arguments.count == 3)
+        #expect(arguments[0] == .string("--foo"))
+        #expect(arguments[1] == .string("bar"))
+        #expect(arguments[2] == .string("--baz"))
+        #expect(Array(arguments) == [.string("--foo"), .string("bar"), .string("--baz")])
+    }
+
+    @Test func testArgumentsFromStringArrayIsIterable() {
+        let arguments = Arguments(["a", "b", "c"])
+
+        #expect(arguments.count == 3)
+        #expect(arguments.first == .string("a"))
+        #expect(arguments.last == .string("c"))
+    }
+
+    @Test func testArgumentsEmpty() {
+        let arguments: Arguments = []
+
+        #expect(arguments.isEmpty)
+        #expect(arguments.count == 0)
+        #expect(arguments.executablePathOverride == nil)
+    }
+
+    @Test func testArgumentsExecutablePathOverrideNil() {
+        let arguments = Arguments(["a", "b"])
+
+        #expect(arguments.executablePathOverride == nil)
+    }
+
+    @Test func testArgumentsExecutablePathOverrideString() {
+        let arguments = Arguments(
+            executablePathOverride: "argv0-override",
+            remainingValues: ["a", "b"]
+        )
+
+        #expect(arguments.executablePathOverride == .string("argv0-override"))
+        #expect(arguments.count == 2)
+        #expect(Array(arguments) == [.string("a"), .string("b")])
+    }
+
+    @Test func testArgumentsExecutablePathOverrideExplicitlyNil() {
+        let arguments = Arguments(
+            executablePathOverride: nil,
+            remainingValues: ["a", "b"]
+        )
+
+        #expect(arguments.executablePathOverride == nil)
+        #expect(arguments.count == 2)
+        #expect(Array(arguments) == [.string("a"), .string("b")])
+    }
+
+    #if !os(Windows)
+    @Test func testArgumentsFromRawBytesIsIterable() {
+        let arguments = Arguments([
+            Array("first".utf8),
+            Array("second".utf8),
+        ])
+
+        #expect(arguments.count == 2)
+        #expect(arguments[0] == .rawBytes(Array("first".utf8)))
+        #expect(arguments[1] == .rawBytes(Array("second".utf8)))
+    }
+
+    @Test func testArgumentsRawBytesExecutablePathOverride() {
+        let arguments = Arguments(
+            executablePathOverride: Array("argv0".utf8),
+            remainingValues: [Array("a".utf8), Array("b".utf8)]
+        )
+
+        #expect(arguments.executablePathOverride == .rawBytes(Array("argv0".utf8)))
+        #expect(arguments.count == 2)
+        #expect(arguments[0] == .rawBytes(Array("a".utf8)))
+        #expect(arguments[1] == .rawBytes(Array("b".utf8)))
+    }
+    #endif // !os(Windows)
+}
+
+// MARK: - Environment
+extension ConfigurationIntrospectionTests {
+    @Test func testEnvironmentInheritDefault() {
+        let environment: Environment = .inherit
+
+        #expect(environment.representation == .inherited(updates: [:]))
+    }
+
+    @Test func testEnvironmentInheritWithUpdates() {
+        let updates: [Environment.Key: String?] = [
+            .path: "/custom/path",
+            "FOO": "foo-value",
+        ]
+
+        let environment: Environment = .inherit.updating(updates)
+        let expected: Environment.Representation = .inherited(updates: updates)
+
+        #expect(environment.representation == expected)
+    }
+
+    @Test func testEnvironmentInheritWithUnsetDirective() {
+        // A `nil` value in updates means "unset relative to inherited
+        // environment", distinct from "absent from updates".
+        let updates: [Environment.Key: String?] = [
+            "FOO": "foo-value",
+            "REMOVE_ME": nil,
+        ]
+
+        let environment: Environment = .inherit.updating(updates)
+        let expected: Environment.Representation = .inherited(updates: updates)
+
+        #expect(environment.representation == expected)
+    }
+
+    @Test func testEnvironmentCustom() {
+        let updates: [Environment.Key: String] = [
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+        ]
+
+        let environment: Environment = .custom(updates)
+        let expected: Environment.Representation = .custom(updates)
+
+        #expect(environment.representation == expected)
+    }
+
+    @Test func testEnvironmentCustomUpdating() {
+        let environment: Environment = .custom([
+            "PATH": "/usr/bin:/bin"
+        ]).updating([
+            "EXTRA": "value"
+        ])
+
+        let expected: Environment.Representation = .custom([
+            "PATH": "/usr/bin:/bin",
+            "EXTRA": "value",
+        ])
+
+        #expect(environment.representation == expected)
+    }
+
+    #if !os(Windows)
+    @Test func testEnvironmentRawBytes() {
+        let entries: [[UInt8]] = [
+            Array("PATH=/usr/bin:/bin\0".utf8),
+            Array("HOME=/home/user\0".utf8),
+        ]
+
+        let environment: Environment = .custom(entries)
+
+        #expect(environment.representation == .rawBytes(entries))
+    }
+    #endif // !os(Windows)
+}
+
+// MARK: - Executable
+extension ConfigurationIntrospectionTests {
+    @Test func testExecutableName() {
+        let executable: Executable = .name("git")
+
+        #expect(executable.representation == .name("git"))
+    }
+
+    @Test func testExecutablePath() {
+        let path: FilePath = "/usr/bin/git"
+        let executable: Executable = .path(path)
+
+        #expect(executable.representation == .path(path))
+    }
+}


### PR DESCRIPTION
Closes #206.

This PR adds public introspection of `Arguments`, `Executable`, and `Environment` so callers generating subprocess configurations can unit-test them without spawning a subprocess. The current storage of these types is opaque, leaving callers with only string-based descriptions to parse.

- `Arguments` conforms to `RandomAccessCollection<Arguments.Value>`, where `Value` is a public mirror of the internal `StringOrRawBytes`. A `Value` enum was chosen over lossy UTF-8 decoding so callers constructing arguments from `[UInt8]` on POSIX can verify the exact bytes.

- `Arguments.executablePathOverride` is exposed as a separate public property rather than folded into iteration. Folding would make `argv[0]` ambiguous between an override and a regular first argument, and would prevent callers from distinguishing the two cases in tests. The internal stored property is renamed to `_executablePathOverride` to free the name for the public accessor.

- `Executable` and `Environment` expose their contents through new `Representation` mirror enums rather than exposing their internal storage types directly, decoupling the public introspection surface from internal storage. `Environment.Key.path` is promoted from `package` to `public` so callers can use it as a canonical reference to the `PATH` key.

The Swift tools version is bumped to 6.2.3 to support `@nonexhaustive` (SE-0487).