### PR TITLE
Fix OpenBSD platform support

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+BSD.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+BSD.swift
@@ -169,7 +169,7 @@ internal func _makeKevent(
     flags: UInt16,
     fflags: UInt32 = 0
 ) -> kevent {
-    #if canImport(Darwin)
+    #if canImport(Darwin) || os(OpenBSD)
     return kevent(
         ident: ident,
         filter: filter,

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -17,7 +17,12 @@ import System
 import SystemPackage
 #endif
 
+#if os(OpenBSD)
+// FIXME: Why is this necessary only on OpenBSD?
+public import _SubprocessCShims
+#else
 import _SubprocessCShims
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -360,13 +360,13 @@ private var _currentPID: ProcessIdentifier {
         threadHandle: GetCurrentThread(),
         jobHandle: INVALID_HANDLE_VALUE
     )
-    #elseif os(Linux) || os(Android) || os(FreeBSD)
+    #elseif canImport(Darwin)
+    return ProcessIdentifier(value: getpid())
+    #else
     return ProcessIdentifier(
         value: getpid(),
         processDescriptor: 0 // Not used in these tests.
     )
-    #else
-    return ProcessIdentifier(value: getpid())
     #endif
 }
 

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -420,10 +420,11 @@ extension SubprocessUnixTests {
                 arguments: ["-c", "kill -\(signal) $$"],
                 output: .discarded
             )
-            #if os(Android)
-            // When terminated by a catchable signal, Android's /bin/sh exits
-            // normally with a status of 128+n instead of dying by the signal.
-            // SIGKILL is uncatchable and still produces a signal-based termination.
+            #if os(Android) || os(OpenBSD)
+            // When terminated by a catchable signal, /bin/sh on Android (mksh)
+            // and OpenBSD (oksh) — both pdksh-derived — exits normally with a
+            // status of 128+n instead of re-raising the signal. SIGKILL is
+            // uncatchable and still produces a signal-based termination.
             // https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Signal-Handling.html
             let expected: TerminationStatus =
                 signal == SIGKILL
@@ -652,20 +653,42 @@ extension SubprocessUnixTests {
                 #expect(closeResult == 0)
             }
         }
+        // Probe each fd via dup2 in a forked external command (true(1)).
+        // Avoids the [-e /dev/fd/N] / [-e /proc/self/fd/N] oracle, which
+        // gives false positives on OpenBSD (static character-device nodes
+        // /dev/fd/0..63 exist regardless of which fds are open) and requires
+        // /proc on Linux / fdescfs on FreeBSD.
+        //
+        // Why /usr/bin/true and not the builtin? When bash applies `>&N` to
+        // a builtin, it first saves the original fd via fcntl(F_DUPFD, 10)
+        // so it can restore it after the builtin returns. While the builtin
+        // is running, fd 10 (or whichever low fd >= 10 is free) is held open
+        // as bash's saved fd, so a probe of fd 10 falsely succeeds. Forking
+        // an external command sidesteps this: bash applies the redirection
+        // in the forked child without saving (the child is about to exec
+        // away), so dup2 only succeeds when the fd was genuinely open.
+        //
+        // The subshell wrapper isolates the redirection failure: dash treats
+        // a redirection failure in the current shell as fatal to the
+        // non-interactive script, but a failure in a subshell only exits
+        // the subshell.
         let shellScript =
             """
             for fd in "$@"; do
-                if [ -e "/proc/self/fd/$fd" ] || [ -e "/dev/fd/$fd" ]; then
+                if (/usr/bin/true <&"$fd") 2>/dev/null; then
                     echo "$fd:OPEN"
                 else
                     echo "$fd:CLOSED"
                 fi
             done
             """
