### PR TITLE
Make Unix `testSuspendResumeProcess()` deterministic

### DIFF
--- a/Tests/SubprocessTests/DarwinTests.swift
+++ b/Tests/SubprocessTests/DarwinTests.swift
@@ -75,30 +75,6 @@ struct SubprocessDarwinTests {
         }
         #expect(FilePath(currentDir) == expected)
     }
-
-    @Test func testSuspendResumeProcess() async throws {
-        _ = try await Subprocess.run(
-            // This will intentionally hang
-            .path("/bin/cat"),
-            input: .none,
-            output: .discarded,
-            error: .discarded
-        ) { subprocess in
-            // First suspend the process
-            try subprocess.send(signal: .suspend)
-            var suspendedStatus: Int32 = 0
-            waitpid(subprocess.processIdentifier.value, &suspendedStatus, WNOHANG | WUNTRACED)
-            #expect(_was_process_suspended(suspendedStatus) > 0)
-            // Now resume the process
-            try subprocess.send(signal: .resume)
-            var resumedStatus: Int32 = 0
-            waitpid(subprocess.processIdentifier.value, &resumedStatus, WNOHANG | WUNTRACED)
-            #expect(_was_process_suspended(resumedStatus) == 0)
-
-            // Now kill the process
-            try subprocess.send(signal: .terminate)
-        }
-    }
 }
 
 #endif // canImport(Darwin)

--- a/Tests/SubprocessTests/LinuxTests.swift
+++ b/Tests/SubprocessTests/LinuxTests.swift
@@ -29,7 +29,6 @@ import SystemPackage
 import FoundationEssentials
 
 import Testing
-import _SubprocessCShims
 @testable import Subprocess
 
 // MARK: PlatformOption Tests
