### PR TITLE
Add back standardOutput and standardError as deprecated renamed properties

### DIFF
--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -216,6 +216,12 @@ extension OutputProtocol where Self == FileDescriptorOutput {
         )
     }
 
+    // TODO: remove for 1.0
+    @available(*, deprecated, renamed: "currentStandardOutput")
+    public static var standardOutput: Self {
+        return currentStandardOutput
+    }
+
     /// Creates a subprocess output that writes to the current process's standard error.
     ///
     /// The file descriptor isn't closed afterwards.
@@ -224,6 +230,12 @@ extension OutputProtocol where Self == FileDescriptorOutput {
             .standardError,
             closeAfterSpawningProcess: false
         )
+    }
+
+    // TODO: remove for 1.0
+    @available(*, deprecated, renamed: "currentStandardError")
+    public static var standardError: Self {
+        return currentStandardError
     }
 }
 


### PR DESCRIPTION
The rename of `standardOutput ` to `currentStandardOutput ` and `standardError ` to `currentStandardError ` in https://github.com/swiftlang/swift-subprocess/pull/233 is causing breakage in various projects like https://github.com/swiftlang/swift-java/pull/775

This PR brings them back as a stopgap deprecated/renamed property to prevent projects from having to pin to 0.4.