### PR TITLE
Use `Int64` and parameter labels for byte-denominated limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The simplest way to use `Subprocess` is to run a process and collect its output:
 ```swift
 import Subprocess
 
-let result = try await run(.name("ls"), output: .string(limit: 4096))
+let result = try await run(.name("ls"), output: .string(byteLimit: 4096))
 
 print(result.processIdentifier) // e.g. 1234
 print(result.terminationStatus) // e.g. exited(0)
@@ -131,7 +131,7 @@ let result = try await run(
     .path("/my/app"),
     input: .none,
     output: .sequence,
-    error: .string(limit: 4096)
+    error: .string(byteLimit: 4096)
 ) { execution in
     var lineCount = 0
     for try await _ in execution.standardOutput.lines() {
@@ -199,7 +199,7 @@ let result = try await run(
     // and add NewKey=NewValue
     environment: .inherit.updating(["NewKey": "NewValue"]),
     workingDirectory: "/Users/",
-    output: .string(limit: 4096)
+    output: .string(byteLimit: 4096)
 )
 ```
 
@@ -211,7 +211,7 @@ let config = Configuration(
     arguments: ["--verbose"],
     environment: .inherit
 )
-let result = try await run(config, output: .string(limit: 4096))
+let result = try await run(config, output: .string(byteLimit: 4096))
 ```
 
 
@@ -245,20 +245,20 @@ For the collected-result API, you must specify how to capture standard output.
 | `.discarded` | Discard output |
 | `.fileDescriptor(_:closeAfterSpawningProcess:)` | Write to a file descriptor |
 | `.currentStandardOutput` or `.currentStandardError` | Write to the parent process's standard output or standard error |
-| `.string(limit:)` or `.string(limit:encoding:)` | Collect as `String?` |
+| `.string(byteLimit:)` or `.string(byteLimit:encoding:)` | Collect as `String?` |
 | `.bytes(limit:)` | Collect as `[UInt8]` |
 | `.sequence` | Stream to the closure via `execution.standardOutput` or `execution.standardError` (closure-based `run` only) |
-| `.data(limit:)` | Collect as `Data` (requires `SubprocessFoundation`) |
+| `.data(byteLimit:)` | Collect as `Data` (requires `SubprocessFoundation`) |
 | `.combinedWithOutput` | Merge standard error into the standard output stream (error parameter only) |
 
-The `limit` parameter specifies the maximum number of bytes to collect. `Subprocess` throws an error if the child process produces more output than the limit allows.
+The `byteLimit`/`limit` parameters specify the maximum number of bytes to collect. `Subprocess` throws an error if the child process produces more output than the limit allows.
 
 Use `.combinedWithOutput` for the `error` parameter to merge standard output and standard error into a single stream, equivalent to the shell redirection `2>&1`:
 
 ```swift
 let result = try await run(
     .name("my-tool"),
-    output: .string(limit: 4096),
+    output: .string(byteLimit: 4096),
     error: .combinedWithOutput
 )
 // result.standardOutput contains both standard output and standard error
@@ -279,7 +279,7 @@ let serverTask = Task {
     let result = try await run(
         .name("server"),
         platformOptions: platformOptions,
-        output: .string(limit: 1024)
+        output: .string(byteLimit: 1024)
     )
 }
 

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -111,7 +111,8 @@ extension SubprocessError {
 
     private enum Context: Sendable, Hashable {
         case string(String)
-        case int(Int)
+        case byteCount(Int64)
+        case codeUnitCount(count: Int, encodingName: String)
         case processControlOperation(ProcessControlOperation)
     }
 
@@ -178,13 +179,17 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
                 return "Failed to write bytes to the child process."
             }
         case .outputLimitExceeded:
