### PR TITLE
Cancel AsyncIO when the child process exits

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,17 +35,17 @@ jobs:
           # Test dependencies
           yum install -y procps
         fi
-      linux_build_command: 'swift test && swift test -c release && swift test --disable-default-traits'
+      linux_build_command: "swift test && swift test -c release && swift test --disable-default-traits"
       enable_freebsd_checks: true
-      freebsd_build_command: 'swift test && swift test -c release && swift test --disable-default-traits'
+      freebsd_build_command: "swift test && swift test -c release && swift test --disable-default-traits"
       windows_swift_versions: '["6.2", "nightly-main"]'
       windows_build_command: |
         Invoke-Program swift test
         Invoke-Program swift test -c release
         Invoke-Program swift test --disable-default-traits
       enable_macos_checks: true
-      macos_xcode_versions: '["26.0"]'
-      macos_build_command: 'xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits'
+      macos_xcode_versions: '["26.4"]'
+      macos_build_command: "xcrun swift test && xcrun swift test -c release && xcrun swift test --disable-default-traits"
       enable_linux_static_sdk_build: true
       enable_android_sdk_build: true
       android_ndk_versions: '["r27d", "r29"]'

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -275,7 +275,10 @@ public func run<
         return try await withThrowingTaskGroup(of: _RunGroupResult<Output, Error>.self) { group in
             var writer: StandardInputWriter?
             if inputIOBox != nil {
-                let inputWriter = StandardInputWriter(diskIO: inputIOBox.take()!)
+                let inputWriter = StandardInputWriter(
+                    diskIO: inputIOBox.take()!,
+                    processIdentifier: processIdentifier
+                )
                 writer = inputWriter
 
                 if Input.self != CustomWriteInput.self {
@@ -294,7 +297,8 @@ public func run<
             if Output.self == SequenceOutput.self {
                 var diskIO = outputIOBox.take()
                 outputSequence = AsyncBufferSequence(
-                    diskIO: diskIO!.consumeDescriptor()
+                    diskIO: diskIO!.consumeDescriptor(),
+                    processIdentifier: processIdentifier
                 )
             } else if Output.OutputType.self == Void.self {
                 // No need to capture output
@@ -303,7 +307,9 @@ public func run<
             } else {
                 var diskIO = outputIOBox.take()
                 group.addTask {
-                    let result = try await output.captureOutput(from: diskIO.take())
+                    let result = try await output.captureOutput(
+                        from: diskIO.take(), for: processIdentifier
+                    )
                     return .standardOutputCaptured(result)
                 }
             }
@@ -311,7 +317,8 @@ public func run<
             if Error.self == SequenceOutput.self {
                 var diskIO = errorIOBox.take()
                 errorSequence = AsyncBufferSequence(
-                    diskIO: diskIO!.consumeDescriptor()
+                    diskIO: diskIO!.consumeDescriptor(),
+                    processIdentifier: processIdentifier
                 )
             } else if Error.OutputType.self == Void.self {
                 // No need to capture error
@@ -320,7 +327,9 @@ public func run<
             } else {
                 var diskIO = errorIOBox.take()
                 group.addTask {
-                    let result = try await error.captureOutput(from: diskIO.take())
+                    let result = try await error.captureOutput(
+                        from: diskIO.take(), for: processIdentifier
+                    )
                     return .standardErrorCaptured(result)
                 }
             }

--- a/Sources/Subprocess/AsyncBufferSequence.swift
+++ b/Sources/Subprocess/AsyncBufferSequence.swift
@@ -57,11 +57,13 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
         public typealias Element = Buffer
 
         private let diskIO: DiskIO
+        private let processIdentifier: ProcessIdentifier
         private let preferredBufferSize: Int
         private var buffer: [Buffer]
 
-        internal init(diskIO: DiskIO) {
+        internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
             self.diskIO = diskIO
+            self.processIdentifier = processIdentifier
             self.buffer = []
             // Only need to query it once at beginning of stream
             self.preferredBufferSize = AsyncIO.queryPipeBufferSize(for: diskIO)
@@ -76,6 +78,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
             // Read more data
             let data = try await AsyncIO.shared.read(
                 from: self.diskIO,
+                for: self.processIdentifier,
                 upTo: self.preferredBufferSize
             )
             guard let data else {
@@ -97,10 +100,12 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
     }
 
     private let diskIO: DiskIO
+    private let processIdentifier: ProcessIdentifier
     private let state: State
 
-    internal init(diskIO: DiskIO) {
+    internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
         self.diskIO = diskIO
+        self.processIdentifier = processIdentifier
         self.state = State()
     }
 
@@ -109,7 +114,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
         guard self.state.initializedCount() == 1 else {
             fatalError("AsyncBufferSequence is single pass. It can only be iterated once.")
         }
-        return Iterator(diskIO: self.diskIO)
+        return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier)
     }
 
     /// Splits the buffer into strings using the specified separator.

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -38,14 +38,14 @@ public struct Configuration: Sendable {
     public var environment: Environment
     /// The working directory to use when running the executable.
     ///
-    /// If this property is `nil`, the subprocess will inherit
-    /// the working directory from the parent process.
+    /// If this property is `nil`, the subprocess inherits the working
+    /// directory from the parent process.
     public var workingDirectory: FilePath?
     /// The platform-specific options to use when
     /// running the subprocess.
     public var platformOptions: PlatformOptions
 
-    /// Creates a Configuration with the parameters you provide.
+    /// Creates a configuration with the parameters you provide.
     /// - Parameters:
     ///   - executable: The executable to run.
     ///   - arguments: The arguments to pass to the executable.
@@ -107,37 +107,78 @@ public struct Configuration: Sendable {
         let processIdentifier = spawnResults.processIdentifier
 
         defer {
-            // Close process file descriptor now we finished monitoring
+            // Close the process file descriptor now that monitoring has finished.
             processIdentifier.close()
         }
 
         return try await withAsyncTaskCleanupHandler { () throws -> ExecutionOutcome<Result> in
-            let inputIO = spawnResults.inputWriteEnd()
-            let outputIO = spawnResults.outputReadEnd()
-            let errorIO = spawnResults.errorReadEnd()
+            // The counter coordinates a race between two finishers: the body
+            // closure and the process-termination monitor. Whichever side
+            // increments first observes a value of `1` and owns the response;
+            // the other side sees `2` and stays out of the way.
+            //
+            // If the monitor wins, the child has exited while the body is
+            // still reading or writing. The body might be blocked on a pipe
+            // that an inherited grandchild keeps open, so the monitor calls
+            // `cancelAsyncIO` to unblock it. If the body wins, the I/O
+            // already finished cleanly and no cancellation is needed.
+            let taskFinishFlag = AtomicCounter()
 
-            let result: Swift.Result<Result, any Swift.Error>
-            do {
-                // Body runs in the same isolation
-                let bodyResult = try await body(processIdentifier, inputIO, outputIO, errorIO)
+            let (result, monitorError) = try await withThrowingTaskGroup(
+                of: SubprocessError?.self,
+                returning: (Swift.Result<Result, any Swift.Error>, SubprocessError?).self
+            ) { group in
+                group.addTask {
+                    do throws(SubprocessError) {
+                        try await waitForProcessTermination(for: processIdentifier)
+                        if taskFinishFlag.addOne() == 1 {
+                            // The body closure hasn't finished but the child
+                            // process has terminated. Cancel all active
+                            // AsyncIO now.
+                            try AsyncIO.shared.cancelAsyncIO(for: processIdentifier)
+                        }
+                        return nil
+                    } catch {
+                        try? AsyncIO.shared.cancelAsyncIO(for: processIdentifier)
+                        return error
+                    }
+                }
 
-                result = .success(bodyResult)
-            } catch {
-                result = .failure(error)
+                let inputIO = spawnResults.inputWriteEnd()
+                let outputIO = spawnResults.outputReadEnd()
+                let errorIO = spawnResults.errorReadEnd()
+
+                let result: Swift.Result<Result, any Swift.Error>
+                do {
+                    // Body runs in the same isolation.
+                    let bodyResult = try await body(processIdentifier, inputIO, outputIO, errorIO)
+                    taskFinishFlag.addOne()
+                    result = .success(bodyResult)
+                } catch {
+                    result = .failure(error)
+                }
+
+                // Wait for the monitor child task to finish.
+                let monitorError = try await group.next() ?? nil
+                return (result, monitorError)
             }
 
-            // Ensure that we begin monitoring process termination after `body` runs
-            // and regardless of whether `body` throws, so that the pid gets reaped
-            // even if `body` throws, and we are not leaving zombie processes in the
-            // process table which will cause the process termination monitoring thread
-            // to effectively hang due to the pid never being awaited
-            let terminationStatus = try await monitorProcessTermination(
-                for: processIdentifier
-            )
+            // Drop the cancellation marker before reaping the zombie. After
+            // `reapProcess` runs the kernel can immediately reuse this PID,
+            // so the marker must be gone first; otherwise a concurrent
+            // `run()` that happens to inherit the same PID would see the
+            // stale entry and reject its registrations.
+            AsyncIO.shared.cleanup(processIdentifier: processIdentifier)
 
-            return ExecutionOutcome(
+            let terminationStatus = try reapProcess(with: processIdentifier)
+
+            if let monitorError {
+                throw monitorError
+            }
+
+            return try ExecutionOutcome(
                 terminationStatus: terminationStatus,
-                value: try result.get()
+                value: result.get()
             )
         } onCleanup: {
             let execution = Execution<Input, Output, Error>(
@@ -146,7 +187,7 @@ public struct Configuration: Sendable {
                 outputStream: nil,
                 errorStream: nil
             )
-            // Attempt to terminate the child process
+            // Attempt to terminate the child process.
             await execution.runTeardownSequence(
                 self.platformOptions.teardownSequence
             )

--- a/Sources/Subprocess/IO/AsyncIO+KQueue.swift
+++ b/Sources/Subprocess/IO/AsyncIO+KQueue.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// AsyncIO implementation based on kqueue
+/// AsyncIO implementation based on kqueue.
 
 #if SUBPROCESS_ASYNCIO_KQUEUE
 
@@ -51,10 +51,7 @@ private let _kevent:
     ) -> Int32 = kevent
 
 private let _kqueueEventSize = 256
-private let _registration:
-    _Mutex<
-        [PlatformFileDescriptor: SignalStream.Continuation]
-    > = _Mutex([:])
+private let _registration: _Mutex<Registration> = _Mutex(Registration())
 
 private func _makeKevent(
     ident: UInt,
@@ -166,10 +163,11 @@ final class AsyncIO: Sendable {
         do throws(Errno) {
             thread = try pthread_create {
                 func reportError(_ error: SubprocessError) {
-                    _registration.withLock { store in
-                        for continuation in store.values {
-                            continuation.finish(throwing: error)
-                        }
+                    let continuations = _registration.withLock { store in
+                        return store.allContinuations()
+                    }
+                    for continuation in continuations {
+                        continuation.finish(throwing: error)
                     }
                 }
 
@@ -213,10 +211,7 @@ final class AsyncIO: Sendable {
                         }
 
                         let continuation = _registration.withLock { store -> SignalStream.Continuation? in
-                            if let continuation = store[targetFileDescriptor] {
-                                return continuation
-                            }
-                            return nil
+                            return store.continuation(for: targetFileDescriptor)
                         }
                         continuation?.yield(true)
                     }
@@ -294,6 +289,7 @@ final class AsyncIO: Sendable {
 
     internal func registerFileDescriptor(
         _ fileDescriptor: FileDescriptor,
+        processIdentifier: ProcessIdentifier,
         for event: Event
     ) -> SignalStream {
         return SignalStream { (continuation: SignalStream.Continuation) -> () in
@@ -311,34 +307,53 @@ final class AsyncIO: Sendable {
                     filter = Int16(EVFILT_WRITE)
                 }
 
-                _registration.withLock { storage in
-                    storage[fileDescriptor.rawValue] = continuation
+                // Hold the lock across the map insert and `kevent` so a
+                // concurrent `cancelAsyncIO` cannot slip in between the
+                // two steps and observe a half-registered descriptor.
+                let outcome: RegistrationOutcome = _registration.withLock { storage in
+                    guard
+                        storage.register(
+                            fileDescriptor: fileDescriptor.rawValue,
+                            continuation: continuation,
+                            processIdentifier: processIdentifier
+                        )
+                    else {
+                        return .alreadyCancelled
+                    }
+
+                    var kev = _makeKevent(
+                        ident: UInt(fileDescriptor.rawValue),
+                        filter: filter,
+                        flags: UInt16(EV_ADD | EV_ENABLE)
+                    )
+                    let rc = _kevent(
+                        state.kqueueFileDescriptor,
+                        &kev,
+                        1,
+                        nil,
+                        0,
+                        nil
+                    )
+
+                    if rc != 0 {
+                        let capturedError = errno
+                        _ = storage.removeRegistration(for: fileDescriptor.rawValue)
+                        let error: SubprocessError = .asyncIOFailed(
+                            reason: "failed to add \(fileDescriptor.rawValue) to kqueue",
+                            underlyingError: Errno(rawValue: capturedError)
+                        )
+                        return .failed(error)
+                    }
+                    return .registered
                 }
 
-                var kev = _makeKevent(
-                    ident: UInt(fileDescriptor.rawValue),
-                    filter: filter,
-                    flags: UInt16(EV_ADD | EV_ENABLE)
-                )
-                let rc = _kevent(
-                    state.kqueueFileDescriptor,
-                    &kev,
-                    1,
-                    nil,
-                    0,
-                    nil
-                )
-                if rc != 0 {
-                    _registration.withLock { storage in
-                        _ = storage.removeValue(forKey: fileDescriptor.rawValue)
-                    }
-                    let capturedError = errno
-                    let error: SubprocessError = .asyncIOFailed(
-                        reason: "failed to add \(fileDescriptor.rawValue) to kqueue",
-                        underlyingError: Errno(rawValue: capturedError)
-                    )
+                switch outcome {
+                case .registered:
+                    break
+                case .alreadyCancelled:
+                    continuation.finish()
+                case .failed(let error):
                     continuation.finish(throwing: error)
-                    return
                 }
             case .failure(let setupError):
                 continuation.finish(throwing: setupError)
@@ -350,37 +365,82 @@ final class AsyncIO: Sendable {
     internal func removeRegistration(for fileDescriptor: FileDescriptor) throws(SubprocessError) {
         switch self.state {
         case .success(let state):
-            let registration = _registration.withLock { store in
-                return store.removeValue(forKey: fileDescriptor.rawValue)
+            let c = _registration.withLock { store -> SignalStream.Continuation? in
+                guard
+                    let continuation = store.removeRegistration(
+                        for: fileDescriptor.rawValue
+                    )
+                else {
+                    return nil
+                }
+
+                for filter in [EVFILT_READ, EVFILT_WRITE] {
+                    var kev = _makeKevent(
+                        ident: UInt(fileDescriptor.rawValue),
+                        filter: Int16(filter),
+                        flags: UInt16(EV_DELETE)
+                    )
+                    _ = _kevent(
+                        state.kqueueFileDescriptor,
+                        &kev,
+                        1,
+                        nil,
+                        0,
+                        nil
+                    )
+                }
+
+                return continuation
             }
-            guard let registration else {
-                return
-            }
-            registration.finish()
-            var kev = _makeKevent(
-                ident: UInt(fileDescriptor.rawValue),
-                filter: Int16(EVFILT_READ),
-                flags: UInt16(EV_DELETE)
-            )
-            _ = _kevent(
-                state.kqueueFileDescriptor,
-                &kev,
-                1,
-                nil,
-                0,
-                nil
-            )
-            kev.filter = Int16(EVFILT_WRITE)
-            _ = _kevent(
-                state.kqueueFileDescriptor,
-                &kev,
-                1,
-                nil,
-                0,
-                nil
-            )
+            c?.finish()
         case .failure(let setupFailure):
             throw setupFailure
+        }
+    }
+
+    internal func cancelAsyncIO(for processIdentifier: ProcessIdentifier) throws(SubprocessError) {
+        switch self.state {
+        case .success(let state):
+            let cancelledContinuations: [SignalStream.Continuation] = _registration.withLock { storage in
+                let previousRegistrations = storage.cancel(processIdentifier: processIdentifier)
+                guard !previousRegistrations.isEmpty else {
+                    return []
+                }
+                var toBeCancelled: [SignalStream.Continuation] = []
+                for registration in previousRegistrations {
+                    toBeCancelled.append(registration.continuation)
+
+                    for filter in [EVFILT_READ, EVFILT_WRITE] {
+                        var kev = _makeKevent(
+                            ident: UInt(registration.fileDescriptor),
+                            filter: Int16(filter),
+                            flags: UInt16(EV_DELETE)
+                        )
+                        _ = _kevent(
+                            state.kqueueFileDescriptor,
+                            &kev,
+                            1,
+                            nil,
+                            0,
+                            nil
+                        )
+                    }
+                }
+
+                return toBeCancelled
+            }
+
+            for c in cancelledContinuations {
+                c.finish()
+            }
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    internal func cleanup(processIdentifier: ProcessIdentifier) {
+        _registration.withLock { storage in
+            storage.remove(processIdentifier: processIdentifier)
         }
     }
 }

--- a/Sources/Subprocess/IO/AsyncIO+Linux.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Linux.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Linux AsyncIO implementation based on epoll
+/// Linux AsyncIO implementation based on epoll.
 
 #if os(Linux) || os(Android)
 
@@ -32,10 +32,7 @@ import _SubprocessCShims
 import Synchronization
 
 private let _epollEventSize = 256
-private let _registration:
-    Mutex<
-        [PlatformFileDescriptor: SignalStream.Continuation]
-    > = Mutex([:])
+private let _registration: Mutex<Registration> = Mutex(Registration())
 
 final class AsyncIO: Sendable {
 
@@ -66,7 +63,7 @@ final class AsyncIO: Sendable {
     private let shutdownFlag: Atomic<UInt8> = Atomic(0)
 
     internal init() {
-        // Create main epoll fd
+        // Create the main epoll fd.
         let epollFileDescriptor = epoll_create1(CInt(EPOLL_CLOEXEC))
         guard epollFileDescriptor >= 0 else {
             let error: SubprocessError = .asyncIOFailed(
@@ -76,7 +73,7 @@ final class AsyncIO: Sendable {
             self.state = .failure(error)
             return
         }
-        // Create shutdownFileDescriptor
+        // Create the shutdown file descriptor.
         let shutdownFileDescriptor = eventfd(0, CInt(EFD_NONBLOCK | EFD_CLOEXEC))
         guard shutdownFileDescriptor >= 0 else {
             let error: SubprocessError = .asyncIOFailed(
@@ -87,7 +84,7 @@ final class AsyncIO: Sendable {
             return
         }
 
-        // Register shutdownFileDescriptor with epoll
+        // Register the shutdown file descriptor with epoll.
         var event = epoll_event(
             events: EPOLLIN.rawValue,
             data: epoll_data(fd: shutdownFileDescriptor)
@@ -107,7 +104,7 @@ final class AsyncIO: Sendable {
             return
         }
 
-        // Create thread data
+        // Create the thread context.
         let context = MonitorThreadContext(
             epollFileDescriptor: epollFileDescriptor,
             shutdownFileDescriptor: shutdownFileDescriptor
@@ -116,10 +113,11 @@ final class AsyncIO: Sendable {
         do throws(Errno) {
             thread = try pthread_create {
                 func reportError(_ error: SubprocessError) {
-                    _registration.withLock { store in
-                        for continuation in store.values {
-                            continuation.finish(throwing: error)
-                        }
+                    let continuations = _registration.withLock { store in
+                        return store.allContinuations()
+                    }
+                    for continuation in continuations {
+                        continuation.finish(throwing: error)
                     }
                 }
 
@@ -128,7 +126,7 @@ final class AsyncIO: Sendable {
                     count: _epollEventSize
                 )
 
-                // Enter the monitor loop
+                // Enter the monitor loop.
                 monitorLoop: while true {
                     let eventCount = epoll_wait(
                         context.epollFileDescriptor,
@@ -138,9 +136,9 @@ final class AsyncIO: Sendable {
                     )
                     if eventCount < 0 {
                         if errno == EINTR || errno == EAGAIN {
-                            continue // interrupted by signal; try again
+                            continue // Interrupted by a signal; try again.
                         }
-                        // Report other errors
+                        // Report other errors.
                         let error: SubprocessError = .asyncIOFailed(
                             reason: "epoll_wait failed",
                             underlyingError: Errno(rawValue: errno)
@@ -152,8 +150,8 @@ final class AsyncIO: Sendable {
                     for index in 0..<Int(eventCount) {
                         let event = events[index]
                         let targetFileDescriptor = event.data.fd
-                        // Breakout the monitor loop if we received shutdown
-                        // from the shutdownFD
+                        // Break out of the monitor loop on a shutdown signal
+                        // from `shutdownFileDescriptor`.
                         if targetFileDescriptor == context.shutdownFileDescriptor {
                             var buf: UInt64 = 0
                             withUnsafeMutableBytes(of: &buf) { ptr in
@@ -164,12 +162,9 @@ final class AsyncIO: Sendable {
                             break monitorLoop
                         }
 
-                        // Notify the continuation
+                        // Notify the continuation.
                         let continuation = _registration.withLock { store -> SignalStream.Continuation? in
-                            if let continuation = store[targetFileDescriptor] {
-                                return continuation
-                            }
-                            return nil
+                            return store.continuation(for: targetFileDescriptor)
                         }
                         continuation?.yield(true)
                     }
@@ -202,17 +197,17 @@ final class AsyncIO: Sendable {
         }
 
         guard self.shutdownFlag.add(1, ordering: .sequentiallyConsistent).newValue == 1 else {
-            // We already closed this AsyncIO
+            // This `AsyncIO` was already shut down.
             return
         }
         var one: UInt64 = 1
-        // Wake up the thread for shutdown
+        // Wake the monitor thread so it can exit.
         let shutdownFd = FileDescriptor(rawValue: currentState.shutdownFileDescriptor)
         let epollFd = FileDescriptor(rawValue: currentState.epollFileDescriptor)
         withUnsafeBytes(of: &one) { ptr in
             _ = try? shutdownFd.write(ptr)
         }
-        // Cleanup the monitor thread
+        // Clean up the monitor thread.
         pthread_join(currentState.monitorThread, nil)
 
         var closeError: Errno? = nil
@@ -234,18 +229,19 @@ final class AsyncIO: Sendable {
 
     internal func registerFileDescriptor(
         _ fileDescriptor: FileDescriptor,
+        processIdentifier: ProcessIdentifier,
         for event: Event
     ) -> SignalStream {
         return SignalStream { (continuation: SignalStream.Continuation) -> () in
-            // If setup failed, nothing much we can do
+            // Nothing to do if setup failed.
             switch self.state {
             case .success(let state):
-                // Set file descriptor to be non blocking
+                // Set the file descriptor to non-blocking.
                 if let nonBlockingFdError = self.setNonblocking(for: fileDescriptor) {
                     continuation.finish(throwing: nonBlockingFdError)
                     return
                 }
-                // Register event
+                // Pick the event to register.
                 let targetEvent: EPOLL_EVENTS
                 switch event {
                 case .read:
@@ -254,33 +250,55 @@ final class AsyncIO: Sendable {
                     targetEvent = EPOLL_EVENTS(EPOLLOUT)
                 }
 
-                // Save the continuation (before calling epoll_ctl, so we don't miss any data)
-                _registration.withLock { storage in
-                    storage[fileDescriptor.rawValue] = continuation
-                }
-
-                var event = epoll_event(
-                    events: targetEvent.rawValue,
-                    data: epoll_data(fd: fileDescriptor.rawValue)
-                )
-                let rc = epoll_ctl(
-                    state.epollFileDescriptor,
-                    EPOLL_CTL_ADD,
-                    fileDescriptor.rawValue,
-                    &event
-                )
-                if rc != 0 {
-                    _registration.withLock { storage in
-                        _ = storage.removeValue(forKey: fileDescriptor.rawValue)
+                // Hold the lock across both the map insert and `epoll_ctl` so
+                // a concurrent `cancelAsyncIO` either runs entirely before
+                // (in which case `register` returns `false`) or entirely
+                // after (in which case it sees the descriptor in the map
+                // and in epoll). Without this, a cancellation could observe
+                // the map entry between `storage.register` and
+                // `epoll_ctl(EPOLL_CTL_ADD)` and try to delete a descriptor
+                // that isn't yet in the epoll set.
+                let outcome: RegistrationOutcome = _registration.withLock { storage in
+                    guard
+                        storage.register(
+                            fileDescriptor: fileDescriptor.rawValue,
+                            continuation: continuation,
+                            processIdentifier: processIdentifier
+                        )
+                    else {
+                        return .alreadyCancelled
                     }
 
-                    let capturedError = errno
-                    let error: SubprocessError = .asyncIOFailed(
-                        reason: "failed to add \(fileDescriptor.rawValue) to epoll list",
-                        underlyingError: Errno(rawValue: capturedError)
+                    var event = epoll_event(
+                        events: targetEvent.rawValue,
+                        data: epoll_data(fd: fileDescriptor.rawValue)
                     )
+                    let rc = epoll_ctl(
+                        state.epollFileDescriptor,
+                        EPOLL_CTL_ADD,
+                        fileDescriptor.rawValue,
+                        &event
+                    )
+
+                    if rc != 0 {
+                        let capturedError = errno
+                        _ = storage.removeRegistration(for: fileDescriptor.rawValue)
+                        let error: SubprocessError = .asyncIOFailed(
+                            reason: "failed to add \(fileDescriptor.rawValue) to epoll list",
+                            underlyingError: Errno(rawValue: capturedError)
+                        )
+                        return .failed(error)
+                    }
+                    return .registered
+                }
+
+                switch outcome {
+                case .registered:
+                    break
+                case .alreadyCancelled:
+                    continuation.finish()
+                case .failed(let error):
                     continuation.finish(throwing: error)
-                    return
                 }
             case .failure(let setupError):
                 continuation.finish(throwing: setupError)
@@ -292,27 +310,75 @@ final class AsyncIO: Sendable {
     internal func removeRegistration(for fileDescriptor: FileDescriptor) throws(SubprocessError) {
         switch self.state {
         case .success(let state):
-            let registration = _registration.withLock { store in
-                return store.removeValue(forKey: fileDescriptor.rawValue)
-            }
-            guard let registration else {
-                return
-            }
-            registration.finish()
-            let rc = epoll_ctl(
-                state.epollFileDescriptor,
-                EPOLL_CTL_DEL,
-                fileDescriptor.rawValue,
-                nil
-            )
-            guard rc == 0 else {
-                throw SubprocessError.asyncIOFailed(
-                    reason: "failed to remove \(fileDescriptor.rawValue) from epoll list",
-                    underlyingError: Errno(rawValue: errno)
+            let c = try _registration.withLock { store throws(SubprocessError) -> SignalStream.Continuation? in
+                guard
+                    let continuation = store.removeRegistration(
+                        for: fileDescriptor.rawValue
+                    )
+                else {
+                    return nil
+                }
+
+                let rc = epoll_ctl(
+                    state.epollFileDescriptor,
+                    EPOLL_CTL_DEL,
+                    fileDescriptor.rawValue,
+                    nil
                 )
+
+                if rc != 0 {
+                    throw SubprocessError.asyncIOFailed(
+                        reason: "failed to remove \(fileDescriptor.rawValue) from epoll list",
+                        underlyingError: Errno(rawValue: errno)
+                    )
+                }
+                return continuation
             }
-        case .failure(let setupFailure):
-            throw setupFailure
+            c?.finish()
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    internal func cancelAsyncIO(for processIdentifier: ProcessIdentifier) throws(SubprocessError) {
+        switch self.state {
+        case .success(let state):
+            let cancelledContinuations = try _registration.withLock { storage throws(SubprocessError) -> [SignalStream.Continuation] in
+                let previousRegistrations = storage.cancel(processIdentifier: processIdentifier)
+                guard !previousRegistrations.isEmpty else {
+                    return []
+                }
+                var toBeCancelled: [SignalStream.Continuation] = []
+                for registration in previousRegistrations {
+                    toBeCancelled.append(registration.continuation)
+
+                    let rc = epoll_ctl(
+                        state.epollFileDescriptor,
+                        EPOLL_CTL_DEL,
+                        registration.fileDescriptor,
+                        nil
+                    )
+                    if rc != 0 && errno != ENOENT {
+                        throw SubprocessError.asyncIOFailed(
+                            reason: "failed to remove \(registration.fileDescriptor) from epoll list",
+                            underlyingError: Errno(rawValue: errno)
+                        )
+                    }
+                }
+                return toBeCancelled
+            }
+
+            for c in cancelledContinuations {
+                c.finish()
+            }
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    internal func cleanup(processIdentifier: ProcessIdentifier) {
+        _registration.withLock { storage in
+            storage.remove(processIdentifier: processIdentifier)
         }
     }
 }

--- a/Sources/Subprocess/IO/AsyncIO+Unix.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Unix.swift
@@ -76,13 +76,15 @@ extension AsyncIO {
 
     func read(
         from diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier,
         upTo maxLength: Int
     ) async throws(SubprocessError) -> [UInt8]? {
-        return try await self.read(from: diskIO.descriptor(), upTo: maxLength)
+        return try await self.read(from: diskIO.descriptor(), for: processIdentifier, upTo: maxLength)
     }
 
     func read(
         from fileDescriptor: FileDescriptor,
+        for processIdentifier: ProcessIdentifier,
         upTo maxLength: Int
     ) async throws(SubprocessError) -> [UInt8]? {
         guard maxLength > 0 else {
@@ -99,22 +101,27 @@ extension AsyncIO {
         var resultBuffer: [UInt8] = Array(
             repeating: 0, count: bufferLength
         )
-        let signalStream = self.registerFileDescriptor(fileDescriptor, for: .read)
+        let signalStream = self.registerFileDescriptor(
+            fileDescriptor,
+            processIdentifier: processIdentifier,
+            for: .read
+        )
 
         do {
-            /// Outer loop: every iteration signals we are ready to read more data
+            /// Outer loop: every iteration signals that the descriptor is ready
+            /// for more data.
             for try await _ in signalStream {
-                /// Inner loop: repeatedly call `.read()` and read more data until:
-                /// 1. We reached EOF (read length is 0), in which case return the result
-                /// 2. We read `maxLength` bytes, in which case return the result
-                /// 3. `read()` returns -1 and sets `errno` to `EAGAIN` or `EWOULDBLOCK`. In
-                ///     this case we `break` out of the inner loop and wait `.read()` to be
-                ///     ready by `await`ing the next signal in the outer loop.
+                /// Inner loop: repeatedly call `read()` and read more data until:
+                /// 1. We reach EOF (read length is 0), in which case return the result.
+                /// 2. We read `maxLength` bytes, in which case return the result.
+                /// 3. `read()` returns -1 and sets `errno` to `EAGAIN` or `EWOULDBLOCK`.
+                ///    In this case `break` out of the inner loop and `await` the next
+                ///    signal in the outer loop.
                 while true {
                     let bytesRead: Int
                     do {
                         bytesRead = try resultBuffer.withUnsafeMutableBytes { bufferPointer in
-                            // Read directly into the buffer at the offset
+                            // Read directly into the buffer at the offset.
                             return try fileDescriptor.read(
                                 into: bufferPointer,
                                 retryOnInterrupt: true
@@ -125,10 +132,10 @@ extension AsyncIO {
                         let _errno = error as! Errno
 
                         if self.shouldWaitForNextSignal(with: _errno.rawValue) {
-                            // No more data for now wait for the next signal
+                            // No data available right now; wait for the next signal.
                             break
                         } else {
-                            // Throw all other errors
+                            // Throw all other errors.
                             try self.removeRegistration(for: fileDescriptor)
                             throw SubprocessError.failedToReadFromProcess(
                                 withUnderlyingError: _errno
@@ -137,8 +144,7 @@ extension AsyncIO {
                     }
 
                     if bytesRead > 0 {
-                        // Read some data
-                        // Return immediately so the caller can
+                        // Read some data. Return immediately so the caller can
                         // process it without waiting for the buffer to fill.
                         try self.removeRegistration(for: fileDescriptor)
                         resultBuffer.removeLast(resultBuffer.count - bytesRead)
@@ -148,16 +154,45 @@ extension AsyncIO {
                         try self.removeRegistration(for: fileDescriptor)
                         return nil
                     } else {
-                        // Should not happen
+                        // This branch is unreachable in practice.
                         throw SubprocessError.failedToReadFromProcess(
                             withUnderlyingError: nil
                         )
                     }
                 }
             }
+
+            // The signal stream finished without delivering more data. This
+            // happens when `cancelAsyncIO` runs because the child has exited
+            // and we want to stop waiting for an EOF that may never come (the
+            // pipe could be held open by an inherited grandchild). Try a final
+            // non-blocking read so we don't drop bytes that were already in
+            // the kernel buffer when cancellation arrived; subsequent calls
+            // keep draining one chunk at a time and then return EOF.
+            try self.removeRegistration(for: fileDescriptor)
+            let drainedLength = resultBuffer.withUnsafeMutableBytes { bufferPtr in
+                // The descriptor was set to non-blocking in `setNonblocking`,
+                // so this `read` returns immediately even if no data is ready.
+                do {
+                    return try fileDescriptor.read(
+                        into: bufferPtr,
+                        retryOnInterrupt: true
+                    )
+                } catch {
+                    // EAGAIN, EWOULDBLOCK, or another error: no more data
+                    // is available right now.
+                    return 0
+                }
+            }
+            if drainedLength > 0 {
+                resultBuffer.removeLast(resultBuffer.count - drainedLength)
+                return resultBuffer
+            }
+
+            return nil
         } catch {
             try self.removeRegistration(for: fileDescriptor)
-            // Reset error code to .failedToRead to match other platforms
+            // Reset the error code to `.failedToRead` to match other platforms.
             guard let originalError = error as? SubprocessError else {
                 throw SubprocessError.failedToReadFromProcess(
                     withUnderlyingError: nil
@@ -167,34 +202,40 @@ extension AsyncIO {
                 withUnderlyingError: originalError.underlyingError
             )
         }
-        return nil
     }
 
     func write(
         _ array: [UInt8],
-        to diskIO: borrowing IODescriptor
+        to diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> Int {
-        return try await self.write(array._bytes, to: diskIO)
+        return try await self.write(array._bytes, to: diskIO, for: processIdentifier)
     }
 
     func write(
         _ span: borrowing RawSpan,
-        to diskIO: borrowing IODescriptor
+        to diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> Int {
         guard span.byteCount > 0 else {
             return 0
         }
         let fileDescriptor = diskIO.descriptor()
-        let signalStream = self.registerFileDescriptor(fileDescriptor, for: .write)
+        let signalStream = self.registerFileDescriptor(
+            fileDescriptor,
+            processIdentifier: processIdentifier,
+            for: .write
+        )
         var writtenLength: Int = 0
         do {
-            /// Outer loop: every iteration signals we are ready to read more data
+            /// Outer loop: every iteration signals that the descriptor is ready
+            /// for more data.
             for try await _ in signalStream {
-                /// Inner loop: repeatedly call `.write()` and write more data until:
-                /// 1. We've written bytes.count bytes.
-                /// 2. `FileDescriptor.write()` throwws `Errno` with `EAGAIN` or `EWOULDBLOCK`. In
-                ///     this case we `break` out of the inner loop and wait `.write()` to be
-                ///     ready by `await`ing the next signal in the outer loop.
+                /// Inner loop: repeatedly call `write()` and write more data until:
+                /// 1. We've written `span.byteCount` bytes.
+                /// 2. `FileDescriptor.write()` throws `Errno` with `EAGAIN` or
+                ///    `EWOULDBLOCK`. In this case `break` out of the inner loop and
+                ///    `await` the next signal in the outer loop.
                 while true {
                     let written: Int
                     do {
@@ -211,10 +252,10 @@ extension AsyncIO {
                         let _errno = error as! Errno
 
                         if self.shouldWaitForNextSignal(with: _errno.rawValue) {
-                            // No more data for now wait for the next signal
+                            // The pipe is full right now; wait for the next signal.
                             break
                         } else {
-                            // Throw all other errors
+                            // Throw all other errors.
                             try self.removeRegistration(for: fileDescriptor)
                             throw SubprocessError.failedToWriteToProcess(
                                 withUnderlyingError: _errno
@@ -224,14 +265,22 @@ extension AsyncIO {
 
                     writtenLength += written
                     if writtenLength >= span.byteCount {
-                        // Wrote all data
+                        // Wrote all data.
                         try self.removeRegistration(for: fileDescriptor)
                         return writtenLength
                     }
                 }
             }
+
+            // The signal stream finished while data remained to write
+            // (typically because `cancelAsyncIO` ran after the child exited).
+            // Return whatever bytes the call already pushed so the caller
+            // observes a partial write rather than misreading silence as a
+            // successful zero-byte write.
+            try self.removeRegistration(for: fileDescriptor)
+            return writtenLength
         } catch {
-            // Reset error code to .failedToWrite to match other platforms
+            // Reset the error code to `.failedToWrite` to match other platforms.
             guard let originalError = error as? SubprocessError else {
                 throw SubprocessError.failedToWriteToProcess(
                     withUnderlyingError: error as? SubprocessError.UnderlyingError
@@ -241,7 +290,6 @@ extension AsyncIO {
                 withUnderlyingError: originalError.underlyingError
             )
         }
-        return 0
     }
 
     @inline(__always)
@@ -252,30 +300,176 @@ extension AsyncIO {
     static func queryPipeBufferSize(for fileDescriptor: IODescriptor.Descriptor) -> Int {
         #if os(Linux) || os(Android)
 
-        // Works on glibc, musl, and Bionic since kernel 2.6.35
+        // Works on glibc, musl, and Bionic since kernel 2.6.35.
         let sz = fcntl(fileDescriptor.rawValue, F_GETPIPE_SZ)
-        // Fall back to page size
+        // Fall back to the page size.
         return sz > 0 ? Int(sz) : systemPageSize
         #elseif canImport(Darwin) || os(OpenBSD)
-        // XNU and OpenBSD both set st_blksize to the pipe's current capacity
-        // in pipe_stat(). Undocumented on Darwin but stable; verify with a unit test.
+        // XNU and OpenBSD both set `st_blksize` to the pipe's current capacity
+        // in `pipe_stat()`. Undocumented on Darwin but stable; verify with a
+        // unit test.
         var st = stat()
         guard
             fstat(
                 fileDescriptor.rawValue, &st
             ) == 0, st.st_blksize > 0
         else {
-            // Fall back to page size
+            // Fall back to the page size.
             return systemPageSize
         }
         return Int(st.st_blksize)
         #else
-        // FreeBSD does not have `st.st_blksize` equivelent.
-        // pipe_stat() hardcodes st.st_blksize = PAGE_SIZE
-        // Use 64kb like other platforms
+        // FreeBSD does not have an `st.st_blksize` equivalent.
+        // `pipe_stat()` hardcodes `st.st_blksize = PAGE_SIZE`, so use 64 KB
+        // like other platforms.
         return 64 * 1024
         #endif
     }
+}
+
+/// A bookkeeping structure that maps file descriptors to their pending I/O
+/// continuations and groups those descriptors by the process that owns them.
+///
+/// The platform-specific `AsyncIO` backends use this type to find the
+/// continuation for a descriptor when the kernel reports activity, and to
+/// identify which descriptors belong to a process when the process exits and
+/// the I/O for it must be cancelled.
+internal struct Registration {
+    typealias Record = (continuation: SignalStream.Continuation, processIdentifier: ProcessIdentifier)
+    typealias CancelledContinuation = (continuation: SignalStream.Continuation, fileDescriptor: PlatformFileDescriptor)
+
+    private var fileDescriptorMap: [PlatformFileDescriptor: Record]
+    private var processIdentifierMap: [ProcessIdentifier: Set<PlatformFileDescriptor>]
+
+    /// The set of processes whose I/O has already been cancelled.
+    ///
+    /// `register` consults this set and rejects new registrations for any
+    /// process that appears in it. This prevents a registration that races
+    /// with `cancel` from establishing a stream that nothing will ever
+    /// cancel. Call `remove(processIdentifier:)` once the process is fully
+    /// reaped to keep this set bounded.
+    private var cancelledProcesses: Set<ProcessIdentifier>
+
+    init() {
+        self.fileDescriptorMap = [:]
+        self.processIdentifierMap = [:]
+        self.cancelledProcesses = Set()
+    }
+
+    /// Records a file descriptor as part of a process's pending I/O.
+    ///
+    /// - Parameters:
+    ///   - fileDescriptor: The descriptor to track.
+    ///   - continuation: The continuation to resume when the descriptor
+    ///     becomes ready or the I/O is cancelled.
+    ///   - processIdentifier: The process that owns the descriptor.
+    /// - Returns: `true` if the registration was added; `false` if the
+    ///   process has already been cancelled. When the function returns
+    ///   `false`, the caller must finish the supplied continuation
+    ///   immediately and skip any further setup such as attaching the
+    ///   descriptor to `epoll` or `kqueue`.
+    mutating func register(
+        fileDescriptor: PlatformFileDescriptor,
+        continuation: SignalStream.Continuation,
+        processIdentifier: ProcessIdentifier
+    ) -> Bool {
+        if self.cancelledProcesses.contains(processIdentifier) {
+            return false
+        }
+        self.fileDescriptorMap[fileDescriptor] = (continuation, processIdentifier)
+        var fileDescriptorSet = self.processIdentifierMap[processIdentifier] ?? Set()
+        fileDescriptorSet.insert(fileDescriptor)
+        self.processIdentifierMap[processIdentifier] = fileDescriptorSet
+        return true
+    }
+
+    /// Removes the registration for `fileDescriptor`.
+    ///
+    /// - Parameter fileDescriptor: The descriptor whose registration to drop.
+    /// - Returns: The continuation associated with the descriptor, or `nil`
+    ///   if no registration exists.
+    mutating func removeRegistration(
+        for fileDescriptor: PlatformFileDescriptor
+    ) -> SignalStream.Continuation? {
+        guard let content = self.fileDescriptorMap.removeValue(forKey: fileDescriptor) else {
+            return nil
+        }
+        if var fileDescriptorSet = self.processIdentifierMap[content.processIdentifier] {
+            fileDescriptorSet.remove(fileDescriptor)
+            self.processIdentifierMap[content.processIdentifier] = fileDescriptorSet
+        }
+        return content.continuation
+    }
+
+    /// Marks `processIdentifier` as cancelled and returns the descriptor
+    /// registrations to abort.
+    ///
+    /// Once a process is marked cancelled, subsequent calls to `register`
+    /// for that process return `false` until `remove(processIdentifier:)`
+    /// drops the marker.
+    ///
+    /// - Parameter processIdentifier: The process whose I/O to cancel.
+    /// - Returns: The registrations that the caller must finish. The
+    ///   array is empty when the process has no pending I/O.
+    mutating func cancel(
+        processIdentifier: ProcessIdentifier
+    ) -> [CancelledContinuation] {
+        self.cancelledProcesses.insert(processIdentifier)
+
+        guard
+            let existing = self.processIdentifierMap.removeValue(
+                forKey: processIdentifier
+            )
+        else {
+            return []
+        }
+
+        return existing.compactMap { fd in
+            guard let content = self.fileDescriptorMap.removeValue(forKey: fd) else {
+                return nil
+            }
+            return (content.continuation, fd)
+        }
+    }
+
+    /// Drops the cancellation marker for `processIdentifier`.
+    ///
+    /// Call this after the process is fully reaped and no further I/O for
+    /// it can occur, to keep `cancelledProcesses` from growing without
+    /// bound.
+    ///
+    /// - Parameter processIdentifier: The process to forget.
+    mutating func remove(processIdentifier: ProcessIdentifier) {
+        self.cancelledProcesses.remove(processIdentifier)
+    }
+
+    /// Returns the continuation registered for `fileDescriptor`, or `nil`
+    /// if none exists.
+    func continuation(for fileDescriptor: PlatformFileDescriptor) -> SignalStream.Continuation? {
+        return self.fileDescriptorMap[fileDescriptor]?.continuation
+    }
+
+    /// Returns every currently registered continuation.
+    ///
+    /// The platform backends call this when the monitor thread fails and
+    /// they need to surface the error to every awaiting reader and writer.
+    func allContinuations() -> [SignalStream.Continuation] {
+        return self.fileDescriptorMap.values.map { $0.continuation }
+    }
+}
+
+/// The result of a single attempt to register a file descriptor with the
+/// platform's I/O multiplexer.
+internal enum RegistrationOutcome {
+    /// The descriptor was added successfully.
+    case registered
+    /// The owning process has already been cancelled, so the registration
+    /// was rejected. The caller finishes the continuation without further
+    /// setup.
+    case alreadyCancelled
+    /// The platform syscall (such as `epoll_ctl` or `kevent`) reported an
+    /// error. The caller finishes the continuation by throwing this error.
+    case failed(SubprocessError)
 }
 
 extension Array: AsyncIO._ContiguousBytes where Element == UInt8 {}

--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Windows AsyncIO based on IO Completion Ports and Overlapped
+/// Windows AsyncIO implementation based on I/O completion ports and overlapped I/O.
 
 #if os(Windows)
 
@@ -25,10 +25,7 @@ import Synchronization
 
 private typealias SignalStream = AsyncThrowingStream<DWORD, any Error>
 private let shutdownPort: UInt64 = .max
-private let _registration:
-    Mutex<
-        [UInt64: SignalStream.Continuation]
-    > = Mutex([:])
+private let _registration: Mutex<Registration> = Mutex(Registration())
 
 final class AsyncIO: @unchecked Sendable {
 
@@ -79,14 +76,14 @@ final class AsyncIO: @unchecked Sendable {
             threadHandle = try begin_thread_x {
                 func reportError(_ error: SubprocessError) {
                     let continuations = _registration.withLock { store in
-                        return store.values
+                        return store.allContinuations()
                     }
                     for continuation in continuations {
                         continuation.finish(throwing: error)
                     }
                 }
 
-                // Monitor loop
+                // Monitor loop.
                 while true {
                     var bytesTransferred: DWORD = 0
                     var targetFileDescriptor: UInt64 = 0
@@ -101,18 +98,18 @@ final class AsyncIO: @unchecked Sendable {
                     )
                     if !monitorResult {
                         let lastError = GetLastError()
-                        if lastError == ERROR_BROKEN_PIPE {
-                            // We finished reading the handle. Signal EOF by
-                            // finishing the stream.
-                            // NOTE: here we deliberately leave now unused continuation
-                            // in the store. Windows does not offer an API to remove a
-                            // HANDLE from an IOCP port, therefore we leave the registration
-                            // to signify the HANDLE has already been resisted.
+                        // `ERROR_BROKEN_PIPE`: end of file.
+                        // `ERROR_OPERATION_ABORTED`: the I/O was cancelled by
+                        // `CancelIoEx`, typically because `cancelAsyncIO` ran
+                        // when the child exited. In both cases finish the
+                        // per-handle stream so the awaiting read or write
+                        // returns to its caller. Leave the registration in
+                        // `store` because Windows can't remove a HANDLE from
+                        // the IOCP, so the entry doubles as a marker that the
+                        // handle is registered until it's closed.
+                        if lastError == ERROR_BROKEN_PIPE || lastError == ERROR_OPERATION_ABORTED {
                             let continuation = _registration.withLock { store -> SignalStream.Continuation? in
-                                if let continuation = store[targetFileDescriptor] {
-                                    return continuation
-                                }
-                                return nil
+                                return store.continuation(for: targetFileDescriptor)
                             }
                             continuation?.finish()
                             continue
@@ -126,16 +123,13 @@ final class AsyncIO: @unchecked Sendable {
                         }
                     }
 
-                    // Breakout the monitor loop if we received shutdown from the shutdownFD
+                    // Break out of the monitor loop on a shutdown signal.
                     if targetFileDescriptor == shutdownPort {
                         break
                     }
-                    // Notify the continuations
+                    // Notify the continuation.
                     let continuation = _registration.withLock { store -> SignalStream.Continuation? in
-                        if let continuation = store[targetFileDescriptor] {
-                            return continuation
-                        }
-                        return nil
+                        return store.continuation(for: targetFileDescriptor)
                     }
                     continuation?.yield(bytesTransferred)
                 }
@@ -163,12 +157,11 @@ final class AsyncIO: @unchecked Sendable {
         else {
             return
         }
-        // Make sure we don't shutdown the same instance twice
+        // Don't shut down the same instance twice.
         guard self.shutdownFlag.add(1, ordering: .relaxed).newValue == 1 else {
-            // We already closed this AsyncIO
             return
         }
-        // Post status to shutdown HANDLE
+        // Post a status to the shutdown HANDLE.
         // swift-format-ignore
         PostQueuedCompletionStatus(
             ioPort,       // CompletionPort
@@ -176,57 +169,77 @@ final class AsyncIO: @unchecked Sendable {
             shutdownPort, // Completion key to post status
             nil           // Overlapped
         )
-        // Wait for monitor thread to exit
+        // Wait for the monitor thread to exit.
         WaitForSingleObject(monitorThreadHandle, INFINITE)
         CloseHandle(ioPort)
         CloseHandle(monitorThreadHandle)
     }
 
-    private func registerHandle(_ handle: HANDLE) -> SignalStream {
+    private func registerHandle(
+        _ handle: HANDLE,
+        processIdentifier: ProcessIdentifier
+    ) -> SignalStream {
         return SignalStream { (continuation: SignalStream.Continuation) in
             switch self.ioCompletionPort {
             case .success(let ioPort):
-                // Make sure thread setup also succeed
+                // Make sure thread setup also succeeded.
                 if case .failure(let error) = monitorThread {
                     continuation.finish(throwing: error)
                     return
                 }
                 let completionKey = UInt64(UInt(bitPattern: handle))
-                // Windows does not offer an API to remove a handle
-                // from given ioCompletionPort. If this handle has already
-                // been registered we simply need to update the continuation
-                let registrationFound = _registration.withLock { storage in
-                    if storage[completionKey] != nil {
-                        // Old registration found. This means this handle has
-                        // already been registered. We simply need to update
-                        // the continuation saved
-                        storage[completionKey] = continuation
-                        return true
-                    } else {
-                        return false
+
+                // Hold the lock across both the map insert and
+                // `CreateIoCompletionPort` so a concurrent `cancelAsyncIO`
+                // cannot mark the process cancelled between the two steps
+                // and leave behind a HANDLE that's bound to the IOCP but
+                // missing the cancellation marker.
+                let outcome: RegistrationOutcome = _registration.withLock { storage in
+                    let result = storage.register(
+                        completionKey: completionKey,
+                        continuation: continuation,
+                        processIdentifier: processIdentifier
+                    )
+                    switch result {
+                    case .alreadyCancelled:
+                        return .alreadyCancelled
+                    case .updated:
+                        // The handle was already attached to the IOCP by a
+                        // previous read or write; the new continuation
+                        // replaces the previous one in the map.
+                        return .registered
+                    case .registered:
+                        // Per the Windows documentation, the function
+                        // returns the handle of the existing I/O completion
+                        // port on success.
+                        guard
+                            CreateIoCompletionPort(
+                                handle, ioPort, completionKey, 0
+                            ) == ioPort
+                        else {
+                            let capturedError = GetLastError()
+                            // Roll back the registration so a future
+                            // attempt (such as the next read on this
+                            // handle) gets a clean slate rather than
+                            // seeing a stale entry.
+                            _ = storage.removeRegistration(for: completionKey)
+                            let error: SubprocessError = .asyncIOFailed(
+                                reason: "CreateIoCompletionPort failed",
+                                underlyingError: SubprocessError.WindowsError(rawValue: capturedError)
+                            )
+                            return .failed(error)
+                        }
+                        return .registered
                     }
                 }
-                if registrationFound {
-                    return
-                }
 
-                // Windows Documentation: The function returns the handle
-                // of the existing I/O completion port if successful
-                guard
-                    CreateIoCompletionPort(
-                        handle, ioPort, completionKey, 0
-                    ) == ioPort
-                else {
-                    let error: SubprocessError = .asyncIOFailed(
-                        reason: "CreateIoCompletionPort failed",
-                        underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
-                    )
+                switch outcome {
+                case .registered:
+                    break
+                case .alreadyCancelled:
+                    continuation.finish()
+                case .failed(let error):
                     continuation.finish(throwing: error)
-                    return
-                }
-                // Now save the continuation
-                _registration.withLock { storage in
-                    storage[completionKey] = continuation
                 }
             case .failure(let error):
                 continuation.finish(throwing: error)
@@ -237,19 +250,55 @@ final class AsyncIO: @unchecked Sendable {
     internal func removeRegistration(for handle: HANDLE) {
         let completionKey = UInt64(UInt(bitPattern: handle))
         _registration.withLock { storage in
-            _ = storage.removeValue(forKey: completionKey)
+            _ = storage.removeRegistration(for: completionKey)
+        }
+    }
+
+    internal func cancelAsyncIO(for processIdentifier: ProcessIdentifier) throws(SubprocessError) {
+        try _registration.withLock { storage throws(SubprocessError) in
+            let completionKeys = storage.cancel(processIdentifier: processIdentifier)
+
+            for key in completionKeys {
+                guard let handle = HANDLE(bitPattern: UInt(truncatingIfNeeded: key)) else {
+                    continue
+                }
+                // `CancelIoEx` with a `NULL` overlapped cancels every pending
+                // I/O on the handle.
+                let result = CancelIoEx(handle, nil)
+                // ERROR_NOT_FOUND with lpOverlapped == nil specifically means:
+                // the handle is valid, but at the moment of the call there are no
+                // cancellable pending I/O requests on it issued by the current process.
+                // This is most likely due to all pending IOs have finished. Treat
+                // `ERROR_NOT_FOUND` as success, which is sementatically correct:
+                // nothing to cancel is successfully cancelled.
+                if !result && GetLastError() != ERROR_NOT_FOUND {
+                    throw SubprocessError.asyncIOFailed(reason: "Failed to cancel AsyncIO for \(handle)")
+                }
+            }
+        }
+    }
+
+    internal func cleanup(processIdentifier: ProcessIdentifier) {
+        _registration.withLock { storage in
+            storage.remove(processIdentifier: processIdentifier)
         }
     }
 
     func read(
         from diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier,
         upTo maxLength: Int
     ) async throws(SubprocessError) -> [UInt8]? {
-        return try await self.read(from: diskIO.descriptor(), upTo: maxLength)
+        return try await self.read(
+            from: diskIO.descriptor(),
+            for: processIdentifier,
+            upTo: maxLength
+        )
     }
 
     func read(
         from handle: HANDLE,
+        for processIdentifier: ProcessIdentifier,
         upTo maxLength: Int
     ) async throws(SubprocessError) -> [UInt8]? {
         guard maxLength > 0 else {
@@ -266,21 +315,24 @@ final class AsyncIO: @unchecked Sendable {
         var resultBuffer: [UInt8] = Array(
             repeating: 0, count: bufferLength
         )
-        var signalStream = self.registerHandle(handle).makeAsyncIterator()
+        var signalStream = self.registerHandle(
+            handle,
+            processIdentifier: processIdentifier
+        ).makeAsyncIterator()
 
-        // We use an empty `_OVERLAPPED()` here because `ReadFile` below
-        // only reads non-seekable files, aka pipes.
+        // Use an empty `_OVERLAPPED()` here because `ReadFile` below only
+        // reads non-seekable files (pipes).
         var overlapped = _OVERLAPPED()
         let succeed = resultBuffer.withUnsafeMutableBufferPointer { bufferPointer in
-            // Get a pointer to the memory at the specified offset
-            // Windows ReadFile uses DWORD for target count, which means we can only
-            // read up to DWORD (aka UInt32) max.
+            // Get a pointer to the memory at the specified offset.
+            // Windows `ReadFile` uses `DWORD` for target count, which means
+            // the call can read at most `DWORD.max` (`UInt32.max`) bytes.
             let targetCount: DWORD = self.calculateRemainingCount(
                 totalCount: bufferPointer.count,
                 readCount: 0
             )
 
-            // Read directly into the buffer at the offset
+            // Read directly into the buffer at the offset.
             return ReadFile(
                 handle,
                 bufferPointer.baseAddress!,
@@ -291,11 +343,12 @@ final class AsyncIO: @unchecked Sendable {
         }
 
         if !succeed {
-            // It is expected `ReadFile` to return `false` in async mode.
-            // Make sure we only get `ERROR_IO_PENDING` or `ERROR_BROKEN_PIPE`
+            // `ReadFile` is expected to return `false` in async mode.
+            // Confirm the call returned `ERROR_IO_PENDING` or
+            // `ERROR_BROKEN_PIPE`.
             let lastError = GetLastError()
             if lastError == ERROR_BROKEN_PIPE {
-                // We reached EOF before any data was read
+                // Reached end of file before any data was read.
                 return nil
             }
             guard lastError == ERROR_IO_PENDING else {
@@ -306,10 +359,20 @@ final class AsyncIO: @unchecked Sendable {
             }
 
         }
-        // Now wait for read to finish
+        // Wait for the read to finish.
         let bytesRead: DWORD
         do {
-            bytesRead = try await signalStream.next() ?? 0
+            guard let next = try await signalStream.next() else {
+                // The signal stream finished without delivering data. This
+                // happens when `cancelAsyncIO` ran (typically because the
+                // child exited) and the IOCP delivered an
+                // `ERROR_OPERATION_ABORTED` completion. By the time the
+                // monitor thread finishes the stream, the kernel has
+                // released its references to `resultBuffer` and
+                // `overlapped`, so it's safe to return.
+                return nil
+            }
+            bytesRead = next
         } catch {
             if let subprocessError = error as? SubprocessError {
                 throw subprocessError
@@ -320,7 +383,7 @@ final class AsyncIO: @unchecked Sendable {
         }
 
         if bytesRead == 0 {
-            // EOF
+            // End of file.
             return nil
         }
 
@@ -332,28 +395,33 @@ final class AsyncIO: @unchecked Sendable {
 
     func write(
         _ array: [UInt8],
-        to diskIO: borrowing IODescriptor
+        to diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> Int {
-        return try await self.write(array._bytes, to: diskIO)
+        return try await self.write(array._bytes, to: diskIO, for: processIdentifier)
     }
 
     func write(
         _ span: borrowing RawSpan,
-        to diskIO: borrowing IODescriptor
+        to diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> Int {
         guard span.byteCount > 0 else {
             return 0
         }
         let handle = diskIO.descriptor()
-        var signalStream = self.registerHandle(handle).makeAsyncIterator()
+        var signalStream = self.registerHandle(
+            handle,
+            processIdentifier: processIdentifier
+        ).makeAsyncIterator()
         var writtenLength: Int = 0
         while true {
-            // We use an empty `_OVERLAPPED()` here because `WriteFile` below
-            // only writes to non-seekable files, aka pipes.
+            // Use an empty `_OVERLAPPED()` here because `WriteFile` below
+            // only writes to non-seekable files (pipes).
             var overlapped = _OVERLAPPED()
             let succeed = span.withUnsafeBytes { ptr in
-                // Windows WriteFile uses DWORD for target count
-                // which means we can only write up to DWORD max
+                // Windows `WriteFile` uses `DWORD` for target count, which
+                // means the call can write at most `DWORD.max` bytes.
                 let remainingLength: DWORD = self.calculateRemainingCount(
                     totalCount: ptr.count,
                     readCount: writtenLength
@@ -369,8 +437,8 @@ final class AsyncIO: @unchecked Sendable {
                 )
             }
             if !succeed {
-                // It is expected `WriteFile` to return `false` in async mode.
-                // Make sure we only get `ERROR_IO_PENDING`
+                // `WriteFile` is expected to return `false` in async mode.
+                // Confirm the call returned `ERROR_IO_PENDING`.
                 let lastError = GetLastError()
                 guard lastError == ERROR_IO_PENDING else {
                     let error: SubprocessError = .failedToWriteToProcess(
@@ -380,11 +448,20 @@ final class AsyncIO: @unchecked Sendable {
                 }
 
             }
-            // Now wait for write to finish
+            // Wait for the write to finish.
             let bytesWritten: DWORD
 
             do {
-                bytesWritten = try await signalStream.next() ?? 0
+                guard let next = try await signalStream.next() else {
+                    // The signal stream finished while data remained to
+                    // write — typically because `cancelAsyncIO` ran after
+                    // the child exited. Return whatever bytes the call
+                    // already pushed so the caller observes a partial
+                    // write rather than misreading silence as a successful
+                    // zero-byte write.
+                    return writtenLength
+                }
+                bytesWritten = next
             } catch {
                 if let subprocessError = error as? SubprocessError {
                     throw subprocessError
@@ -401,26 +478,180 @@ final class AsyncIO: @unchecked Sendable {
         }
     }
 
-    // Windows ReadFile uses DWORD for target count, which means we can only
-    // read up to DWORD (aka UInt32) max.
+    // Windows `ReadFile` uses `DWORD` for target count, which means the
+    // call can read at most `DWORD.max` (`UInt32.max`) bytes.
     private func calculateRemainingCount(totalCount: Int, readCount: Int) -> DWORD {
-        // We support both 32bit and 64bit systems for Windows
+        // Subprocess supports both 32-bit and 64-bit Windows.
         if MemoryLayout<Int>.size == MemoryLayout<Int32>.size {
-            // On 32 bit systems we don't have to worry about overflowing
+            // 32-bit systems can't overflow the count.
             return DWORD(truncatingIfNeeded: totalCount - readCount)
         } else {
-            // On 64 bit systems we need to cap the count at DWORD max
+            // On 64-bit systems, cap the count at `DWORD.max`.
             return DWORD(truncatingIfNeeded: min(totalCount - readCount, Int(DWORD.max)))
         }
     }
 
     static func queryPipeBufferSize(for fileDescriptor: IODescriptor.Descriptor) -> Int {
         // Windows does not provide an API to query pipe buffer size.
-        // Node `getDefaultHighWaterMark` uses 16k
+        // Node's `getDefaultHighWaterMark` uses 16 KB.
         return 16 * 1024
     }
 }
 
 extension Array: AsyncIO._ContiguousBytes where Element == UInt8 {}
+
+/// A bookkeeping structure that maps IOCP completion keys to their pending
+/// I/O continuations and groups those keys by the process that owns them.
+///
+/// `AsyncIO+Windows` uses this type to find the continuation for a handle
+/// when the IOCP reports a completion, and to identify which handles
+/// belong to a process when the process exits and the I/O for it must be
+/// cancelled with `CancelIoEx`.
+private struct Registration {
+    typealias CompletionKey = UInt64
+    typealias Record = (continuation: SignalStream.Continuation, processIdentifier: ProcessIdentifier)
+
+    private var handleMap: [CompletionKey: Record]
+    private var processIdentifierMap: [ProcessIdentifier: Set<CompletionKey>]
+
+    /// The set of processes whose I/O has already been cancelled.
+    ///
+    /// `register` consults this set and rejects new registrations for any
+    /// process that appears in it. This prevents a registration that
+    /// races with `cancel` from establishing a stream that nothing will
+    /// ever cancel.
+    private var cancelledProcesses: Set<ProcessIdentifier>
+
+    init() {
+        self.handleMap = [:]
+        self.processIdentifierMap = [:]
+        self.cancelledProcesses = Set()
+    }
+
+    /// The result of a single attempt to register a handle.
+    enum RegisterResult {
+        /// The first time this completion key was seen. The caller still
+        /// needs to attach the handle to the IOCP via
+        /// `CreateIoCompletionPort`.
+        case registered
+        /// The completion key was already present. Windows can't
+        /// unregister from an IOCP, so the existing attachment is reused
+        /// and only the continuation is updated.
+        case updated
+        /// The owning process is already cancelled. The caller finishes
+        /// the supplied continuation immediately and skips the IOCP
+        /// setup.
+        case alreadyCancelled
+    }
+
+    /// Records a completion key as part of a process's pending I/O.
+    ///
+    /// - Parameters:
+    ///   - completionKey: The IOCP completion key to track.
+    ///   - continuation: The continuation to resume when the IOCP reports
+    ///     a completion or the I/O is cancelled.
+    ///   - processIdentifier: The process that owns the handle.
+    /// - Returns: A `RegisterResult` describing what the caller must do
+    ///   next.
+    mutating func register(
+        completionKey: CompletionKey,
+        continuation: SignalStream.Continuation,
+        processIdentifier: ProcessIdentifier
+    ) -> RegisterResult {
+        if self.cancelledProcesses.contains(processIdentifier) {
+            return .alreadyCancelled
+        }
+
+        var isNew = true
+        if let oldRecord = self.handleMap.removeValue(forKey: completionKey) {
+            oldRecord.continuation.finish()
+            isNew = false
+        }
+
+        self.handleMap[completionKey] = (continuation, processIdentifier)
+        if isNew {
+            var set = self.processIdentifierMap[processIdentifier] ?? Set()
+            set.insert(completionKey)
+            self.processIdentifierMap[processIdentifier] = set
+        }
+        return isNew ? .registered : .updated
+    }
+
+    /// Removes the registration for `completionKey`.
+    ///
+    /// - Parameter completionKey: The completion key whose registration
+    ///   to drop.
+    /// - Returns: The continuation associated with the key, or `nil` if
+    ///   no registration exists.
+    mutating func removeRegistration(
+        for completionKey: CompletionKey
+    ) -> SignalStream.Continuation? {
+        guard let record = self.handleMap.removeValue(forKey: completionKey) else {
+            return nil
+        }
+        if var set = self.processIdentifierMap[record.processIdentifier] {
+            set.remove(completionKey)
+            if set.isEmpty {
+                self.processIdentifierMap.removeValue(forKey: record.processIdentifier)
+            } else {
+                self.processIdentifierMap[record.processIdentifier] = set
+            }
+        }
+        return record.continuation
+    }
+
+    /// Marks `processIdentifier` as cancelled and returns the completion
+    /// keys whose pending I/O the caller must abort.
+    ///
+    /// The continuations remain in `handleMap` so the IOCP completion
+    /// that follows `CancelIoEx` can be routed back to the right
+    /// awaiting task. Entries are removed from `handleMap` later, when
+    /// each handle is closed via `_safelyClose`.
+    ///
+    /// - Parameter processIdentifier: The process whose I/O to cancel.
+    /// - Returns: The completion keys to pass to `CancelIoEx`.
+    mutating func cancel(processIdentifier: ProcessIdentifier) -> Set<CompletionKey> {
+        self.cancelledProcesses.insert(processIdentifier)
+        return self.processIdentifierMap.removeValue(forKey: processIdentifier) ?? []
+    }
+
+    /// Drops the cancellation marker for `processIdentifier`.
+    ///
+    /// Call this after the process has fully exited and no further I/O
+    /// for it can occur, to keep `cancelledProcesses` from growing
+    /// without bound.
+    ///
+    /// - Parameter processIdentifier: The process to forget.
+    mutating func remove(processIdentifier: ProcessIdentifier) {
+        self.cancelledProcesses.remove(processIdentifier)
+    }
+
+    /// Returns the continuation registered for `completionKey`, or `nil`
+    /// if none exists.
+    func continuation(for completionKey: CompletionKey) -> SignalStream.Continuation? {
+        return self.handleMap[completionKey]?.continuation
+    }
+
+    /// Returns every currently registered continuation.
+    ///
+    /// The monitor thread calls this when it fails and needs to surface
+    /// the error to every awaiting reader and writer.
+    func allContinuations() -> [SignalStream.Continuation] {
+        return self.handleMap.values.map { $0.continuation }
+    }
+}
+
+/// The result of a single attempt to register a handle with the IOCP.
+private enum RegistrationOutcome {
+    /// The handle was added successfully.
+    case registered
+    /// The owning process has already been cancelled, so the registration
+    /// was rejected. The caller finishes the continuation without further
+    /// setup.
+    case alreadyCancelled
+    /// `CreateIoCompletionPort` reported an error. The caller finishes
+    /// the continuation by throwing this error.
+    case failed(SubprocessError)
+}
 
 #endif

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -254,9 +254,11 @@ extension InputProtocol {
 public final actor StandardInputWriter: Sendable {
 
     internal var diskIO: IODescriptor
+    internal let processIdentifier: ProcessIdentifier
 
-    init(diskIO: consuming IODescriptor) {
+    init(diskIO: consuming IODescriptor, processIdentifier: ProcessIdentifier) {
         self.diskIO = diskIO
+        self.processIdentifier = processIdentifier
     }
 
     /// Writes an array of bytes to the subprocess's standard input.
@@ -267,7 +269,7 @@ public final actor StandardInputWriter: Sendable {
     public func write(
         _ array: [UInt8]
     ) async throws(SubprocessError) -> Int {
-        return try await AsyncIO.shared.write(array, to: self.diskIO)
+        return try await AsyncIO.shared.write(array, to: self.diskIO, for: self.processIdentifier)
     }
 
     /// Writes a raw span to the subprocess's standard input.
@@ -277,7 +279,7 @@ public final actor StandardInputWriter: Sendable {
     ///     See ``underlyingError`` for more details.
     /// - Returns: The number of bytes written.
     public func write(_ span: borrowing RawSpan) async throws(SubprocessError) -> Int {
-        return try await AsyncIO.shared.write(span, to: self.diskIO)
+        return try await AsyncIO.shared.write(span, to: self.diskIO, for: self.processIdentifier)
     }
 
     /// Writes a string to the subprocess's standard input.

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -125,16 +125,17 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
     public let maxSize: Int
 
     internal func captureOutput(
-        from diskIO: consuming IODescriptor
+        from diskIO: consuming IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> [UInt8] {
         var result: [UInt8] = []
         do {
             var maxLength = self.maxSize
             if maxLength != .max {
-                // If we actually have a max length, attempt to read one
-                // more byte to determine whether output exceeds the limit
+                // Read one extra byte to detect output that exceeds the
+                // limit.
                 maxLength += 1
-                // We can also reserve capacity
+                // Reserve capacity to avoid reallocations.
                 result.reserveCapacity(maxLength)
             }
             let bufferSize = AsyncIO.queryPipeBufferSize(for: diskIO.descriptor())
@@ -144,6 +145,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
                 guard
                     let chunk = try await AsyncIO.shared.read(
                         from: diskIO,
+                        for: processIdentifier,
                         upTo: min(bufferSize, remaining)
                     )
                 else {
@@ -335,19 +337,21 @@ extension OutputProtocol {
         return try CreatedPipe(closeWhenDone: true, purpose: .output)
     }
 
-    /// Capture the output from the subprocess up to maxSize
+    /// Captures the output from the subprocess, up to `maxSize` bytes.
     @_disfavoredOverload
     internal func captureOutput(
-        from diskIO: consuming IODescriptor?
+        from diskIO: consuming IODescriptor?,
+        for processIdentifier: ProcessIdentifier
     ) async throws -> OutputType {
         if OutputType.self == Void.self {
             try diskIO?.safelyClose()
             return () as! OutputType
         }
-        // `diskIO` is only `nil` for any types that conform to `OutputProtocol`
-        // and have `Void` as ``OutputType` (i.e. `DiscardedOutput`). Since we
-        // made sure `OutputType` is not `Void` on the line above, `diskIO`
-        // must not be nil; otherwise, this is a programmer error.
+        // `diskIO` is only `nil` for types that conform to `OutputProtocol`
+        // and have `Void` as `OutputType` (such as `DiscardedOutput`). The
+        // line above already returned for the `Void` case, so `diskIO`
+        // must not be `nil` here; otherwise the call site is a programmer
+        // error.
         guard var diskIO else {
             fatalError(
                 "Internal Inconsistency Error: diskIO must not be nil when OutputType is not Void"
@@ -355,15 +359,17 @@ extension OutputProtocol {
         }
 
         if let bytesOutput = self as? BytesOutput {
-            return try await bytesOutput.captureOutput(from: diskIO) as! Self.OutputType
+            return try await bytesOutput.captureOutput(
+                from: diskIO, for: processIdentifier
+            ) as! Self.OutputType
         }
 
         var result: [UInt8] = []
         do {
             var maxLength = self.maxSize
             if maxLength != .max {
-                // If we actually have a max length, attempt to read one
-                // more byte to determine whether output exceeds the limit
+                // Read one extra byte to detect output that exceeds the
+                // limit.
                 maxLength += 1
                 result.reserveCapacity(maxLength)
             }
@@ -374,6 +380,7 @@ extension OutputProtocol {
                 guard
                     let chunk = try await AsyncIO.shared.read(
                         from: diskIO,
+                        for: processIdentifier,
                         upTo: min(bufferSize, remaining)
                     )
                 else {
@@ -396,7 +403,10 @@ extension OutputProtocol {
 }
 
 extension OutputProtocol where OutputType == Void {
-    internal func captureOutput(from fileDescriptor: consuming IODescriptor?) async throws {}
+    internal func captureOutput(
+        from fileDescriptor: consuming IODescriptor?,
+        for processIdentifier: ProcessIdentifier
+    ) async throws {}
 
     /// Converts the output from a raw span to the expected output type.
     public func output(from span: RawSpan) throws {

--- a/Sources/Subprocess/Platforms/Subprocess+BSD.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+BSD.swift
@@ -27,19 +27,21 @@ internal import Dispatch
 
 // MARK: - Process Monitoring
 @Sendable
-internal func monitorProcessTermination(
+internal func waitForProcessTermination(
     for processIdentifier: ProcessIdentifier
-) async throws(SubprocessError) -> TerminationStatus {
-    switch Result(catching: { () throws(Errno) -> TerminationStatus? in try processIdentifier.reap() }) {
-    case let .success(status?):
-        return status
-    case .success(nil):
-        break
-    case let .failure(error):
+) async throws(SubprocessError) {
+    // Fast path: if the process is already a zombie, return immediately.
+    // Using WNOWAIT leaves the zombie in place for the eventual `reapProcess`.
+    do throws(Errno) {
+        if try processIdentifier.peekIfExited() {
+            return
+        }
+    } catch {
         throw .failedToMonitor(withUnderlyingError: error)
     }
+
     return try await _castError {
-        let result = try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             let source = DispatchSource.makeProcessSource(
                 identifier: processIdentifier.value,
                 eventMask: [.exit],
@@ -47,21 +49,10 @@ internal func monitorProcessTermination(
             )
             source.setEventHandler {
                 source.cancel()
-
-                do throws(Errno) {
-                    // NOTE_EXIT may be delivered slightly before the process becomes reapable,
-                    // so we must call waitid without WNOHANG to avoid a narrow possibility of a race condition.
-                    // If waitid does block, it won't do so for very long at all.
-                    let status = try processIdentifier.blockingReap()
-                    continuation.resume(returning: status)
-                } catch {
-                    let subprocessError: SubprocessError = .failedToMonitor(withUnderlyingError: error)
-                    continuation.resume(throwing: subprocessError)
-                }
+                continuation.resume()
             }
             source.resume()
         }
-        return result
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -66,12 +66,12 @@ extension Int32 {
 
 // MARK: - Process Monitoring
 @Sendable
-internal func monitorProcessTermination(
+internal func waitForProcessTermination(
     for processIdentifier: ProcessIdentifier
-) async throws(SubprocessError) -> TerminationStatus {
+) async throws(SubprocessError) {
     return try await _castError {
         return try await withCheckedThrowingContinuation { continuation in
-            let status = _processMonitorState.withLock { state -> Result<TerminationStatus, SubprocessError>? in
+            let status = _processMonitorState.withLock { state -> Result<Bool, SubprocessError>? in
                 switch state {
                 case .notStarted:
                     let error: SubprocessError = .failedToMonitor(withUnderlyingError: nil)
@@ -112,15 +112,13 @@ internal func monitorProcessTermination(
                         // Since Linux coalesce signals, it's possible by the time we request
                         // monitoring the process has already exited. Check to make sure that
                         // is not the case and only save continuation then.
-                        switch Result(catching: { () throws(Errno) -> TerminationStatus? in try processIdentifier.reap() }) {
-                        case let .success(status?):
-                            return .success(status)
-                        case .success(nil):
+                        switch Result(catching: { () throws(Errno) -> Bool in try processIdentifier.peekIfExited() }) {
+                        case let .success(processExited):
                             // Save this continuation to be called by signal handler
                             var newState = storage
                             newState.continuations[processIdentifier.value] = continuation
                             state = .started(newState)
-                            return nil
+                            return .success(processExited)
                         case let .failure(underlyingError):
                             let error: SubprocessError = .failedToMonitor(
                                 withUnderlyingError: underlyingError
@@ -132,7 +130,15 @@ internal func monitorProcessTermination(
             }
 
             if let status {
-                continuation.resume(with: status)
+                switch status {
+                case .success(let processExisted):
+                    if processExisted {
+                        // Resume the continuation now that the process has exited
+                        continuation.resume()
+                    }
+                case .failure(let failure):
+                    continuation.resume(throwing: failure)
+                }
             }
         }
     }
@@ -147,7 +153,7 @@ private enum ProcessMonitorState {
         let epollFileDescriptor: CInt
         let shutdownFileDescriptor: CInt
         let monitorThread: pthread_t
-        var continuations: [PlatformFileDescriptor: CheckedContinuation<TerminationStatus, any Error>]
+        var continuations: [PlatformFileDescriptor: CheckedContinuation<Void, any Error>]
     }
 
     case notStarted
@@ -238,8 +244,8 @@ private func monitorThreadFunc(context: MonitorThreadContext) {
             let error: SubprocessError = .failedToMonitor(
                 withUnderlyingError: Errno(rawValue: pwaitErrno)
             )
-            let continuations = _processMonitorState.withLock { state -> [CheckedContinuation<TerminationStatus, any Error>] in
-                let result: [CheckedContinuation<TerminationStatus, any Error>]
+            let continuations = _processMonitorState.withLock { state -> [CheckedContinuation<Void, any Error>] in
+                let result: [CheckedContinuation<Void, any Error>]
                 if case .started(let storage) = state {
                     result = Array(storage.continuations.values)
                 } else {
@@ -273,9 +279,9 @@ private func monitorThreadFunc(context: MonitorThreadContext) {
 
             // P_PIDFD requires Linux Kernel 5.4 and above
             if _waitProcessDescriptorSupported {
-                _blockAndWaitForProcessDescriptor(targetFileDescriptor, context: context)
+                _unregisterProcessDescriptorAndNotify(targetFileDescriptor, context: context)
             } else {
-                _reapAllKnownChildProcesses(targetFileDescriptor, context: context)
+                _notifyAllKnownChildProcesses(targetFileDescriptor, context: context)
             }
         }
     }
@@ -405,30 +411,9 @@ internal func _setupMonitorSignalHandler() {
     setup
 }
 
-private func _blockAndWaitForProcessDescriptor(_ pidfd: CInt, context: MonitorThreadContext) {
-    var terminationStatus = Result(catching: { () throws(Errno) in
-        try TerminationStatus(_waitid(idtype: idtype_t(UInt32(P_PIDFD)), id: id_t(pidfd), flags: WEXITED))
-    }).mapError { underlyingError in
-        return SubprocessError.failedToMonitor(withUnderlyingError: underlyingError)
-    }
-
-    // Remove this pidfd from epoll to prevent further notifications
-    let rc = epoll_ctl(
-        context.epollFileDescriptor,
-        EPOLL_CTL_DEL,
-        pidfd,
-        nil
-    )
-    if rc != 0 {
-        let epollErrno = errno
-        terminationStatus = .failure(
-            SubprocessError.failedToMonitor(
-                withUnderlyingError: Errno(rawValue: epollErrno)
-            )
-        )
-    }
-    // Notify the continuation
-    let continuation = _processMonitorState.withLock { state -> CheckedContinuation<TerminationStatus, any Error>? in
+private func _unregisterProcessDescriptorAndNotify(_ pidfd: CInt, context: MonitorThreadContext) {
+    // Remove the continuation
+    let result = _processMonitorState.withLock { state -> (continuation: CheckedContinuation<Void, any Error>, error: SubprocessError?)? in
         guard case .started(let storage) = state,
             let continuation = storage.continuations[pidfd]
         else {
@@ -438,17 +423,38 @@ private func _blockAndWaitForProcessDescriptor(_ pidfd: CInt, context: MonitorTh
         var newStorage = storage
         newStorage.continuations.removeValue(forKey: pidfd)
         state = .started(newStorage)
-        return continuation
+
+        // Remove this pidfd from epoll to prevent further notifications
+        let rc = epoll_ctl(
+            context.epollFileDescriptor,
+            EPOLL_CTL_DEL,
+            pidfd,
+            nil
+        )
+        if rc != 0 {
+            let epollErrno = errno
+            let error = SubprocessError.failedToMonitor(
+                withUnderlyingError: Errno(rawValue: epollErrno)
+            )
+            return (continuation, error)
+        }
+
+        return (continuation, nil)
     }
-    continuation?.resume(with: terminationStatus)
+
+    if let error = result?.error {
+        result?.continuation.resume(throwing: error)
+    } else {
+        result?.continuation.resume()
+    }
 }
 
 // On older kernels, fall back to using signal handlers
 private typealias ResultContinuation = (
-    result: Result<TerminationStatus, SubprocessError>,
-    continuation: CheckedContinuation<TerminationStatus, any Error>
+    failure: SubprocessError?,
+    continuation: CheckedContinuation<Void, any Error>
 )
-private func _reapAllKnownChildProcesses(_ signalFd: CInt, context: MonitorThreadContext) {
+private func _notifyAllKnownChildProcesses(_ signalFd: CInt, context: MonitorThreadContext) {
     guard signalFd == _signalPipe.readEnd else {
         return
     }
@@ -470,19 +476,17 @@ private func _reapAllKnownChildProcesses(_ signalFd: CInt, context: MonitorThrea
         // Since Linux coalesce signals, we need to loop through all known child process
         // to check if they exited.
         loop: for (knownChildPID, continuation) in storage.continuations {
-            let terminationStatus: Result<TerminationStatus, SubprocessError>
-            switch Result(catching: { () throws(Errno) -> TerminationStatus? in try _reap(pid: knownChildPID) }) {
-            case let .success(status?):
-                terminationStatus = .success(status)
-            case .success(nil):
-                // Move on to the next child
-                continue loop
+            switch Result(catching: { () throws(Errno) -> Bool in try _peekIfExited(pid: knownChildPID) }) {
+            case let .success(processExisted):
+                if processExisted {
+                    results.append((failure: nil, continuation: continuation))
+                } else {
+                    // The process is still running, move on to the next one
+                    continue loop
+                }
             case let .failure(error):
-                terminationStatus = .failure(
-                    SubprocessError.failedToMonitor(withUnderlyingError: error)
-                )
+                results.append((failure: SubprocessError.failedToMonitor(withUnderlyingError: error), continuation: continuation))
             }
-            results.append((result: terminationStatus, continuation: continuation))
             // Now we have the exit code, remove saved continuations
             updatedContinuations.removeValue(forKey: knownChildPID)
         }
@@ -494,7 +498,11 @@ private func _reapAllKnownChildProcesses(_ signalFd: CInt, context: MonitorThrea
     }
     // Resume continuations
     for c in resumingContinuations {
-        c.continuation.resume(with: c.result)
+        if let error = c.failure {
+            c.continuation.resume(throwing: error)
+        } else {
+            c.continuation.resume()
+        }
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -684,6 +684,23 @@ extension PlatformOptions: CustomStringConvertible, CustomDebugStringConvertible
 }
 #endif // !canImport(Darwin)
 
+@Sendable
+internal func reapProcess(
+    with processIdentifier: ProcessIdentifier
+) throws(SubprocessError) -> TerminationStatus {
+    do throws(Errno) {
+        // On some platforms, the process exit notification (in particular NOTE_EXIT from kqueue)
+        // may be delivered slightly before the process becomes reapable,
+        // so we must call waitid without WNOHANG to avoid a narrow possibility of a race condition.
+        // If waitid does block, it won't do so for very long at all.
+        let status = try processIdentifier.blockingReap()
+        return status
+    } catch {
+        let subprocessError: SubprocessError = .failedToMonitor(withUnderlyingError: error)
+        throw subprocessError
+    }
+}
+
 extension ProcessIdentifier {
     /// Reaps the zombie for the exited process. This function may block.
     @available(*, noasync)
@@ -694,6 +711,14 @@ extension ProcessIdentifier {
     /// Reaps the zombie for the exited process, or returns `nil` if the process is still running. This function will not block.
     internal func reap() throws(Errno) -> TerminationStatus? {
         try _reap(pid: value)
+    }
+
+    /// Checks whether the process has already exited without consuming the
+    /// zombie. Returns `true` if a child has exited (or stopped/continued in a
+    /// way `waitid` reports), `false` if the child is still running. The
+    /// zombie remains available for a subsequent call to ``blockingReap()``.
+    internal func peekIfExited() throws(Errno) -> Bool {
+        try _peekIfExited(pid: value)
     }
 }
 
@@ -710,6 +735,13 @@ internal func _reap(pid: pid_t) throws(Errno) -> TerminationStatus? {
         return nil
     }
     return TerminationStatus(siginfo)
+}
+
+internal func _peekIfExited(pid: pid_t) throws(Errno) -> Bool {
+    // WNOWAIT leaves the zombie in the process table so a subsequent
+    // `_blockingReap` (or `_reap`) can still consume it.
+    let siginfo = try _waitid(idtype: P_PID, id: id_t(pid), flags: WEXITED | WNOHANG | WNOWAIT)
+    return !(siginfo.si_pid == 0 && siginfo.si_signo == 0)
 }
 
 internal func _waitid(idtype: idtype_t, id: id_t, flags: Int32) throws(Errno) -> siginfo_t {

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -601,9 +601,9 @@ extension PlatformOptions: CustomStringConvertible, CustomDebugStringConvertible
 
 // MARK: - Process Monitoring
 @Sendable
-internal func monitorProcessTermination(
+internal func waitForProcessTermination(
     for processIdentifier: ProcessIdentifier
-) async throws(SubprocessError) -> TerminationStatus {
+) async throws(SubprocessError) {
     // Once the continuation resumes, it will need to unregister the wait, so
     // yield the wait handle back to the calling scope.
     var waitHandle: HANDLE?
@@ -647,7 +647,15 @@ internal func monitorProcessTermination(
             }
         }
     }
+}
 
+@Sendable
+internal func reapProcess(
+    with processIdentifier: ProcessIdentifier
+) throws(SubprocessError) -> TerminationStatus {
+    // Windows keeps the exit code reachable through the process HANDLE
+    // until the HANDLE is closed, so there is no zombie to reap. We just
+    // need to read the exit code via `GetExitCodeProcess`.
     var status: DWORD = 0
     guard GetExitCodeProcess(processIdentifier.processDescriptor, &status) else {
         throw SubprocessError.failedToMonitor(

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -122,7 +122,7 @@ extension StandardInputWriter {
     public func write(
         _ data: Data
     ) async throws(SubprocessError) -> Int {
-        return try await AsyncIO.shared.write(data, to: self.diskIO)
+        return try await AsyncIO.shared.write(data, to: self.diskIO, for: self.processIdentifier)
     }
 
     /// Writes an asynchronous sequence of `Data` to the subprocess's standard input.
@@ -154,9 +154,10 @@ extension Data: AsyncIO._ContiguousBytes {}
 extension AsyncIO {
     internal func write(
         _ data: Data,
-        to diskIO: borrowing IODescriptor
+        to diskIO: borrowing IODescriptor,
+        for processIdentifier: ProcessIdentifier
     ) async throws(SubprocessError) -> Int {
-        return try await self.write(data.bytes, to: diskIO)
+        return try await self.write(data.bytes, to: diskIO, for: processIdentifier)
     }
 }
 

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -243,13 +243,14 @@ private func _shutdownWorkerThread() {
 
 #if canImport(Darwin)
 // Unfortunately on Darwin we cannot unconditionally use Atomic since it requires macOS 15
-internal struct AtomicCounter: ~Copyable {
+internal final class AtomicCounter: Sendable {
     private let storage: OSAllocatedUnfairLock<UInt8>
 
     internal init() {
         self.storage = .init(initialState: 0)
     }
 
+    @discardableResult
     internal func addOne() -> UInt8 {
         return self.storage.withLock {
             $0 += 1
@@ -258,7 +259,7 @@ internal struct AtomicCounter: ~Copyable {
     }
 }
 #else
-internal struct AtomicCounter: ~Copyable {
+internal final class AtomicCounter: Sendable {
 
     private let storage: Atomic<UInt8>
 
@@ -266,6 +267,7 @@ internal struct AtomicCounter: ~Copyable {
         self.storage = Atomic(0)
     }
 
+    @discardableResult
     internal func addOne() -> UInt8 {
         return self.storage.add(1, ordering: .sequentiallyConsistent).newValue
     }

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -346,3 +346,41 @@ extension SubprocessAsyncIOTests.TestBed {
         try await Task.sleep(for: duration)
     }
 }
+
+/// A `ProcessIdentifier` for the current test process.
+///
+/// The AsyncIO-only tests below never spawn a child, so they have no
+/// real `ProcessIdentifier` to pass. The tests only call `read` and
+/// `write` (never `cancelAsyncIO`), so this stand-in is sufficient.
+private var _currentPID: ProcessIdentifier {
+    #if os(Windows)
+    return ProcessIdentifier(
+        value: GetCurrentProcessId(),
+        processDescriptor: GetCurrentProcess(),
+        threadHandle: GetCurrentThread()
+    )
+    #elseif os(Linux) || os(Android) || os(FreeBSD)
+    return ProcessIdentifier(
+        value: getpid(),
+        processDescriptor: 0 // Not used in these tests.
+    )
+    #else
+    return ProcessIdentifier(value: getpid())
+    #endif
+}
+
+extension AsyncIO {
+    func write(
+        _ array: [UInt8],
+        to diskIO: borrowing IODescriptor
+    ) async throws(SubprocessError) -> Int {
+        return try await self.write(array._bytes, to: diskIO, for: _currentPID)
+    }
+
+    func read(
+        from diskIO: borrowing IODescriptor,
+        upTo maxLength: Int
+    ) async throws(SubprocessError) -> [UInt8]? {
+        return try await self.read(from: diskIO, for: _currentPID, upTo: maxLength)
+    }
+}

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -2286,6 +2286,325 @@ extension SubprocessIntegrationTests {
     }
 }
 
+// MARK: - Cancellable IO Tests
+
+// Regression tests for https://github.com/swiftlang/swift-subprocess/issues/256.
+// Ensure Subprocess cancels IO when the child process exits
+
+#if !os(Windows)
+extension SubprocessIntegrationTests {
+    @Test func testWeDoNotHangIfStandardInputRemainsOpenButProcessExits() async throws {
+        // The shell forks a `sleep` grandchild that inherits stdin, then
+        // the main shell reads one line and exits. The parent has 16 MB
+        // queued for stdin which the grandchild never reads; the write
+        // loop is therefore blocked on a full pipe with no reader making
+        // forward progress.
+        //
+        // The subshell trick — duplicating stdin into fd 2 in the parent
+        // shell, then mapping fd 2 back onto fd 0 in the subshell — is
+        // necessary because POSIX requires backgrounded processes (`&`)
+        // to have their stdin redirected to `/dev/null` unless explicitly
+        // overridden. Without this dance, dash and other strict shells
+        // would hand the grandchild `/dev/null` instead of the real stdin
+        // pipe.
+        let script = """
+            exec 2>&-
+            exec 2<&0
+            ( exec 0<&2; exec 2>&-; exec sleep 12345678 ) &
+            exec 2>&-
+            read -r line
+            echo "$line"
+            echo "$!"
+            exec >&-
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", script]
+        )
+
+        var sleepPidToKill: pid_t = 0
+        defer {
+            if sleepPidToKill != 0 {
+                kill(sleepPidToKill, SIGKILL)
+            }
+        }
+
+        // "GO\n" plus 16 MB of filler. The first chunk is small enough to fit
+        // in the pipe buffer; the filler is what wedges the writer.
+        var input: [UInt8] = []
+        input.append(contentsOf: "GO\n".utf8)
+        input.append(contentsOf: Array(repeating: UInt8(0x42), count: 16 * 1024 * 1024))
+
+        let result = try await _run(
+            setup,
+            input: .array(input),
+            output: .sequence,
+            error: .discarded
+        ) { execution in
+            var iterator = execution.standardOutput.strings().makeAsyncIterator()
+            #expect(try await iterator.next() == "GO")
+            let pidLine = try await iterator.next()
+            return pidLine.flatMap { pid_t($0) } ?? 0
+        }
+
+        sleepPidToKill = result.closureOutput
+        #expect(sleepPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+    }
+
+    @Test func testWeDoNotHangIfStandardOutputRemainsOpenButProcessExits() async throws {
+        // The shell forks a `sleep` grandchild that inherits stdout. Stdin
+        // and stderr are diverted to `/dev/null` so the grandchild only
+        // holds stdout open. The main shell prints to both streams and
+        // exits; the grandchild keeps the parent's stdout read end from
+        // reaching EOF.
+        //
+        // The PID is sent on stderr so the call can capture it via
+        // `.sequence`, while `.string(limit:)` is the mechanism that
+        // would hang on stdout.
+        let script = """
+            ( exec sleep 12345678 ) </dev/null 2>/dev/null &
+            echo "$!" >&2
+            echo "GO"
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", script]
+        )
+
+        var sleepPidToKill: pid_t = 0
+        defer {
+            if sleepPidToKill != 0 {
+                kill(sleepPidToKill, SIGKILL)
+            }
+        }
+
+        let result = try await _run(
+            setup,
+            input: .none,
+            output: .string(limit: 1024),
+            error: .sequence
+        ) { execution in
+            var capturedPid: pid_t = 0
+            for try await line in execution.standardError.strings() {
+                if let pid = pid_t(line) {
+                    capturedPid = pid
+                }
+            }
+            return capturedPid
+        }
+
+        sleepPidToKill = result.closureOutput
+        #expect(sleepPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+        #expect((result.standardOutput ?? "").contains("GO"))
+    }
+
+    @Test func testWeDoNotHangIfStandardErrorRemainsOpenButProcessExits() async throws {
+        // Mirror of the stdout test: the grandchild only inherits stderr,
+        // and `.string(limit:)` on stderr blocks waiting for an EOF that
+        // never arrives.
+        let script = """
+            ( exec sleep 12345678 ) </dev/null >/dev/null &
+            echo "$!"
+            echo "GO" >&2
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", script]
+        )
+
+        var sleepPidToKill: pid_t = 0
+        defer {
+            if sleepPidToKill != 0 {
+                kill(sleepPidToKill, SIGKILL)
+            }
+        }
+
+        let result = try await _run(
+            setup,
+            input: .none,
+            output: .sequence,
+            error: .string(limit: 1024)
+        ) { execution in
+            var capturedPid: pid_t = 0
+            for try await line in execution.standardOutput.strings() {
+                if let pid = pid_t(line) {
+                    capturedPid = pid
+                }
+            }
+            return capturedPid
+        }
+
+        sleepPidToKill = result.closureOutput
+        #expect(sleepPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+        #expect((result.standardError ?? "").contains("GO"))
+    }
+}
+#else
+extension SubprocessIntegrationTests {
+    // PowerShell snippet that spawns a long-sleeping grandchild via
+    // `Start-Process -NoNewWindow -PassThru`. The `-NoNewWindow` switch
+    // routes through .NET's `Process.Start` with `UseShellExecute=false`,
+    // which always passes `bInheritHandles=TRUE` and copies PowerShell's
+    // own std handles into `STARTUPINFO.hStd*`. The grandchild therefore
+    // inherits the pipe handles Subprocess set up for PowerShell, and
+    // those pipes stay open after PowerShell exits — the Win32 analog of
+    // the POSIX `fork` and `exec` dance the Unix tests use.
+    private static let spawnGrandchildSleep = """
+        $proc = Start-Process -NoNewWindow -FilePath powershell.exe `
+            -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 12345678' `
+            -PassThru
+        """
+
+    private static func killGrandchild(_ pid: DWORD) {
+        guard pid != 0 else { return }
+        guard let handle = OpenProcess(DWORD(PROCESS_TERMINATE), false, pid) else {
+            return
+        }
+        _ = TerminateProcess(handle, 1)
+        CloseHandle(handle)
+    }
+
+    @Test func testWeDoNotHangIfStandardInputRemainsOpenButProcessExits() async throws {
+        // PowerShell forks the sleeping grandchild (which inherits stdin),
+        // reads one line, echoes the line plus the grandchild PID, then
+        // exits. The parent has 16 MB queued for stdin which the grandchild
+        // never reads; the write loop is therefore blocked on a full pipe
+        // buffer with no reader making forward progress.
+        let script = """
+            $ErrorActionPreference = 'Stop'
+            \(Self.spawnGrandchildSleep)
+            $line = [Console]::In.ReadLine()
+            Write-Output $line
+            Write-Output $proc.Id
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]
+        )
+
+        var grandchildPidToKill: DWORD = 0
+        defer { Self.killGrandchild(grandchildPidToKill) }
+
+        // "GO\r\n" plus 16 MB of filler. The first chunk is small enough to
+        // fit in the pipe buffer; the filler is what wedges the writer.
+        var input: [UInt8] = []
+        input.append(contentsOf: "GO\r\n".utf8)
+        input.append(contentsOf: Array(repeating: UInt8(0x42), count: 16 * 1024 * 1024))
+
+        let result = try await _run(
+            setup,
+            input: .array(input),
+            output: .sequence,
+            error: .discarded
+        ) { execution in
+            var iterator = execution.standardOutput.strings().makeAsyncIterator()
+            #expect(try await iterator.next() == "GO")
+            let pidLine = try await iterator.next()
+            return pidLine.flatMap { DWORD($0) } ?? 0
+        }
+
+        grandchildPidToKill = result.closureOutput
+        #expect(grandchildPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+    }
+
+    @Test func testWeDoNotHangIfStandardOutputRemainsOpenButProcessExits() async throws {
+        // PowerShell forks the sleeping grandchild (which inherits stdout
+        // since `Start-Process -NoNewWindow` copies the parent's std
+        // handles), prints the PID on stderr so we can capture it via
+        // `.sequence`, prints "GO" on stdout, and exits. The grandchild
+        // keeps the stdout write end alive — `.string(limit:)` on stdout
+        // is the call that would hang waiting for an EOF that never
+        // arrives.
+        let script = """
+            $ErrorActionPreference = 'Stop'
+            \(Self.spawnGrandchildSleep)
+            [Console]::Error.WriteLine($proc.Id)
+            Write-Output 'GO'
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]
+        )
+
+        var grandchildPidToKill: DWORD = 0
+        defer { Self.killGrandchild(grandchildPidToKill) }
+
+        let result = try await _run(
+            setup,
+            input: .none,
+            output: .string(limit: 1024),
+            error: .sequence
+        ) { execution in
+            // The grandchild also inherits stderr, so the call can't
+            // iterate to EOF here. Read until a line parses as a PID and
+            // return — the I/O is cancelled once the child exits.
+            var iterator = execution.standardError.strings().makeAsyncIterator()
+            while let line = try await iterator.next() {
+                if let pid = DWORD(line) {
+                    return pid
+                }
+            }
+            return DWORD(0)
+        }
+
+        grandchildPidToKill = result.closureOutput
+        #expect(grandchildPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+        #expect((result.standardOutput ?? "").contains("GO"))
+    }
+
+    @Test func testWeDoNotHangIfStandardErrorRemainsOpenButProcessExits() async throws {
+        // Mirror of the stdout test: PowerShell prints the PID on stdout
+        // (so we can capture it via `.sequence`) and "GO" on stderr, then
+        // exits. The grandchild keeps the stderr write end alive —
+        // `.string(limit:)` on stderr is the call that would hang.
+        let script = """
+            $ErrorActionPreference = 'Stop'
+            \(Self.spawnGrandchildSleep)
+            Write-Output $proc.Id
+            [Console]::Error.WriteLine('GO')
+            exit 0
+            """
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script]
+        )
+
+        var grandchildPidToKill: DWORD = 0
+        defer { Self.killGrandchild(grandchildPidToKill) }
+
+        let result = try await _run(
+            setup,
+            input: .none,
+            output: .sequence,
+            error: .string(limit: 1024)
+        ) { execution in
+            var iterator = execution.standardOutput.strings().makeAsyncIterator()
+            while let line = try await iterator.next() {
+                if let pid = DWORD(line) {
+                    return pid
+                }
+            }
+            return DWORD(0)
+        }
+
+        grandchildPidToKill = result.closureOutput
+        #expect(grandchildPidToKill != 0)
+        #expect(result.terminationStatus == .exited(0))
+        #expect((result.standardError ?? "").contains("GO"))
+    }
+}
+#endif // !os(Windows)
+
 // MARK: - Other Tests
 extension SubprocessIntegrationTests {
     @Test func testTerminateProcess() async throws {

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -327,3 +327,8 @@ extension SubprocessProcessMonitoringTests {
         }
     }
 }
+
+internal func monitorProcessTermination(for processIdentifier: ProcessIdentifier) async throws -> TerminationStatus {
+    try await waitForProcessTermination(for: processIdentifier)
+    return try reapProcess(with: processIdentifier)
+}

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -177,7 +177,8 @@ extension SubprocessUnixTests {
                 trap 'echo saw SIGQUIT;' QUIT
                 trap 'echo saw SIGTERM;' TERM
                 trap 'echo saw SIGINT; exit 42;' INT
-                while true; do sleep 1; done
+                echo ready
+                while true; do sleep 0.1; done
                 exit 2
                 """,
             ],
@@ -186,9 +187,16 @@ extension SubprocessUnixTests {
             error: .discarded
         ) { subprocess in
             return try await withThrowingTaskGroup(of: Void.self) { group in
+                // Gate the teardown task on bash having actually installed
+                // its signal traps. The reader signals readiness when it
+                // sees the `ready` marker the script prints after the
+                // `trap` lines.
+                let (readyStream, readyContinuation) = AsyncStream.makeStream(of: Void.self)
+
                 group.addTask {
-                    try await Task.sleep(for: .milliseconds(200))
-                    // Send shut down signal
+                    var readyIterator = readyStream.makeAsyncIterator()
+                    _ = await readyIterator.next()
+                    // Send the teardown signal sequence.
                     await subprocess.teardown(using: [
                         .send(signal: .quit, allowedDurationToNextStep: .milliseconds(500)),
                         .send(signal: .terminate, allowedDurationToNextStep: .milliseconds(500)),
@@ -198,7 +206,13 @@ extension SubprocessUnixTests {
                 group.addTask {
                     var outputs: [String] = []
                     for try await line in subprocess.standardOutput.strings() {
-                        outputs.append(line.trimmingCharacters(in: .newlines))
+                        let trimmed = line.trimmingCharacters(in: .newlines)
+                        if trimmed == "ready" {
+                            readyContinuation.yield()
+                            readyContinuation.finish()
+                            continue
+                        }
+                        outputs.append(trimmed)
                     }
                     #expect(outputs == ["saw SIGQUIT", "saw SIGTERM", "saw SIGINT"])
                 }


### PR DESCRIPTION
Subprocess used to assume that a child's exit closes the pipe FDs it inherited. When the child forked a grandchild that also holds those FDs, the kernel keeps the pipes alive after the child exits and AsyncIO's read/write loops never see EOF or EPIPE — run() hangs.

Split process monitoring into two phases:
- waitForProcessTermination waits for the kernel to report exit.
- reapProcess consumes the zombie and returns the status.

Configuration.run now spawns a parallel monitor task and races it against the body closure via an AtomicCounter. If the process exits while the body is still doing I/O, the monitor calls AsyncIO.cancelAsyncIO(for:) to unblock every pending read or write for that process.

Each platform's AsyncIO backend gains a Registration struct that groups file descriptors (or IOCP completion keys on Windows) by process. Cancellation walks those descriptors and either deletes them from epoll/kqueue or calls CancelIoEx. A cancelledProcesses set rejects late registrations so a register-vs-cancel race cannot leak a stream. run clears the marker before reapProcess so PID reuse is safe.

Adds regression tests covering stdin, stdout, and stderr on Unix (POSIX shell + sleep grandchild) and Windows (PowerShell + Start-Process -NoNewWindow grandchild).

Resolves: https://github.com/swiftlang/swift-subprocess/issues/256