### PR TITLE
Avoid double-reap of child process after read `EINTR`

### DIFF
--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -514,6 +514,14 @@ static int _highest_possibly_open_fd(void) {
     return sysconf(_SC_OPEN_MAX);
 }
 
+static void _subprocess_reap_pid(pid_t pid) {
+    siginfo_t info;
+    int rc;
+    do {
+        rc = waitid(P_PID, pid, &info, WEXITED);
+    } while (rc == -1 && errno == EINTR);
+}
+
 int _subprocess_fork_exec(
     pid_t * _Nonnull pid,
     int * _Nonnull pidfd,
@@ -740,8 +748,7 @@ int _subprocess_fork_exec(
     } else {
 #define reap_child_process_and_return_errno int capturedError = errno; \
     close(pipefd[0]); \
-    siginfo_t info; \
-    waitid(P_PID, childPid, &info, WEXITED); \
+    _subprocess_reap_pid(childPid); \
     return capturedError
 
 #if TARGET_OS_LINUX
@@ -778,24 +785,22 @@ int _subprocess_fork_exec(
                 close(pipefd[0]);
                 return 0;
             }
-            // if we reach this point, exec failed.
-            // Since we already have the child pid (fork succeed), reap the child
-            // This mimic posix_spawn behavior
-            siginfo_t info;
-            waitid(P_PID, childPid, &info, WEXITED);
-
+            // Capture errno now, before close()/waitid() can overwrite it.
+            int read_errno = errno;
+            if (read_rc < 0 && read_errno == EINTR) {
+                // Interrupted by a signal. Retry the read. Do not reap here;
+                // the child is reaped exactly once below.
+                continue;
+            }
+            // exec failed. Reap the child (mimics posix_spawn, which reaps on
+            // exec failure) using the pid from the successful fork.
+            _subprocess_reap_pid(childPid);
+            close(pipefd[0]);
             if (read_rc > 0) {
-                // Child exec failed and reported back
-                close(pipefd[0]);
+                // Child exec failed and reported its errno back
                 return childError;
             } else {
-                // Read failed
-                if (errno == EINTR) {
-                    continue;
-                } else {
-                    close(pipefd[0]);
-                    return errno;
-                }
+                return read_errno;
             }
         }
     }


### PR DESCRIPTION
Closes #131.

When `read()` on the error pipe fails with `EINTR`, the original loop reaps the child with `waitid()`, restarts the loop, and on the next iteration reads the buffered error and calls `waitid()` on `childPid` a second time. By then, the PID may have been recycled onto a different child of this process, so the second `waitid()` can reap an unrelated process.

Restructure the parent read loop so the `EINTR` retry is handled before the reap, guaranteeing the child is reaped exactly once. Move the reap into a new `_subprocess_reap_pid()` helper that retries `waitid()` on its own `EINTR`, and update the `reap_child_process_and_return_errno` macro to use the same helper.