### PR TITLE
Make `testConcurrentSlowExitsDoNotHang()` deterministic and leak-free

### DIFF
--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -733,39 +733,26 @@ extension SubprocessUnixTests {
         }
     }
 
-    // Ensure Subprocess does not hang on Linux when several concurrent
-    // `Subprocess.run` calls saw their children exit in a tight burst.
-    //
-    // Spawns 16 `bash` children, each with a SIGTERM trap that sleeps one second
-    // before exiting. Every body closure sends SIGTERM at roughly the same instant,
-    // so all 16 children finish their trap and become zombies inside a single small.
-    @Test(.requiresBash) func testConcurrentSlowExitsDoNotHang() async throws {
-        // 16 concurrent slow-to-exit children is enough to flood the
-        // monitor and trigger the burst on Linux.
+    @Test(.timeLimit(.minutes(1)))
+    func testConcurrentSlowExitsDoNotHang() async throws {
+        // When many concurrent `Subprocess.run` calls have their children exit
+        // in a tight burst, the SIGCHLD-coalescing reaper must drain every
+        // ready child per wakeup. 16 children that each sleep ~1s will exit
+        // within a few milliseconds of each other and flood the reaper; the
+        // body-less runs keep all 16 monitors blocked on termination for the
+        // full second, so the exits land while every monitor is waiting. No
+        // signal or trap is involved: the reaper keys on child exit (SIGCHLD),
+        // which is identical whether a child exits on a timer or a signal, so
+        // a timed exit reproduces the same stress without relying on bash.
         let count = 16
-        // Trap SIGTERM, sleep 1 s in the handler, then exit. bash (not
-        // POSIX sh) is required: `sh -c 'trap ...; sleep 300'` would defer
-        // the trap until `sleep 300` completes, while bash interrupts
-        // `wait` immediately on signal.
-        let script = "trap 'sleep 1; exit 0' TERM; sleep 300 & wait"
-
         try await withThrowingTaskGroup(of: TerminationStatus.self) { group in
             for _ in 0..<count {
                 group.addTask {
-                    let result = try await Subprocess.run(
-                        .name("bash"),
-                        arguments: ["-c", script],
-                        input: .none,
-                        output: .discarded,
-                        error: .discarded
-                    ) { execution in
-                        // Let all N processes install their traps before
-                        // we signal them, so the kills land in a tight
-                        // burst and the children exit ~simultaneously.
-                        try await Task.sleep(for: .milliseconds(100))
-                        try execution.send(signal: .terminate)
-                    }
-                    return result.terminationStatus
+                    try await Subprocess.run(
+                        .path("/bin/sleep"),
+                        arguments: ["1"],
+                        output: .discarded
+                    ).terminationStatus
                 }
             }
             for try await status in group {


### PR DESCRIPTION
`testConcurrentSlowExitsDoNotHang()` is flaky, and under repeated runs it also leaks processes until spawning fails with `EAGAIN`.

The test spawns 16 bash children running `trap 'sleep 1; exit 0' TERM; sleep 300 & wait`, sends each `SIGTERM` after 100ms, and asserts every child exits `0`. It fails in two ways, both rooted in the trap/signal/background-sleep design.

First, the exit status is not deterministic. `SIGTERM` interrupts the `wait`, which returns `128+SIGTERM` (`143`); the trap's `exit 0` doesn't reliably override that status, so the run occasionally reports `.exited(143)`. On Darwin's system bash (3.2) this reproduces about 1/50 times.

Second, when the trap fires `exit 0`, the backgrounded `sleep 300` is orphaned, reparented to `launchd`, and runs for its full 300 seconds. Nothing reaps it, so each iteration strands 16 `sleep 300` processes; when run repeatedly, they accumulate until the process limit is reached and every subsequent attempt fails with `EAGAIN`, producing a cascade of subsequent failures. I confirmed this by inspection when running the test; after a single run, 16 orphaned `sleep 300` (PPID 1) remain and persist past the test process's own exit, so nothing on the success path could have reaped them.

This PR uses 16 body-less `/bin/sleep 1` children. The reaper keys on child exit (`SIGCHLD`), which is identical whether a child exits on a timer or a signal, so the children still exit in a tight burst and flood the reaper. The body-less runs keep all 16 monitors blocked on termination for the full second, so the exits land while every monitor is waiting, reproducing the condition the test guards against. This approach has the benefit of being deterministic, leaking nothing, and not relying on bash. The time limit is added to avoid hanging in case of reaper regressions. This test passes when run 1,000 times consecutively.