### PR TITLE
Run teardown sequence when the custom closure throws

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -139,6 +139,14 @@ public struct Configuration: Sendable {
                     taskFinishFlag.addOne()
                     result = .success(bodyResult)
                 } catch {
+                    let execution = Execution<Input, Output, Error>(
+                        processIdentifier: processIdentifier,
+                        inputWriter: nil,
+                        outputStream: nil,
+                        errorStream: nil
+                    )
+                    // Attempt to terminate the child process when the body throws
+                    await execution.teardown(using: self.platformOptions.teardownSequence)
                     result = .failure(error)
                 }
 

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -3437,6 +3437,32 @@ extension SubprocessIntegrationTests {
             #expect(output == ["100°C", "32—x", "€5"])
         }
     }
+
+    @Test func testSubprocessTearsdownChildProcessWhenBodyThrows() async throws {
+        struct MyError: Swift.Error {}
+
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: ["-Command", "Start-Sleep -Seconds 9999"]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .name("tail"),
+            arguments: ["-f", "/dev/null"]
+        )
+        #endif
+        await #expect(throws: MyError.self) {
+            _ = try await _run(
+                setup,
+                input: .none,
+                output: .discarded,
+                error: .discarded
+            ) { execution in
+                throw MyError()
+            }
+        }
+    }
 }
 
 // MARK: - Utilities


### PR DESCRIPTION
Currently, Subprocess waits for the child process to exit naturally when the body closure throws. We should attempt to tear down the child process when that happens to prevent infinite hangs.