-        var arguments = ["-c", shellScript, "--"]
-        #if os(FreeBSD)
-        arguments.append("") // FreeBSD /bin/sh interprets the first argument as the script name
-        #endif
+        // POSIX `sh -c command_string [command_name [argument...]]` always
+        // takes the next argv as $0. Do not pass `--`: OpenBSD's ksh-derived
+        // /bin/sh does not honor it as an option terminator and would assign
+        // it to $0 (while FreeBSD's ash-derived /bin/sh consumes it and
+        // shifts $0 onto the next arg) — keep things deterministic by
+        // passing a single explicit placeholder.
+        var arguments = ["-c", shellScript, "subprocess-fd-test"]
         arguments.append(contentsOf: openedFileDescriptors.map { "\($0)" })
 
         let result = try await Subprocess.run(


### PR DESCRIPTION
Fix OpenBSD platform support, plus two test-only fixes for OpenBSD-specific shell quirks that are not Subprocess implementation bugs.

Detailed explanation from Claude:

testExitSignal()
================

Symptom: SIGTERM produced exited(143) instead of signaled(15); SIGINT produced exited(130) instead of signaled(2). SIGKILL was reported correctly.

Root cause: OpenBSD's /bin/sh is a hard link to /bin/ksh (oksh, pdksh- derived). When it receives SIGTERM/SIGINT, oksh's trap handler sets EF_FAKE_SIGDIE. The re-raise in quitenv() (bin/ksh/main.c) is gated on both EF_FAKE_SIGDIE *and* getpgrp() == kshpid. Subprocess does not place the child in its own process group, so the pgrp-leader check fails and oksh falls through to exit(128 + signo). The parent therefore observes WIFEXITED with status 143/130, not WIFSIGNALED. SIGKILL is uncatchable so it still reports signaled(9). FreeBSD/NetBSD escape this because their /bin/sh is Almquist-derived and does the standard signal(sig, SIG_DFL); raise(sig) re-raise.

This is the same shape that the test already special-cases for Android's mksh (also pdksh-derived). Fix: extend the existing #if os(Android) branch to also cover OpenBSD.

testSubprocessDoesNotInheritVeryHighFileDescriptors() =====================================================

Symptom: 11 output lines for 10 tracked fds; one rogue :OPEN line with no fd number; six fds reported OPEN instead of CLOSED. The Subprocess implementation is correct — closefrom(pipefd[1]+1) plus the explicit close loop in process_shims.c closes everything kernel-side regardless of FD_CLOEXEC. The bugs were both in the test's verification oracle.

Bug 1: /dev/fd/N is not a runtime view of open fds on OpenBSD. OpenBSD ships static character-device nodes /dev/fd/0..63 from etc/MAKEDEV.common; there is no fdescfs and no /proc (procfs was removed in 5.7). So [ -e /dev/fd/N ] is always true for N <= 63 regardless of whether the calling process has fd N open. The F_DUPFD ladder produces fds {4, 5, 6, 8, 16, 32, 64, 128, 256, 512} — exactly six (4, 5, 6, 8, 16, 32) fall in the always-existing range, matching the six false-OPEN failures.

Bug 2: 'sh -c CMD -- ARGS' argv handling differs between the BSDs. The previous test passed '--' as the option terminator and added a synthetic '' for FreeBSD/OpenBSD because FreeBSD's ash-derived /bin/sh consumes '--' as an option terminator (so the next arg becomes $0 and the first FD would be lost without the placeholder). OpenBSD's ksh-derived /bin/sh does not honor '--' as an option terminator — '--' itself becomes $0 — so adding '' shifted everything by one, producing the 11th iteration. The empty-string iteration tested [ -e /dev/fd/ ] (the directory), which exists, producing the rogue :OPEN line.

Fix: replace the /dev/fd / /proc oracle with a dup2-based probe (`true >&"$fd"` succeeds iff dup2(fd, 1) succeeds, i.e. iff fd is open). Drop '--' and use a single explicit $0 placeholder, which makes the argv layout identical across Linux, macOS, FreeBSD, OpenBSD, and Android.

Verification commands on the OpenBSD CI host that confirm both diagnoses:

  /bin/sh -c 'kill -TERM $$'; echo $?              # expect 143
  ls /dev/fd | wc -l                               # expect 64
  /bin/sh -c 'echo "[$0] [$#] [$@]"' -- "" a b c   # expect [--] [3] [ a b c]

References:
- OpenBSD ksh trap.c / main.c quitenv() pgrp gate: https://github.com/openbsd/src/blob/master/bin/ksh/main.c
- OpenBSD etc/MAKEDEV.common static fd/0..63 nodes: https://github.com/openbsd/src/blob/master/etc/MAKEDEV.common
- OpenBSD closefrom(2): https://man.openbsd.org/closefrom
- GNU autoconf signal handling note: https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Signal-Handling.html