### PR TITLE
Make graceful shutdown return as soon as the subprocess exits

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -188,9 +188,7 @@ public struct Configuration: Sendable {
                 errorStream: nil
             )
             // Attempt to terminate the child process.
-            await execution.runTeardownSequence(
-                self.platformOptions.teardownSequence
-            )
+            await execution.teardown(using: self.platformOptions.teardownSequence)
         }
     }
 }

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -83,26 +83,31 @@ internal func waitForProcessTermination(
                     // On older releases, use signalfd so we do not need
                     // to register anything with epoll
                     if processIdentifier.processDescriptor > 0 {
-                        // Register processDescriptor with epoll
-                        var event = epoll_event(
-                            events: EPOLLIN.rawValue,
-                            data: epoll_data(fd: processIdentifier.processDescriptor)
-                        )
-                        let rc = epoll_ctl(
-                            storage.epollFileDescriptor,
-                            EPOLL_CTL_ADD,
-                            processIdentifier.processDescriptor,
-                            &event
-                        )
-                        if rc != 0 {
-                            let epollErrno = errno
-                            let error: SubprocessError = .failedToMonitor(
-                                withUnderlyingError: Errno(rawValue: epollErrno)
+                        var newState = storage
+                        // epoll rejects duplicate EPOLL_CTL_ADD for the same fd
+                        // with EEXIST, so only register the pidfd the first
+                        // time we see it. Subsequent waiters share the
+                        // existing registration via the continuation list.
+                        if newState.continuations[processIdentifier.processDescriptor] == nil {
+                            var event = epoll_event(
+                                events: EPOLLIN.rawValue,
+                                data: epoll_data(fd: processIdentifier.processDescriptor)
                             )
-                            return .failure(error)
+                            let rc = epoll_ctl(
+                                storage.epollFileDescriptor,
+                                EPOLL_CTL_ADD,
+                                processIdentifier.processDescriptor,
+                                &event
+                            )
+                            if rc != 0 {
+                                let epollErrno = errno
+                                let error: SubprocessError = .failedToMonitor(
+                                    withUnderlyingError: Errno(rawValue: epollErrno)
+                                )
+                                return .failure(error)
+                            }
                         }
                         // Now save the registration
-                        var newState = storage
                         var list = newState.continuations[processIdentifier.processDescriptor] ?? []
                         list.append(continuation)
                         newState.continuations[processIdentifier.processDescriptor] = list
@@ -119,7 +124,7 @@ internal func waitForProcessTermination(
                             if !processExited {
                                 // Save this continuation to be called by signal handler
                                 var newState = storage
-                                var list = newState.continuations[processIdentifier.processDescriptor] ?? []
+                                var list = newState.continuations[processIdentifier.value] ?? []
                                 list.append(continuation)
                                 newState.continuations[processIdentifier.value] = list
                                 state = .started(newState)

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -102,9 +102,35 @@ extension Execution {
     /// - Parameter sequence: The steps to perform.
     public func teardown(using sequence: some Sequence<TeardownStep> & Sendable) async {
         await withUncancelledTask {
-            await runTeardownSequence(sequence)
+            await withTaskGroup(of: TeardownGroupResult.self) { group in
+                group.addTask {
+                    try? await waitForProcessTermination(for: self.processIdentifier)
+                    return .processMonitoringFinished
+                }
+
+                group.addTask {
+                    await runTeardownSequence(sequence)
+                    return .teardownFinished
+                }
+
+                let firstFinishedTask = await group.next()!
+                switch firstFinishedTask {
+                case .processMonitoringFinished:
+                    // Process has exited. Cancel the teardown task now
+                    group.cancelAll()
+                case .teardownFinished:
+                    // Teardown sequence has finished. Wait for process monitoring
+                    // to finish due to `kill`
+                    await group.waitForAll()
+                }
+            }
         }
     }
+}
+
+private enum TeardownGroupResult {
+    case processMonitoringFinished
+    case teardownFinished
 }
 
 internal enum TeardownStepCompletion {

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -296,6 +296,39 @@ extension SubprocessProcessMonitoringTests {
         }
     }
 
+    @Test func testCanMonitorSameProcessConcurrently() async throws {
+        // Multiple tasks waiting on the *same* process must all observe its
+        // termination. This is the idempotency contract of
+        // waitForProcessTermination: registering the same process for
+        // monitoring more than once concurrently must succeed on every
+        // platform. (On Linux >= 5.4 this specifically guards against
+        // double-registering the pidfd with epoll, which fails with EEXIST.)
+        let waiterCount = 10
+        // Keep the child alive long enough that every waiter registers
+        // before it exits, so the concurrent-registration path is exercised.
+        let config = self.longRunningProcess(withTimeOutSeconds: 1)
+        try await withSpawnedExecution(config: config) { execution in
+            try await withThrowingTaskGroup { group in
+                for _ in 0..<waiterCount {
+                    group.addTask {
+                        // Call the monitoring primitive directly instead of
+                        // monitorProcessTermination: the zombie must be reaped
+                        // exactly once, so we reap only after every waiter has
+                        // observed termination.
+                        try await waitForProcessTermination(
+                            for: execution.processIdentifier
+                        )
+                    }
+                }
+
+                try await group.waitForAll()
+            }
+            // Every waiter resumed without error; reap the process once.
+            let status = try reapProcess(with: execution.processIdentifier)
+            #expect(status.isSuccess)
+        }
+    }
+
     @Test func testExitSignalCoalescing() async throws {
         // Spawn many immediately exit processes in a row to trigger
         // signal coalescing. Make sure we can handle this

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -223,6 +223,71 @@ extension SubprocessUnixTests {
     }
 }
 
+// MARK: - Teardown Timing
+extension SubprocessUnixTests {
+    /// Spawns a child that prints `ready` and then blocks in `sleep`, waits
+    /// for that marker so the child is known to be running, then cancels the
+    /// run to trigger teardown and returns how long the teardown took.
+    private func measureCancelledTeardown(
+        using teardownSequence: [TeardownStep]
+    ) async -> Duration {
+        let (readyStream, readyContinuation) = AsyncStream.makeStream(of: Void.self)
+        return await withTaskGroup(
+            of: Void.self,
+            returning: Duration.self
+        ) { group in
+            group.addTask {
+                var platformOptions = PlatformOptions()
+                // Isolate the child in its own session so teardown can't reach
+                // anything but the process we spawned.
+                platformOptions.createSession = true
+                platformOptions.teardownSequence = teardownSequence
+                let configuration = Configuration(
+                    .path("/bin/sh"),
+                    // `exec` so the monitored child becomes `sleep` itself,
+                    // which dies instantly on SIGTERM/SIGKILL.
+                    arguments: ["-c", "echo ready; exec sleep 10"],
+                    platformOptions: platformOptions
+                )
+                _ = try? await Subprocess.run(
+                    configuration,
+                    input: .none,
+                    output: .sequence,
+                    error: .discarded
+                ) { execution in
+                    for try await line in execution.standardOutput.strings() {
+                        if line.trimmingCharacters(in: .whitespacesAndNewlines) == "ready" {
+                            readyContinuation.finish()
+                        }
+                    }
+                }
+            }
+            // Block until the child confirms it is running.
+            for await _ in readyStream {}
+            // Time only the teardown triggered by cancellation.
+            return await ContinuousClock().measure {
+                group.cancelAll()
+                await group.waitForAll()
+            }
+        }
+    }
+
+    @Test func testKillTeardownReturnsAsSoonAsProcessExits() async {
+        let elapsed = await self.measureCancelledTeardown(using: [
+            .send(signal: .kill, allowedDurationToNextStep: .seconds(5))
+        ])
+        #expect(elapsed < .seconds(5), "SIGKILL is uncatchable; teardown should not wait")
+    }
+
+    @Test func testTerminateTeardownReturnsAsSoonAsProcessExits() async {
+        let elapsed = await self.measureCancelledTeardown(using: [
+            .send(signal: .terminate, allowedDurationToNextStep: .seconds(3)),
+            .send(signal: .kill, allowedDurationToNextStep: .seconds(5)),
+        ])
+        #expect(elapsed < .seconds(5), "sleep dies on SIGTERM instantly; teardown should not wait")
+    }
+}
+
 // MARK: - PATH Resolution Tests
 extension SubprocessUnixTests {
     @Test func testExecutablePathsPreserveOrder() throws {


### PR DESCRIPTION
Race process-termination monitoring against the teardown sequence in a task group: if the monitor finishes first, the child has exited, so cancel the teardown task and return immediately; if teardown finishes first (after its terminal ), wait for the monitor to observe the exit.

Make `waitForProcessTermination` on all platforms `idempotent`, since now we are calling it multiple times.

Resolves: rdar://174278515