### PR TITLE
Mark Windows UserCredentials API as internal for now

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -314,7 +314,7 @@ extension Configuration {
 public struct PlatformOptions: Sendable {
     /// The credentials to use when spawning the subprocess
     /// as a different user.
-    public struct UserCredentials: Sendable, Hashable {
+    internal struct UserCredentials: Sendable, Hashable {
         /// The name of the user.
         ///
         /// This is the name of the user account to run as.
@@ -389,7 +389,7 @@ public struct PlatformOptions: Sendable {
     }
 
     /// The user credentials for starting the process as another user.
-    public var userCredentials: UserCredentials? = nil
+    internal var userCredentials: UserCredentials? = nil
     /// The console behavior of the new process.
     ///
     /// Defaults to inheriting the console from the parent process.


### PR DESCRIPTION
There's 4 different APIs for spawning processes on Windows:

- CreateProcessW  (we call this today)
- CreateProcessAsUserW (we **don't** call this today)
- CreateProcessWithTokenW (we **don't** call this today)
- CreateProcessWithLogonW  (we call this today)

All have notably different behavior and required privileges, and it's not clear if there's the canonical one which is the lowest common denominator we can always use, or whether we need to provide all of the different paths to the user by allowing them to pass creds OR a token.

I was discussing a bit with @compnerd and we believe we should mark these APIs internal for now and defer them to post 1.0. That way it can give us proper time to make sure we're designing the right API surface, and is the kind of thing we can easily make as an additive change later on.