### PR TITLE
Rename AsyncBufferSequence to SubprocessOutputSequence to avoid naming conflict with AsyncBufferSequence from swift-async-algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This returns an `ExecutionResult` containing the process identifier, termination
 For more control, pass a closure that runs while the child process is active. The closure receives a single `Execution` value that you use to send signals, write to standard input, and stream standard output and standard error.
 
 > [!CAUTION]
-> The `Execution`, `AsyncBufferSequence`, and `StandardInputWriter` values are valid only for the duration of the closure. Don't let them escape the closure.
+> The `Execution`, `SubprocessOutputSequence`, and `StandardInputWriter` values are valid only for the duration of the closure. Don't let them escape the closure.
 
 You opt into each interactive stream by choosing the matching input or output type:
 
@@ -169,7 +169,7 @@ try await run(
 }
 ```
 
-In the closure-based API, output streams are delivered as an `AsyncBufferSequence` — an asynchronous sequence of `Buffer` values. Each `Buffer` provides access to its bytes via `withUnsafeBytes(_:)` or the `bytes` property (a `RawSpan`).
+In the closure-based API, output streams are delivered as an `SubprocessOutputSequence` — an asynchronous sequence of `Buffer` values. Each `Buffer` provides access to its bytes via `withUnsafeBytes(_:)` or the `bytes` property (a `RawSpan`).
 
 The preferred way to convert `Buffer` to `String` is to read output line by line using `.lines()`. You can optionally specify an encoding and buffering policy:
 

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -291,12 +291,12 @@ public func run<
                 }
             }
 
-            var outputSequence: AsyncBufferSequence? = nil
-            var errorSequence: AsyncBufferSequence? = nil
+            var outputSequence: SubprocessOutputSequence? = nil
+            var errorSequence: SubprocessOutputSequence? = nil
             // Capture output and error in parallel
             if Output.self == SequenceOutput.self {
                 var diskIO = outputIOBox.take()
-                outputSequence = AsyncBufferSequence(
+                outputSequence = SubprocessOutputSequence(
                     diskIO: diskIO!.consumeDescriptor(),
                     processIdentifier: processIdentifier
                 )
@@ -316,7 +316,7 @@ public func run<
 
             if Error.self == SequenceOutput.self {
                 var diskIO = errorIOBox.take()
-                errorSequence = AsyncBufferSequence(
+                errorSequence = SubprocessOutputSequence(
                     diskIO: diskIO!.consumeDescriptor(),
                     processIdentifier: processIdentifier
                 )

--- a/Sources/Subprocess/Buffer.swift
+++ b/Sources/Subprocess/Buffer.swift
@@ -21,7 +21,7 @@ internal import FoundationEssentials
 
 #endif
 
-extension AsyncBufferSequence {
+extension SubprocessOutputSequence {
     /// An immutable collection of bytes.
     public struct Buffer: Sendable {
         internal let data: [UInt8]
@@ -33,7 +33,7 @@ extension AsyncBufferSequence {
 }
 
 // MARK: - Properties
-extension AsyncBufferSequence.Buffer {
+extension SubprocessOutputSequence.Buffer {
     /// The number of bytes in the buffer.
     public var count: Int {
         return self.data.count
@@ -46,7 +46,7 @@ extension AsyncBufferSequence.Buffer {
 }
 
 // MARK: - Accessors
-extension AsyncBufferSequence.Buffer {
+extension SubprocessOutputSequence.Buffer {
     /// Accesses the raw bytes stored in this buffer.
     /// - Parameter body: A closure with an `UnsafeRawBufferPointer` parameter that
     ///   points to the contiguous storage for the buffer. If no such storage exists,

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(Subprocess
   IO/AsyncIO+Windows.swift
   IO/AsyncIO+Unix.swift
   Span+Subprocess.swift
-  AsyncBufferSequence.swift
+  SubprocessOutputSequence.swift
   API.swift
   SubprocessFoundation/Span+SubprocessFoundation.swift
   SubprocessFoundation/Output+Foundation.swift

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -46,14 +46,14 @@ public struct Execution<Input: InputProtocol, Output: OutputProtocol, Error: Out
     public let processIdentifier: ProcessIdentifier
 
     private let inputWriter: StandardInputWriter?
-    private let outputStream: AsyncBufferSequence?
-    private let errorStream: AsyncBufferSequence?
+    private let outputStream: SubprocessOutputSequence?
+    private let errorStream: SubprocessOutputSequence?
 
     init(
         processIdentifier: ProcessIdentifier,
         inputWriter: StandardInputWriter?,
-        outputStream: AsyncBufferSequence?,
-        errorStream: AsyncBufferSequence?
+        outputStream: SubprocessOutputSequence?,
+        errorStream: SubprocessOutputSequence?
     ) {
         self.processIdentifier = processIdentifier
         self.inputWriter = inputWriter
@@ -75,7 +75,7 @@ extension Execution where Input == CustomWriteInput {
 extension Execution where Output == SequenceOutput {
     /// The standard output of the subprocess as an asynchronous sequence of
     /// buffers.
-    public var standardOutput: AsyncBufferSequence {
+    public var standardOutput: SubprocessOutputSequence {
         return self.outputStream!
     }
 }
@@ -83,7 +83,7 @@ extension Execution where Output == SequenceOutput {
 extension Execution where Error == SequenceOutput {
     /// The standard error of the subprocess as an asynchronous sequence of
     /// buffers.
-    public var standardError: AsyncBufferSequence {
+    public var standardError: SubprocessOutputSequence {
         return self.errorStream!
     }
 }
@@ -95,12 +95,12 @@ extension Execution {
     }
 
     @available(*, unavailable, message: "this property requires that the output is .sequence")
-    public var standardOutput: AsyncBufferSequence {
+    public var standardOutput: SubprocessOutputSequence {
         fatalError()
     }
 
     @available(*, unavailable, message: "this property requires that the error is .sequence")
-    public var standardError: AsyncBufferSequence {
+    public var standardError: SubprocessOutputSequence {
         fatalError()
     }
 }

--- a/Sources/Subprocess/IO/AsyncIO+KQueue.swift
+++ b/Sources/Subprocess/IO/AsyncIO+KQueue.swift
@@ -82,7 +82,7 @@ private func _makeKevent(
 
 final class AsyncIO: Sendable {
 
-    typealias OutputStream = AsyncThrowingStream<AsyncBufferSequence.Buffer, any Error>
+    typealias OutputStream = AsyncThrowingStream<SubprocessOutputSequence.Buffer, any Error>
 
     private struct MonitorThreadContext: Sendable {
         let kqueueFileDescriptor: CInt

--- a/Sources/Subprocess/IO/AsyncIO+Linux.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Linux.swift
@@ -36,7 +36,7 @@ private let _registration: Mutex<Registration> = Mutex(Registration())
 
 final class AsyncIO: Sendable {
 
-    typealias OutputStream = AsyncThrowingStream<AsyncBufferSequence.Buffer, any Error>
+    typealias OutputStream = AsyncThrowingStream<SubprocessOutputSequence.Buffer, any Error>
 
     private struct MonitorThreadContext: Sendable {
         let epollFileDescriptor: CInt

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -50,7 +50,7 @@ extension OutputProtocol where Self == DataOutput {
 extension Data {
     /// Creates a `Data` value from a buffer.
     /// - Parameter buffer: The buffer to copy from.
-    public init(buffer: AsyncBufferSequence.Buffer) {
+    public init(buffer: SubprocessOutputSequence.Buffer) {
         self = Data(buffer.data)
     }
 }

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -39,7 +39,7 @@ import os
 #endif
 
 /// An asynchronous sequence of buffers that streams output from a subprocess.
-public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
+public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     /// The failure type for the asynchronous sequence.
     public typealias Failure = any Swift.Error
     /// The element type for the asynchronous sequence.
@@ -51,7 +51,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
     internal typealias DiskIO = FileDescriptor
     #endif
 
-    /// An iterator for ``AsyncBufferSequence``.
+    /// An iterator for ``SubprocessOutputSequence``.
     public struct Iterator: AsyncIteratorProtocol {
         /// The element type for the iterator.
         public typealias Element = Buffer
@@ -94,7 +94,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
         }
 
         /// Retrieves the next buffer in the sequence, or `nil` if the sequence ended.
-        public mutating func next() async throws -> AsyncBufferSequence.Buffer? {
+        public mutating func next() async throws -> SubprocessOutputSequence.Buffer? {
             return try await self.next(isolation: nil)
         }
     }
@@ -112,7 +112,7 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
     /// Creates an iterator for this asynchronous sequence.
     public func makeAsyncIterator() -> Iterator {
         guard self.state.initializedCount() == 1 else {
-            fatalError("AsyncBufferSequence is single pass. It can only be iterated once.")
+            fatalError("SubprocessOutputSequence is single pass. It can only be iterated once.")
         }
         return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier)
     }
@@ -166,9 +166,9 @@ public struct AsyncBufferSequence: AsyncSequence, @unchecked Sendable {
 }
 
 @available(*, unavailable)
-extension AsyncBufferSequence.Iterator: Sendable {}
+extension SubprocessOutputSequence.Iterator: Sendable {}
 
-extension AsyncBufferSequence {
+extension SubprocessOutputSequence {
     private final class State {
         #if os(macOS)
         private let value: OSAllocatedUnfairLock<Int>
@@ -198,7 +198,7 @@ extension AsyncBufferSequence {
 }
 
 // MARK: - StringSequence
-extension AsyncBufferSequence {
+extension SubprocessOutputSequence {
     /// An asynchronous sequence of strings parsed from a buffer
     /// sequence.
     ///
@@ -230,7 +230,7 @@ extension AsyncBufferSequence {
         /// The element type for the asynchronous sequence.
         public typealias Element = String
 
-        private let base: AsyncBufferSequence
+        private let base: SubprocessOutputSequence
         private let bufferingPolicy: BufferingPolicy
         private let separator: Separator
 
@@ -239,7 +239,7 @@ extension AsyncBufferSequence {
             /// The element type for this Iterator.
             public typealias Element = String
 
-            private var source: AsyncBufferSequence.AsyncIterator
+            private var source: SubprocessOutputSequence.AsyncIterator
             private var buffer: [Encoding.CodeUnit]
             private var underlyingBuffer: [Encoding.CodeUnit]
             private var underlyingBufferIndex: Array<Encoding.CodeUnit>.Index
@@ -250,7 +250,7 @@ extension AsyncBufferSequence {
             private let separatorCodeUnits: [Encoding.CodeUnit]
 
             internal init(
-                underlyingIterator: AsyncBufferSequence.AsyncIterator,
+                underlyingIterator: SubprocessOutputSequence.AsyncIterator,
                 bufferingPolicy: BufferingPolicy,
                 separator: Separator
             ) {
@@ -486,7 +486,7 @@ extension AsyncBufferSequence {
         }
 
         internal init(
-            underlying: AsyncBufferSequence,
+            underlying: SubprocessOutputSequence,
             encoding: Encoding.Type,
             bufferingPolicy: BufferingPolicy,
             separator: Separator
@@ -499,9 +499,9 @@ extension AsyncBufferSequence {
 }
 
 @available(*, unavailable)
-extension AsyncBufferSequence.StringSequence.AsyncIterator: Sendable {}
+extension SubprocessOutputSequence.StringSequence.AsyncIterator: Sendable {}
 
-extension AsyncBufferSequence.StringSequence {
+extension SubprocessOutputSequence.StringSequence {
     /// A strategy for handling buffer capacity.
     public enum BufferingPolicy: Sendable {
         /// Adds to the buffer without imposing a limit on line length.


### PR DESCRIPTION
Resolves: https://github.com/swiftlang/swift-subprocess/issues/245