@@ -37,72 +36,6 @@ import _SubprocessCShims
 struct SubprocessLinuxTests {
     init() {
         _ = globallyIgnoredSIGPIPE
-    }
-
-    @Test func testSuspendResumeProcess() async throws {
-        func blockAndWaitForStatus(
-            pid: pid_t,
-            waitThread: inout pthread_t?,
-            targetSignal: Int32,
-            _ handler: @Sendable @escaping (Int32) -> Void
-        ) async throws {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                do {
-                    waitThread = try pthread_create {
-                        var suspendedStatus: Int32 = 0
-                        let rc = waitpid(pid, &suspendedStatus, targetSignal)
-                        if rc == -1 {
-                            continuation.resume(throwing: Errno(rawValue: errno))
-                            return
-                        }
-                        handler(suspendedStatus)
-                        continuation.resume()
-                    }
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-
-        _ = try await Subprocess.run(
-            // This will intentionally hang
-            .name("sleep"),
-            arguments: ["infinity"],
-            input: .none,
-            output: .discarded,
-            error: .discarded
-        ) { subprocess in
-            // First suspend the process
-            try subprocess.send(signal: .suspend)
-            var thread1: pthread_t? = nil
-            try await blockAndWaitForStatus(
-                pid: subprocess.processIdentifier.value,
-                waitThread: &thread1,
-                targetSignal: WSTOPPED
-            ) { status in
-                #expect(_was_process_suspended(status) > 0)
-            }
-            // Now resume the process
-            try subprocess.send(signal: .resume)
-            var thread2: pthread_t? = nil
-            try await blockAndWaitForStatus(
-                pid: subprocess.processIdentifier.value,
-                waitThread: &thread2,
-                targetSignal: WCONTINUED
-            ) { status in
-                #expect(_was_process_suspended(status) == 0)
-            }
-
-            // Now kill the process
-            try subprocess.send(signal: .terminate)
-
-            if let thread1 {
-                pthread_join(thread1, nil)
-            }
-            if let thread2 {
-                pthread_join(thread2, nil)
-            }
-        }
     }
 
     @Test func testUniqueProcessIdentifier() async throws {

--- a/Tests/SubprocessTests/ProcessControlTests.swift
+++ b/Tests/SubprocessTests/ProcessControlTests.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin) || canImport(Glibc) || canImport(Android) || canImport(Musl)
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+import Testing
+@testable import Subprocess
+
+#if canImport(System)
+import System
+#else
+import SystemPackage
+#endif
+
+@Suite(.serialized)
+struct ProcessControlTests {
+    init() {
+        _ = globallyIgnoredSIGPIPE
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func testSuspendResumeProcess() async throws {
+        // Set up pipes manually so the test owns both ends. This lets us bound
+        // how long we wait for output. Standard sequence/iterator-based outputs
+        // use non-Sendable iterators that can't be moved into a child task.
+        let inputPipe = try FileDescriptor.pipe()
+        let outputPipe = try FileDescriptor.pipe()
+
+        // Make the read end non-blocking so readLine() can poll with a
+        // deadline instead of blocking indefinitely.
+        let flags = fcntl(outputPipe.readEnd.rawValue, F_GETFL)
+        try #require(fcntl(outputPipe.readEnd.rawValue, F_SETFL, flags | O_NONBLOCK) == 0)
+
+        try await outputPipe.readEnd.closeAfter {
+            try await inputPipe.writeEnd.closeAfter {
+                _ = try await Subprocess.run(
+                    .path("/bin/cat"),
+                    // cat reads from inputPipe.readEnd. The parent keeps writeEnd to feed it.
+                    input: .fileDescriptor(inputPipe.readEnd, closeAfterSpawningProcess: true),
+                    // cat writes to outputPipe.writeEnd. The parent keeps readEnd to drain it.
+                    output: .fileDescriptor(outputPipe.writeEnd, closeAfterSpawningProcess: true),
+                    error: .discarded
+                ) { subprocess in
+                    // Confirm cat is running and echoing before manipulating its state.
+                    try inputPipe.writeEnd.writeLine("ready")
+                    try #require(try await outputPipe.readEnd.readLine(timeout: .seconds(2)) == "ready")
+
+                    // Suspend cat, then write two lines it must not echo back. If
+                    // SIGSTOP took effect, no amount of waiting produces output,
+                    // and the lines accumulate in the pipe buffer until SIGCONT.
+                    try subprocess.send(signal: .suspend)
+                    try inputPipe.writeEnd.writeLine("first")
+                    try inputPipe.writeEnd.writeLine("second")
+
+                    // Give cat 200ms to (incorrectly) produce output. If the suspend
+                    // didn't work, cat already echoed and the pipe has bytes ready.
+                    let leaked = try await outputPipe.readEnd.readLine(timeout: .milliseconds(200))
+                    try #require(leaked == nil, "cat produced output while suspended: \(leaked ?? "")")
+
+                    // Resume cat. Both buffered lines must emerge in order, proving
+                    // the process accumulated state while stopped and released it
+                    // on SIGCONT.
+                    try subprocess.send(signal: .resume)
+                    try #require(try await outputPipe.readEnd.readLine(timeout: .seconds(2)) == "first")
+                    try #require(try await outputPipe.readEnd.readLine(timeout: .seconds(2)) == "second")
+
+                    // Tear down. SIGTERM makes cat exit; closeAfter closes the
+                    // parent's write end as cleanup once run() returns.
+                    try subprocess.send(signal: .terminate)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Utilities
+extension FileDescriptor {
+    /// Writes a line plus newline to the file descriptor.
+    fileprivate func writeLine(_ line: String) throws {
+        let bytes = Array("\(line)\n".utf8)
+        try bytes.withUnsafeBufferPointer { ptr in
+            _ = try self.write(UnsafeRawBufferPointer(ptr))
+        }
+    }
+
+    /// Reads a single line (up to and excluding the next `\n`) from a
+    /// non-blocking file descriptor, returning `nil` if no line arrives
+    /// within `timeout`.
+    fileprivate func readLine(timeout: Duration) async throws -> String? {
+        let deadline = ContinuousClock.now + timeout
+        var accumulated: [UInt8] = []
+
+        while ContinuousClock.now < deadline {
+            var byte: UInt8 = 0
+            let n = withUnsafeMutablePointer(to: &byte) { ptr in
+                #if canImport(Darwin)
+                return Darwin.read(self.rawValue, ptr, 1)
+                #elseif canImport(Android)
+                return Android.read(self.rawValue, ptr, 1)
+                #elseif canImport(Glibc)
+                return Glibc.read(self.rawValue, ptr, 1)
+                #elseif canImport(Musl)
+                return Musl.read(self.rawValue, ptr, 1)
+                #endif
+            }
+
+            if n == 1 {
+                if byte == 0x0A {
+                    return String(decoding: accumulated, as: UTF8.self)
+                }
+                accumulated.append(byte)
+            } else if n == 0 {
+                return accumulated.isEmpty ? nil : String(decoding: accumulated, as: UTF8.self)
+            } else if errno == EAGAIN || errno == EWOULDBLOCK {
+                try await Task.sleep(for: .milliseconds(5))
+            } else if errno == EINTR {
+                continue
+            } else {
+                throw Errno(rawValue: errno)
+            }
+        }
+        return nil
+    }
+}
+
+#endif // canImport(Darwin) || canImport(Glibc) || canImport(Android) || canImport(Musl)


### PR DESCRIPTION
`testSuspendResumeProcess()` fails 211/5000 times (~4.2%) on Darwin with the following error:

> "Failed to monitor the child process exit status with underlying error: No child processes" (ECHILD)

It also fails on Android (Linux) as in #269.

The original test spawns `cat` with `input: .none`, redirecting `stdin` to `/dev/null`. With no input, `cat` reads EOF immediately and exits, racing the test's `send(signal: .suspend)`. When `cat` wins the race, it terminates before being suspended. 

The test then calls `waitpid()` to inspect and consume the child's status. In the intended case, `cat` is suspended and `waitpid()` consumes the stopped-state notification. In the race-loser case, `cat` has already exited and `waitpid()` consumes the exit notification, reaping the zombie before Subprocess can do so.

`Configuration.run()` subsequently calls `waitid()` via `monitorProcessTermination()`, but the kernel no longer has a record of the child, so Subprocess throws `failedToMonitorProcess` wrapping `ECHILD`.

### Design

This PR shifts verification from kernel-state inspection to observable behavior. The revised test:

1. Spawns `cat` with manually-managed input and output pipes.
2. Confirms `cat` echoes before any signals are sent.
3. Stops `cat`, writes two more lines, waits 200ms, and confirms no output appears.
4. Resumes `cat` and confirms both buffered lines emerge in order.

Regarding the 200ms timeout in step 3, any value large enough to outlast normal scheduling variance would work. Generally, a longer timeout strengthens the assertion.

This test introduces the use of Swift Testing's built-in timeout, which isn't currently used elsewhere in the test suite. In #267, @jakepetroules and I were talking about whether to use Swift Testing's timeouts (which have coarse granularity of at least 1 minute), or introducing a `withTimeout()` helper that accepts arbitrarily small timeouts. This test doesn't materially benefit from a smaller timeout, so I prefer using the built-in functionality.

I considered alternatives such as polling `proc_pidinfo` for `pbi_status == SSTOP` (rejected polling in general) or a local kqueue with `EVFILT_PROC | NOTE_SIGNAL` (requires building notification infrastructure for a single test).

This test passes 100% of the time across 2500 local iterations on Darwin. I ran it on Android via GitHub Actions ~50 times and some runs pass, but others fail with infrastructure issues setting up the emulator. Will be more reliable running on the real Subprocess CI.

### Windows

Windows uses Powershell and does not seem to have the same problem. It may be worth it to rewrite it anyway in a follow-up PR for consistency.