### PR TITLE
Replace call to `CreatePipe()` with call to `_pipe()` on Windows.

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1298,18 +1298,19 @@ extension FileDescriptor {
         writeEnd: FileDescriptor
     ) {
         var fds: [2 of CInt] = [-1, -1]
-        try fds.mutableSpan.withUnsafeMutableBufferPointer { fds in
+        var span = fds.mutableSpan
+        try span.withUnsafeMutableBufferPointer { fds throws(SubprocessError) in
             guard 0 == _pipe(fds.baseAddress!, 0, _O_BINARY) else {
                 throw SubprocessError.asyncIOFailed(
                     reason: "Failed to create pipe",
                     underlyingError: nil // FIXME: Errno(rawValue: _subprocess_windows_get_errno())
                 )
             }
-            return (
-                readEnd: FileDescriptor(rawValue: fds[0]),
-                writeEnd: FileDescriptor(rawValue: fds[1])
-            )
         }
+        return (
+            readEnd: FileDescriptor(rawValue: fds[0]),
+            writeEnd: FileDescriptor(rawValue: fds[1])
+        )
     }
 
     var platformDescriptor: PlatformFileDescriptor {

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1298,16 +1298,18 @@ extension FileDescriptor {
         writeEnd: FileDescriptor
     ) {
         var fds: [2 of CInt] = [-1, -1]
-        guard 0 == _pipe(&fds, 0, _O_BINARY) else {
-            throw SubprocessError.asyncIOFailed(
-                reason: "Failed to create pipe",
-                underlyingError: nil // FIXME: Errno(rawValue: _subprocess_windows_get_errno())
+        try fds.span.withUnsafeBufferPointer { fds in
+            guard 0 == _pipe(fds.baseAddress!, 0, _O_BINARY) else {
+                throw SubprocessError.asyncIOFailed(
+                    reason: "Failed to create pipe",
+                    underlyingError: nil // FIXME: Errno(rawValue: _subprocess_windows_get_errno())
+                )
+            }
+            return (
+                readEnd: FileDescriptor(rawValue: fds[0]),
+                writeEnd: FileDescriptor(rawValue: fds[1])
             )
         }
-        return (
-            readEnd: FileDescriptor(rawValue: fds[0]),
-            writeEnd: FileDescriptor(rawValue: fds[1])
-        )
     }
 
     var platformDescriptor: PlatformFileDescriptor {

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1297,36 +1297,16 @@ extension FileDescriptor {
         readEnd: FileDescriptor,
         writeEnd: FileDescriptor
     ) {
-        var saAttributes: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES()
-        saAttributes.nLength = DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size)
-        saAttributes.bInheritHandle = true
-        saAttributes.lpSecurityDescriptor = nil
-
-        var readHandle: HANDLE? = nil
-        var writeHandle: HANDLE? = nil
-        guard CreatePipe(&readHandle, &writeHandle, &saAttributes, 0),
-            readHandle != INVALID_HANDLE_VALUE,
-            writeHandle != INVALID_HANDLE_VALUE,
-            let readHandle: HANDLE = readHandle,
-            let writeHandle: HANDLE = writeHandle
-        else {
+        var fds: [2 of CInt] = [-1, -1]
+        guard 0 == _pipe(&fds, 0, _O_BINARY) else {
             throw SubprocessError.asyncIOFailed(
-                reason: "Filed to create pipe",
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                reason: "Failed to create pipe",
+                underlyingError: nil // FIXME: Errno(rawValue: _subprocess_windows_get_errno())
             )
         }
-        let readFd = _open_osfhandle(
-            intptr_t(bitPattern: readHandle),
-            FileDescriptor.AccessMode.readOnly.rawValue
-        )
-        let writeFd = _open_osfhandle(
-            intptr_t(bitPattern: writeHandle),
-            FileDescriptor.AccessMode.writeOnly.rawValue
-        )
-
         return (
-            readEnd: FileDescriptor(rawValue: readFd),
-            writeEnd: FileDescriptor(rawValue: writeFd)
+            readEnd: FileDescriptor(rawValue: fds[0]),
+            writeEnd: FileDescriptor(rawValue: fds[1])
         )
     }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1298,7 +1298,7 @@ extension FileDescriptor {
         writeEnd: FileDescriptor
     ) {
         var fds: [2 of CInt] = [-1, -1]
-        try fds.span.withUnsafeBufferPointer { fds in
+        try fds.mutableSpan.withUnsafeMutableBufferPointer { fds in
             guard 0 == _pipe(fds.baseAddress!, 0, _O_BINARY) else {
                 throw SubprocessError.asyncIOFailed(
                     reason: "Failed to create pipe",


### PR DESCRIPTION
Our call to `CreatePipe()` is effectively recreating the logic of `_pipe()`, but risks leaking handles at the various points of failure. Let's just use the UCRT implementation instead.