### PR TITLE
Make `testRunawayProcess()` deterministic

### DIFF
--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -472,8 +472,12 @@ extension SubprocessUnixTests {
                 group.addTask {
                     var platformOptions = PlatformOptions()
                     platformOptions.teardownSequence = [
-                        // Send SIGINT for child to catch
-                        .send(signal: .interrupt, allowedDurationToNextStep: .milliseconds(100))
+                        // SIGTERM for the child to catch (paired with the poll
+                        // loop in the script). The grace period must comfortably
+                        // exceed the poll interval so the trap is serviced
+                        // before escalation. The grace period is a ceiling;
+                        // teardown returns as soon as the child exits.
+                        .send(signal: .terminate, allowedDurationToNextStep: .seconds(1))
                     ]
                     let result = try await Subprocess.run(
                         .name("bash"),
@@ -485,11 +489,18 @@ extension SubprocessUnixTests {
                             # It runs in the background forever until this script kills it
                             /usr/bin/yes "Runaway process from \(#function), please file a SwiftSubprocess bug." > /dev/null &
                             child_pid=$! # Retrieve the grand child yes pid
-                            # When SIGINT is sent to the script, kill grand child now
-                            trap "echo >&2 'child: received signal, killing grand child ($child_pid)'; kill -s KILL $child_pid; exit 0" INT
+                            # When SIGTERM is sent to the script, kill grand child now
+                            trap "echo >&2 'child: received signal, killing grand child ($child_pid)'; kill -s KILL $child_pid; exit 0" TERM
                             echo "$child_pid" # communicate the child pid to our parent
                             echo "child: waiting for grand child, pid: $child_pid" >&2
-                            wait $child_pid # wait for runaway child to exit
+                            # Poll rather than `wait "$child_pid"`. A blocking wait on a child that never
+                            # exits leaves bash no point at which to service a deferred trap, so a signal
+                            # landing in the window just before waitpid blocks is recorded but never run,
+                            # and teardown escalates to SIGKILL. A short sleep loop returns to a
+                            # trap-checking safe point each iteration, bounding trap latency.
+                            while kill -0 "$child_pid" 2>/dev/null; do
+                                sleep 0.05
+                            done
                             """,
                         ],
                         platformOptions: platformOptions,
@@ -498,7 +509,7 @@ extension SubprocessUnixTests {
                         error: .fileDescriptor(.standardError, closeAfterSpawningProcess: false)
                     ) { execution in
                         // Read stdout incrementally. Once we see the PID line,
-                        // we know the trap is set up and it's safe to send SIGINT.
+                        // we know the trap is set up and it's safe to send SIGTERM.
                         var grandChildPid: pid_t?
                         for try await line in execution.standardOutput.strings() {
                             let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)


### PR DESCRIPTION
`testRunawayProcess()` fails about 0.05% of the time on macOS.

On cancellation, the test's teardown sent the child `SIGINT`, escalating to `SIGKILL` after 100ms; the `INT` trap was meant to kill the runaway grandchild and `exit 0`, and the child otherwise blocked in `wait "$child_pid"`. It failed intermittently in two ways, both from trapping an asynchronous signal around a blocking `wait`.

First, `signaled(11)`: bash interrupts the `wait` for `SIGINT` via `siglongjmp`, and on Darwin's system bash (3.2, arm64e) that `longjmp` occasionally fails pointer authentication and crashes the child with `SIGSEGV`:

```
Exception Type:    EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS ... (possible pointer authentication failure)
...
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_platform.dylib      	       0x18cdfd7cc _longjmp + 72
1   ???                           	     0xc5dc358af08 ???
2   libsystem_platform.dylib      	       0x18cdff744 _sigtramp + 56
3   libsystem_platform.dylib      	       0x18cdfd810 setjmp + 28
4   bash                          	       ...
```

Second, `signaled(9)`: If the signal lands after bash last checks pending traps, but before it blocks in `wait`, the trap is recorded but never run. A `wait` on a child that never exits offers no further safe point, so the child lives until teardown escalates to `SIGKILL`.

This PR sends `SIGTERM` instead. Its trap runs at a deferred safe point rather than `longjmp`-ing out of the handler, so the crash cannot occur. Poll with `kill -0`/`sleep` rather than blocking in `wait`, so a deferred trap runs within one short interval; also widen the grace period so it comfortably exceeds that interval and the trap is serviced before escalation. This test passes when run 10,000 times consecutively.

I considered removing bash entirely, but that would require a purpose-built helper for various platforms and didn't seem worth it.