-            if let context = self.context[self.code],
-                case .int(let limit) = context
-            {
-                return "Child process output exceeded the limit of \(limit) bytes."
-            } else {
-                return "Child process output exceeded the limit."
+            if let context = self.context[self.code] {
+                switch context {
+                case .byteCount(let limit):
+                    return "Child process output exceeded the limit of \(limit) bytes."
+                case .codeUnitCount(let limit, let encodingName):
+                    return "Child process output exceeded the line length limit of \(limit) \(encodingName) code units."
+                default:
+                    break
+                }
             }
+            return "Child process output exceeded the limit."
         case .asyncIOFailed:
             let context = self.context[self.code]
             switch (self.underlyingError, context) {
@@ -286,12 +291,28 @@ extension SubprocessError {
         )
     }
 
-    internal static func outputLimitExceeded(limit: Int) -> Self {
+    internal static func outputLimitExceeded(byteLimit: Int64) -> Self {
         return SubprocessError(
             code: .outputLimitExceeded,
             underlyingError: nil,
             context: [
-                .outputLimitExceeded: .int(limit)
+                .outputLimitExceeded: .byteCount(byteLimit)
+            ]
+        )
+    }
+
+    internal static func outputLimitExceeded<Encoding: _UnicodeEncoding>(
+        codeUnits limit: Int,
+        encoding: Encoding.Type
+    ) -> Self {
+        return SubprocessError(
+            code: .outputLimitExceeded,
+            underlyingError: nil,
+            context: [
+                .outputLimitExceeded: .codeUnitCount(
+                    count: limit,
+                    encodingName: String(describing: encoding)
+                )
             ]
         )
     }

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -29,12 +29,12 @@ public protocol OutputProtocol: Sendable, ~Copyable {
     func output(from span: RawSpan) throws -> OutputType
 
     /// The maximum number of bytes to collect.
-    var maxSize: Int { get }
+    var maxSize: Int64 { get }
 }
 
 extension OutputProtocol {
     /// The maximum number of bytes to collect.
-    public var maxSize: Int { 128 * 1024 }
+    public var maxSize: Int64 { 128 * 1024 }
 }
 
 /// An output type that discards output from the child process.
@@ -102,7 +102,7 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
     /// The type for this output.
     public typealias OutputType = String?
     /// The maximum number of bytes to collect.
-    public let maxSize: Int
+    public let maxSize: Int64
 
     /// Creates a string from a raw span.
     public func output(from span: RawSpan) throws -> String? {
@@ -112,8 +112,8 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
         }
     }
 
-    internal init(limit: Int, encoding: Encoding.Type) {
-        self.maxSize = limit
+    internal init(byteLimit: Int64, encoding: Encoding.Type) {
+        self.maxSize = byteLimit
     }
 }
 
@@ -122,7 +122,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
     /// The output type for this output option.
     public typealias OutputType = [UInt8]
     /// The maximum number of bytes to collect.
-    public let maxSize: Int
+    public let maxSize: Int64
 
     internal func captureOutput(
         from diskIO: consuming IODescriptor,
@@ -130,18 +130,23 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
     ) async throws(SubprocessError) -> [UInt8] {
         var result: [UInt8] = []
         do {
-            var maxLength = self.maxSize
-            if maxLength != .max {
+            var maxLength: Int64 = self.maxSize
+            let isBounded = maxLength != .max
+            if isBounded {
                 // Read one extra byte to detect output that exceeds the
                 // limit.
                 maxLength += 1
+            }
+            // Clamp to `Int.max` on 32-bit platforms.
+            let cappedMaxLength = Int(exactly: maxLength) ?? Int.max
+            if isBounded {
                 // Reserve capacity to avoid reallocations.
-                result.reserveCapacity(maxLength)
+                result.reserveCapacity(cappedMaxLength)
             }
             let bufferSize = AsyncIO.queryPipeBufferSize(for: diskIO.descriptor())
 
-            while result.count < maxLength {
-                let remaining = maxLength - result.count
+            while result.count < cappedMaxLength {
+                let remaining = cappedMaxLength - result.count
                 guard
                     let chunk = try await AsyncIO.shared.read(
                         from: diskIO,
@@ -159,8 +164,8 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
         }
         try diskIO.safelyClose()
 
-        if result.count > self.maxSize {
-            throw .outputLimitExceeded(limit: self.maxSize)
+        if Int64(result.count) > self.maxSize {
+            throw .outputLimitExceeded(byteLimit: self.maxSize)
         }
         return result
     }
@@ -170,7 +175,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
         span.withUnsafeBytes { Array($0) }
     }
 
-    internal init(limit: Int) {
+    internal init(limit: Int64) {
         self.maxSize = limit
     }
 }
@@ -231,23 +236,23 @@ extension OutputProtocol where Self == StringOutput<UTF8> {
     /// Creates a subprocess output that collects output as a UTF-8 string.
     ///
     /// The subprocess throws an error if the child process
-    /// produces more bytes than `limit`.
-    public static func string(limit: Int) -> Self {
-        return .init(limit: limit, encoding: UTF8.self)
+    /// produces more bytes than `byteLimit`.
+    public static func string(byteLimit: Int64) -> Self {
+        return .init(byteLimit: byteLimit, encoding: UTF8.self)
     }
 }
 
 extension OutputProtocol {
     /// Creates a subprocess output that collects output as
-    /// a string using the given encoding, up to `limit` bytes.
+    /// a string using the given encoding, up to `byteLimit` bytes.
     ///
     /// The subprocess throws an error if the child process
-    /// produces more bytes than `limit`.
+    /// produces more bytes than `byteLimit`.
     public static func string<Encoding: Unicode.Encoding>(
-        limit: Int,
+        byteLimit: Int64,
         encoding: Encoding.Type
     ) -> Self where Self == StringOutput<Encoding> {
-        return .init(limit: limit, encoding: encoding)
+        return .init(byteLimit: byteLimit, encoding: encoding)
     }
 }
 
@@ -257,7 +262,7 @@ extension OutputProtocol where Self == BytesOutput {
     ///
     /// The subprocess throws an error if the child process
     /// produces more bytes than `limit`.
-    public static func bytes(limit: Int) -> Self {
+    public static func bytes(limit: Int64) -> Self {
         return .init(limit: limit)
     }
 }
@@ -366,17 +371,22 @@ extension OutputProtocol {
 
         var result: [UInt8] = []
         do {
-            var maxLength = self.maxSize
-            if maxLength != .max {
+            var maxLength: Int64 = self.maxSize
+            let isBounded = maxLength != .max
+            if isBounded {
                 // Read one extra byte to detect output that exceeds the
                 // limit.
                 maxLength += 1
-                result.reserveCapacity(maxLength)
+            }
+            // Clamp to `Int.max` on 32-bit platforms.
+            let cappedMaxLength = Int(exactly: maxLength) ?? Int.max
+            if isBounded {
+                result.reserveCapacity(cappedMaxLength)
             }
             let bufferSize = AsyncIO.queryPipeBufferSize(for: diskIO.descriptor())
 
-            while result.count < maxLength {
-                let remaining = maxLength - result.count
+            while result.count < cappedMaxLength {
+                let remaining = cappedMaxLength - result.count
                 guard
                     let chunk = try await AsyncIO.shared.read(
                         from: diskIO,
@@ -394,8 +404,8 @@ extension OutputProtocol {
         }
 
         try diskIO.safelyClose()
-        if result.count > self.maxSize {
-            throw SubprocessError.outputLimitExceeded(limit: self.maxSize)
+        if Int64(result.count) > self.maxSize {
+            throw SubprocessError.outputLimitExceeded(byteLimit: self.maxSize)
         }
 
         return try self.output(from: result)

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -24,26 +24,26 @@ public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
     /// The output type for this output option.
     public typealias OutputType = Data
     /// The maximum number of bytes to collect.
-    public let maxSize: Int
+    public let maxSize: Int64
 
     /// Creates data from a raw span.
     public func output(from span: RawSpan) throws(SubprocessError) -> Data {
         return Data(span)
     }
 
-    internal init(limit: Int) {
-        self.maxSize = limit
+    internal init(byteLimit: Int64) {
+        self.maxSize = byteLimit
     }
 }
 
 extension OutputProtocol where Self == DataOutput {
     /// Creates a subprocess output that collects output as `Data`,
-    /// up to `limit` bytes.
+    /// up to `byteLimit` bytes.
     ///
     /// The subprocess throws an error if the child process
-    /// produces more bytes than `limit`.
-    public static func data(limit: Int) -> Self {
-        return .init(limit: limit)
+    /// produces more bytes than `byteLimit`.
+    public static func data(byteLimit: Int64) -> Self {
+        return .init(byteLimit: byteLimit)
     }
 }
 

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -129,7 +129,7 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     ///   the buffer contents as strings.
     public func strings(
         separatedBy separator: StringSequence<UTF8>.Separator = .lineBreaks,
-        bufferingPolicy: StringSequence<UTF8>.BufferingPolicy = .maxLineLength(128 * 1024),
+        bufferingPolicy: StringSequence<UTF8>.BufferingPolicy = .maxLineLength(codeUnits: 128 * 1024),
     ) -> StringSequence<UTF8> {
         return StringSequence(
             underlying: self,
@@ -153,7 +153,7 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     ///   the buffer contents as strings.
     public func strings<Encoding: _UnicodeEncoding & Sendable>(
         separatedBy separator: StringSequence<Encoding>.Separator = .lineBreaks,
-        bufferingPolicy: StringSequence<Encoding>.BufferingPolicy = .maxLineLength(128 * 1024),
+        bufferingPolicy: StringSequence<Encoding>.BufferingPolicy = .maxLineLength(codeUnits: 128 * 1024),
         as encoding: Encoding.Type,
     ) -> StringSequence<Encoding> {
         return StringSequence(
@@ -382,8 +382,8 @@ extension SubprocessOutputSequence {
 
                 while let first = try await nextCodeUnit() {
                     // Throw if we exceed max line length
-                    if case .maxLineLength(let maxLength) = self.bufferingPolicy, buffer.count >= maxLength {
-                        throw SubprocessError.outputLimitExceeded(limit: maxLength)
+                    if case .maxLineLength(let maxCodeUnits) = self.bufferingPolicy, buffer.count >= maxCodeUnits {
+                        throw SubprocessError.outputLimitExceeded(codeUnits: maxCodeUnits, encoding: Encoding.self)
                     }
 
                     switch self.separator.storage {
@@ -506,10 +506,11 @@ extension SubprocessOutputSequence.StringSequence {
     public enum BufferingPolicy: Sendable {
         /// Adds to the buffer without imposing a limit on line length.
         case unbounded
-        /// Imposes a maximum line length limit.
+        /// Imposes a maximum line length limit, measured in code units of
+        /// the sequence's `Encoding`.
         ///
         /// The subprocess throws an error if a line exceeds this limit.
-        case maxLineLength(Int)
+        case maxLineLength(codeUnits: Int)
     }
 
     /// A delimiter that determines where a ``StringSequence``

--- a/Tests/SubprocessTests/DarwinTests.swift
+++ b/Tests/SubprocessTests/DarwinTests.swift
@@ -45,7 +45,7 @@ struct SubprocessDarwinTests {
             .path("/bin/bash"),
             arguments: ["-c", "ps -o pid,pgid,tpgid -p $$"],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         try assertNewSessionCreated(with: psResult)
     }
@@ -62,7 +62,7 @@ struct SubprocessDarwinTests {
         let pwdResult = try await Subprocess.run(
             .path("/bin/pwd"),
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(pwdResult.terminationStatus.isSuccess)
         let currentDir = try #require(

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -66,7 +66,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -111,7 +111,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -184,7 +184,7 @@ extension SubprocessIntegrationTests {
                 environment: .inherit.updating([
                     "PATH": "\(firstDir.path()):\(secondDir.path())"
                 ]),
-                output: .string(limit: 8)
+                output: .string(byteLimit: 8)
             )
             #expect(first.terminationStatus.isSuccess)
             #expect(first.standardOutput?.trimmingNewLineAndQuotes() == "FIRST")
@@ -194,7 +194,7 @@ extension SubprocessIntegrationTests {
                 environment: .inherit.updating([
                     "PATH": "\(secondDir.path()):\(firstDir.path())"
                 ]),
-                output: .string(limit: 8)
+                output: .string(byteLimit: 8)
             )
             #expect(second.terminationStatus.isSuccess)
             #expect(second.standardOutput?.trimmingNewLineAndQuotes() == "SECOND")
@@ -221,7 +221,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -254,7 +254,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 16),
+            output: .string(byteLimit: 16),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -277,7 +277,7 @@ extension SubprocessIntegrationTests {
                 executablePathOverride: nil,
                 remainingValues: [arguments]
             ),
-            output: .string(limit: 32)
+            output: .string(byteLimit: 32)
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
@@ -309,7 +309,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -358,7 +358,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -406,7 +406,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -434,7 +434,7 @@ extension SubprocessIntegrationTests {
         let result2 = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         // The new echo/printenv should not find `SubprocessTest`
@@ -473,7 +473,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -523,7 +523,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -563,7 +563,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #if os(Windows)
@@ -588,7 +588,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -613,7 +613,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 32),
+            output: .string(byteLimit: 32),
             error: .discarded
         )
         #expect(result.terminationStatus == .exited(1))
@@ -636,7 +636,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 64),
+            output: .string(byteLimit: 64),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -666,7 +666,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -700,7 +700,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
@@ -750,7 +750,7 @@ extension SubprocessIntegrationTests {
         #endif
 
         await #expect(throws: expectedError) {
-            _ = try await _run(setup, input: .none, output: .string(limit: .max), error: .discarded)
+            _ = try await _run(setup, input: .none, output: .string(byteLimit: .max), error: .discarded)
         }
     }
 }
@@ -772,7 +772,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 16),
+            output: .string(byteLimit: 16),
             error: .discarded
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -799,7 +799,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .string(content, using: UTF8.self),
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -825,7 +825,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .array(Array(content.utf8)),
-            output: .string(limit: .max),
+            output: .string(byteLimit: .max),
             error: .discarded
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -862,7 +862,7 @@ extension SubprocessIntegrationTests {
         let cat = try await _run(
             setup,
             input: .fileDescriptor(text, closeAfterSpawningProcess: true),
-            output: .data(limit: 2048 * 1024),
+            output: .data(byteLimit: 2048 * 1024),
             error: .discarded
         )
         #expect(cat.terminationStatus.isSuccess)
@@ -894,7 +894,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .data(expected),
-            output: .data(limit: 2048 * 1024),
+            output: .data(byteLimit: 2048 * 1024),
             error: .discarded
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -971,7 +971,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .sequence(stream),
-            output: .data(limit: 2048 * 1024),
+            output: .data(byteLimit: 2048 * 1024),
             error: .discarded
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -1055,8 +1055,8 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
-            error: .string(limit: .max)
+            output: .string(byteLimit: .max),
+            error: .string(byteLimit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
         #expect(result.standardOutput?.trimmingNewLineAndQuotes().isEmpty == true)
@@ -1113,7 +1113,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .data(expected),
-            output: .string(limit: 2048 * 1024, encoding: UTF8.self),
+            output: .string(byteLimit: 2048 * 1024, encoding: UTF8.self),
             error: .discarded
         )
         let output = try #require(
@@ -1146,11 +1146,11 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
-                output: .string(limit: 16),
+                output: .string(byteLimit: 16),
                 error: .discarded
             )
         }
@@ -1205,7 +1205,7 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
@@ -1325,7 +1325,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .data(expected),
-            output: .data(limit: 2048 * 1024),
+            output: .data(byteLimit: 2048 * 1024),
             error: .discarded
         )
         #expect(
@@ -1350,11 +1350,11 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
-                output: .data(limit: 16),
+                output: .data(byteLimit: 16),
                 error: .discarded
             )
         }
@@ -1385,7 +1385,7 @@ extension SubprocessIntegrationTests {
             setup,
             input: .data(expected),
             output: .discarded,
-            error: .string(limit: 2048 * 1024, encoding: UTF8.self)
+            error: .string(byteLimit: 2048 * 1024, encoding: UTF8.self)
         )
         let output = try #require(
             catResult.standardError?.trimmingNewLineAndQuotes()
@@ -1416,12 +1416,12 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
                 output: .discarded,
-                error: .string(limit: 16)
+                error: .string(byteLimit: 16)
             )
         }
     }
@@ -1474,7 +1474,7 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
@@ -1643,7 +1643,7 @@ extension SubprocessIntegrationTests {
             setup,
             input: .data(expected),
             output: .discarded,
-            error: .data(limit: 2048 * 1024)
+            error: .data(byteLimit: 2048 * 1024)
         )
         #expect(
             catResult.standardError == expected
@@ -1666,12 +1666,12 @@ extension SubprocessIntegrationTests {
         )
         #endif
 
-        await #expect(throws: SubprocessError.outputLimitExceeded(limit: 16)) {
+        await #expect(throws: SubprocessError.outputLimitExceeded(byteLimit: 16)) {
             _ = try await _run(
                 setup,
                 input: .none,
                 output: .discarded,
-                error: .data(limit: 16)
+                error: .data(byteLimit: 16)
             )
         }
     }
@@ -1736,8 +1736,8 @@ extension SubprocessIntegrationTests {
             let result = try await _run(
                 setup,
                 input: .none,
-                output: .string(limit: 4),
-                error: .string(limit: 4)
+                output: .string(byteLimit: 4),
+                error: .string(byteLimit: 4)
             )
             #expect(result.terminationStatus.isSuccess)
             #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "x")
@@ -1762,8 +1762,8 @@ extension SubprocessIntegrationTests {
             let result = try await _run(
                 setup,
                 input: .none,
-                output: .string(limit: 4),
-                error: .string(limit: 4)
+                output: .string(byteLimit: 4),
+                error: .string(byteLimit: 4)
             )
             #expect(result.terminationStatus.isSuccess)
             #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "x")
@@ -1834,8 +1834,8 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: .max),
-            error: .string(limit: .max)
+            output: .string(byteLimit: .max),
+            error: .string(byteLimit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
         #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "")
@@ -1905,7 +1905,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 64),
+            output: .string(byteLimit: 64),
             error: .combinedWithOutput
         )
         #expect(result.terminationStatus.isSuccess)
@@ -2012,7 +2012,7 @@ extension SubprocessIntegrationTests {
         let catResult = try await _run(
             setup,
             input: .none,
-            output: .data(limit: 64),
+            output: .data(byteLimit: 64),
             error: .combinedWithOutput
         )
         #expect(catResult.terminationStatus.isSuccess)
@@ -2136,7 +2136,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 64),
+            output: .string(byteLimit: 64),
             error: .discarded
         ) { _ in
             return "closure-value"
@@ -2218,7 +2218,7 @@ extension SubprocessIntegrationTests {
             setup,
             input: .none,
             output: .sequence,
-            error: .string(limit: 64)
+            error: .string(byteLimit: 64)
         ) { execution in
             var collected = ""
             for try await line in execution.standardOutput.strings() {
@@ -2247,7 +2247,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 64),
+            output: .string(byteLimit: 64),
             error: .sequence
         ) { execution in
             var collected = ""
@@ -2280,7 +2280,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .inputWriter,
-            output: .string(limit: 64),
+            output: .string(byteLimit: 64),
             error: .discarded
         ) { execution in
             _ = try await execution.standardInputWriter.write("hello\n")
@@ -2367,7 +2367,7 @@ extension SubprocessIntegrationTests {
         // reaching EOF.
         //
         // The PID is sent on stderr so the call can capture it via
-        // `.sequence`, while `.string(limit:)` is the mechanism that
+        // `.sequence`, while `.string(byteLimit:)` is the mechanism that
         // would hang on stdout.
         let script = """
             ( exec sleep 12345678 ) </dev/null 2>/dev/null &
@@ -2390,7 +2390,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 1024),
+            output: .string(byteLimit: 1024),
             error: .sequence
         ) { execution in
             var capturedPid: pid_t = 0
@@ -2410,7 +2410,7 @@ extension SubprocessIntegrationTests {
 
     @Test func testWeDoNotHangIfStandardErrorRemainsOpenButProcessExits() async throws {
         // Mirror of the stdout test: the grandchild only inherits stderr,
-        // and `.string(limit:)` on stderr blocks waiting for an EOF that
+        // and `.string(byteLimit:)` on stderr blocks waiting for an EOF that
         // never arrives.
         let script = """
             ( exec sleep 12345678 ) </dev/null >/dev/null &
@@ -2434,7 +2434,7 @@ extension SubprocessIntegrationTests {
             setup,
             input: .none,
             output: .sequence,
-            error: .string(limit: 1024)
+            error: .string(byteLimit: 1024)
         ) { execution in
             var capturedPid: pid_t = 0
             for try await line in execution.standardOutput.strings() {
@@ -2526,7 +2526,7 @@ extension SubprocessIntegrationTests {
         // since `Start-Process -NoNewWindow` copies the parent's std
         // handles), prints the PID on stderr so we can capture it via
         // `.sequence`, prints "GO" on stdout, and exits. The grandchild
-        // keeps the stdout write end alive — `.string(limit:)` on stdout
+        // keeps the stdout write end alive — `.string(byteLimit:)` on stdout
         // is the call that would hang waiting for an EOF that never
         // arrives.
         let script = """
@@ -2547,7 +2547,7 @@ extension SubprocessIntegrationTests {
         let result = try await _run(
             setup,
             input: .none,
-            output: .string(limit: 1024),
+            output: .string(byteLimit: 1024),
             error: .sequence
         ) { execution in
             // The grandchild also inherits stderr, so the call can't
@@ -2572,7 +2572,7 @@ extension SubprocessIntegrationTests {
         // Mirror of the stdout test: PowerShell prints the PID on stdout
         // (so we can capture it via `.sequence`) and "GO" on stderr, then
         // exits. The grandchild keeps the stderr write end alive —
-        // `.string(limit:)` on stderr is the call that would hang.
+        // `.string(byteLimit:)` on stderr is the call that would hang.
         let script = """
             $ErrorActionPreference = 'Stop'
             \(Self.spawnGrandchildSleep)
@@ -2592,7 +2592,7 @@ extension SubprocessIntegrationTests {
             setup,
             input: .none,
             output: .sequence,
-            error: .string(limit: 1024)
+            error: .string(byteLimit: 1024)
         ) { execution in
             var iterator = execution.standardOutput.strings().makeAsyncIterator()
             while let line = try await iterator.next() {
@@ -2815,8 +2815,8 @@ extension SubprocessIntegrationTests {
                     let r = try await _run(
                         setup,
                         input: .string(string),
-                        output: .data(limit: .max),
-                        error: .data(limit: .max)
+                        output: .data(byteLimit: .max),
+                        error: .data(byteLimit: .max)
                     )
                     #expect(r.terminationStatus == .exited(0))
                     #expect(r.standardOutput.count == 100_000, "Standard output actual \(r.standardOutput.count)")
@@ -3112,7 +3112,7 @@ extension SubprocessIntegrationTests {
                 let result = try await _run(
                     setup,
                     input: .fileDescriptor(readEnd, closeAfterSpawningProcess: true),
-                    output: .string(limit: 32),
+                    output: .string(byteLimit: 32),
                     error: .discarded
                 )
 

--- a/Tests/SubprocessTests/LinterTests.swift
+++ b/Tests/SubprocessTests/LinterTests.swift
@@ -78,7 +78,7 @@ struct SubprocessLintingTest {
         let lintResult = try await Subprocess.run(
             configuration,
             output: .discarded,
-            error: .string(limit: .max)
+            error: .string(byteLimit: .max)
         )
         #expect(
             lintResult.terminationStatus.isSuccess,

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -101,8 +101,8 @@ extension SubprocessUnixTests {
             .path("/usr/bin/id"),
             arguments: ["-G"],
             platformOptions: platformOptions,
-            output: .string(limit: .max),
-            error: .string(limit: .max),
+            output: .string(byteLimit: .max),
+            error: .string(byteLimit: .max),
         )
         #expect(idResult.terminationStatus.isSuccess, Comment(rawValue: idResult.standardError ?? ""))
         let ids = try #require(
@@ -135,7 +135,7 @@ extension SubprocessUnixTests {
             .path("/bin/sh"),
             arguments: ["-c", "ps -o pid,pgid -p $$"],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(psResult.terminationStatus.isSuccess)
         let resultValue = try #require(
@@ -167,7 +167,7 @@ extension SubprocessUnixTests {
             .path("/bin/sh"),
             arguments: ["-c", "cat /proc/$$/stat"],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         try assertNewSessionCreated(fromProcStat: statResult)
         #else
@@ -177,7 +177,7 @@ extension SubprocessUnixTests {
             .path("/bin/sh"),
             arguments: ["-c", "ps -o pid,pgid,tpgid -p $$"],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         try assertNewSessionCreated(with: psResult)
         #endif
@@ -380,7 +380,7 @@ extension SubprocessUnixTests {
                 return try await Subprocess.run(
                     .path("/bin/sh"),
                     arguments: ["-c", "trap 'echo no' TERM; while true; do sleep 1; done"],
-                    output: .string(limit: .max)
+                    output: .string(byteLimit: .max)
                 ).terminationStatus
             }
             group.addTask {
@@ -606,8 +606,8 @@ extension SubprocessUnixTests {
         let result = try await Subprocess.run(
             .path("/bin/sh"),
             arguments: .init(arguments),
-            output: .string(limit: .max),
-            error: .string(limit: .max)
+            output: .string(byteLimit: .max),
+            error: .string(byteLimit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
         #expect(result.standardError?.trimmingNewLineAndQuotes().isEmpty == true)
@@ -650,7 +650,7 @@ extension SubprocessUnixTests {
                         """,
                     ],
                     input: .none,
-                    output: .string(limit: 64),
+                    output: .string(byteLimit: 64),
                     error: .discarded
                 )
             }
@@ -721,7 +721,7 @@ extension SubprocessUnixTests {
             .path("/usr/bin/id"),
             arguments: [argument],
             platformOptions: platformOptions,
-            output: .string(limit: 32)
+            output: .string(byteLimit: 32)
         )
         #expect(idResult.terminationStatus.isSuccess)
         let id = try #require(idResult.standardOutput)
@@ -848,7 +848,7 @@ extension SubprocessUnixTests {
         let limitResult = try await Subprocess.run(
             .path("/bin/sh"),
             arguments: ["-c", "ulimit -n"],
-            output: .string(limit: 32)
+            output: .string(byteLimit: 32)
         )
         guard
             let limitString = limitResult
@@ -877,8 +877,8 @@ extension SubprocessUnixTests {
                         arguments: [
                             "-sc", #"echo "$1" && echo "$1" >&2"#, "--", String(repeating: "X", count: byteCount),
                         ],
-                        output: .data(limit: .max),
-                        error: .data(limit: .max)
+                        output: .data(byteLimit: .max),
+                        error: .data(byteLimit: .max)
                     )
                     guard r.terminationStatus.isSuccess else {
                         Issue.record("Unexpected exit \(r.terminationStatus) from \(r.processIdentifier)")

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -53,7 +53,7 @@ extension SubprocessWindowsTests {
                 .path("C:\\Windows\\System32\\whoami.exe"),
                 workingDirectory: workingDirectory,
                 platformOptions: platformOptions,
-                output: .string(limit: .max)
+                output: .string(byteLimit: .max)
             )
 
             try withKnownIssue {
@@ -100,7 +100,7 @@ extension SubprocessWindowsTests {
                 "-ExecutionPolicy", "Bypass", "-File", windowsTester.string,
                 "-mode", "get-console-window",
             ],
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(sameConsoleResult.terminationStatus.isSuccess)
         let sameConsoleValue = try #require(
@@ -120,7 +120,7 @@ extension SubprocessWindowsTests {
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(differentConsoleResult.terminationStatus.isSuccess)
         let differentConsoleValue = try #require(
@@ -142,7 +142,7 @@ extension SubprocessWindowsTests {
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(detachConsoleResult.terminationStatus.isSuccess)
         let detachConsoleValue = try #require(
@@ -166,7 +166,7 @@ extension SubprocessWindowsTests {
                 "-mode", "get-console-window",
             ],
             platformOptions: platformOptions,
-            output: .string(limit: .max)
+            output: .string(byteLimit: .max)
         )
         #expect(newConsoleResult.terminationStatus.isSuccess)
         let newConsoleValue = try #require(
@@ -196,7 +196,7 @@ extension SubprocessWindowsTests {
                 "-Command", "$consoleTitle = [console]::Title; Write-Host $consoleTitle",
             ],
             platformOptions: platformOptions,
-            output: .string(limit: 32)
+            output: .string(byteLimit: 32)
         )
         #expect(changeTitleResult.terminationStatus.isSuccess)
         let newTitle = try #require(
@@ -248,7 +248,7 @@ extension SubprocessWindowsTests {
                     "-mode", "is-process-suspended",
                     "-processID", "\(subprocess.processIdentifier.value)",
                 ],
-                output: .string(limit: .max)
+                output: .string(byteLimit: .max)
             )
             #expect(checkResult.terminationStatus.isSuccess)
             var isSuspended = try #require(
@@ -265,7 +265,7 @@ extension SubprocessWindowsTests {
                     "-mode", "is-process-suspended",
                     "-processID", "\(subprocess.processIdentifier.value)",
                 ],
-                output: .string(limit: .max)
+                output: .string(byteLimit: .max)
             )
             #expect(checkResult.terminationStatus.isSuccess)
             isSuspended = try #require(


### PR DESCRIPTION
Closes #248.

This PR adds a new public `ByteCount` type to make byte-denominated limits across the API unambiguous.

## Design

The shape is adapted from [swift-nio's `ByteCount`](https://github.com/apple/swift-nio/blob/6338e9fb5e136af8337b48eee65f8868d571a3d7/Sources/NIOFS/ByteCount.swift), except with no `.unlimited` static property. Per the discussion in #248, callers should make an explicit choice rather than opting into unbounded allocation.

`CustomStringConvertible` conformance produces human-readable descriptions such as `"2 MiB (2097152 bytes)"`, with the following behavior:

- Values smaller than 1 KiB render as plain bytes (for example, `"512 bytes"`).
- Values are truncated rather than rounded, so the displayed value never overstates the underlying count.
- IEC labels (KiB, MiB, GiB) are used over JEDEC labels (KB, MB, GB) for technical correctness.

## `BufferingPolicy.maxLineLength`

`BufferingPolicy.maxLineLength` is currently measured in `Encoding.CodeUnit`, not bytes. This PR labels the associated value as `maxLineLength(codeUnits: Int)` to make the unit explicit, and adds `SubprocessError.Context.codeUnitCount(count: Int, encodingName: String)` plus a matching `outputLimitExceeded(codeUnits:encoding:)` factory method so the error description renders the count alongside the encoding name.

Switching the buffer itself to byte-denominated limits would be a behavioral change. I can do that in a follow-up PR if there's interest.

## Testing

This PR adds a new test suite and updates existing tests to use the new type, without changing any existing semantics. For example, `.string(limit: .max)` changes to `.string(limit: .bytes(.max))`.