### PR TITLE
Update WindowsError to be able to represent NTSTATUS, HRESULT, errno, and Win32 error

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -824,7 +824,7 @@ internal func _safelyClose(_ target: _CloseTarget) throws(SubprocessError) {
             }
             let subprocessError: SubprocessError = .asyncIOFailed(
                 reason: "Failed to close HANDLE",
-                underlyingError: SubprocessError.WindowsError(rawValue: error)
+                underlyingError: SubprocessError.WindowsError(win32Error: error)
             )
 
             throw subprocessError
@@ -1066,7 +1066,7 @@ internal struct CreatedPipe: ~Copyable, Sendable {
                 // Throw all other errors
                 throw .asyncIOFailed(
                     reason: "CreateNamedPipeW failed",
-                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                    underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                 )
             }
 
@@ -1094,7 +1094,7 @@ internal struct CreatedPipe: ~Copyable, Sendable {
             guard let childEnd, childEnd != INVALID_HANDLE_VALUE else {
                 throw .asyncIOFailed(
                     reason: "CreateFileW failed",
-                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                    underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                 )
             }
             switch purpose {
@@ -1287,13 +1287,13 @@ extension HANDLE {
         else {
             throw .asyncIOFailed(
                 reason: "Failed to create pipe",
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         guard let handle else {
             throw .asyncIOFailed(
                 reason: "Failed to create pipe",
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         return handle

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -225,12 +225,47 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
 #if os(Windows)
 
 extension SubprocessError {
-    /// An error that represents a Windows error code from `GetLastError`.
-    public struct WindowsError: Error, RawRepresentable, Hashable {
-        public let rawValue: DWORD
+    /// Represents an error originating from one of the underlying Windows subsystems.
+    public enum WindowsError: Error, Hashable {
 
-        public init(rawValue: DWORD) {
-            self.rawValue = rawValue
+        /// An error returned by the Windows NT kernel or Native API.
+        ///
+        /// `NTSTATUS` values are typically returned by low-level system functions
+        /// prefixed with `Nt` or `Zw`.
+        case ntStatus(NTSTATUS)
+
+        /// A Win32 subsystem error.
+        ///
+        /// These are the standard `DWORD` error codes typically retrieved by calling
+        /// `GetLastError()` immediately after a Win32 API function fails.
+        case win32(DWORD)
+
+        /// A Component Object Model (COM) or Windows Runtime (WinRT) error.
+        ///
+        /// `HRESULT` values encode the severity, facility, and error code. A negative
+        /// value generally indicates a failure.
+        case hresult(HRESULT)
+
+        /// A C Runtime (CRT) or POSIX-style error.
+        ///
+        /// These are typically retrieved from the thread-local `errno` variable after
+        /// a standard C library function fails.
+        case cRuntime(errno_t)
+
+        public init(ntStatus: NTSTATUS) {
+            self = .ntStatus(ntStatus)
+        }
+
+        public init(win32Error: DWORD) {
+            self = .win32(win32Error)
+        }
+
+        public init(hresult: HRESULT) {
+            self = .hresult(hresult)
+        }
+
+        public init(cRuntimeError: errno_t) {
+            self = .cRuntime(cRuntimeError)
         }
     }
 }

--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -62,7 +62,7 @@ final class AsyncIO: @unchecked Sendable {
         else {
             let error: SubprocessError = .asyncIOFailed(
                 reason: "CreateIoCompletionPort failed",
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
             self.ioCompletionPort = .failure(error)
             self.monitorThread = .failure(error)
@@ -116,7 +116,7 @@ final class AsyncIO: @unchecked Sendable {
                         } else {
                             let error: SubprocessError = .asyncIOFailed(
                                 reason: "GetQueuedCompletionStatus failed",
-                                underlyingError: SubprocessError.WindowsError(rawValue: lastError)
+                                underlyingError: SubprocessError.WindowsError(win32Error: lastError)
                             )
                             reportError(error)
                             break
@@ -225,7 +225,7 @@ final class AsyncIO: @unchecked Sendable {
                             _ = storage.removeRegistration(for: completionKey)
                             let error: SubprocessError = .asyncIOFailed(
                                 reason: "CreateIoCompletionPort failed",
-                                underlyingError: SubprocessError.WindowsError(rawValue: capturedError)
+                                underlyingError: SubprocessError.WindowsError(win32Error: capturedError)
                             )
                             return .failed(error)
                         }
@@ -353,7 +353,7 @@ final class AsyncIO: @unchecked Sendable {
             }
             guard lastError == ERROR_IO_PENDING else {
                 let error: SubprocessError = .failedToReadFromProcess(
-                    withUnderlyingError: SubprocessError.WindowsError(rawValue: lastError)
+                    withUnderlyingError: SubprocessError.WindowsError(win32Error: lastError)
                 )
                 throw error
             }
@@ -442,7 +442,7 @@ final class AsyncIO: @unchecked Sendable {
                 let lastError = GetLastError()
                 guard lastError == ERROR_IO_PENDING else {
                     let error: SubprocessError = .failedToWriteToProcess(
-                        withUnderlyingError: SubprocessError.WindowsError(rawValue: lastError)
+                        withUnderlyingError: SubprocessError.WindowsError(win32Error: lastError)
                     )
                     throw error
                 }

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -228,12 +228,12 @@ extension Configuration {
                 if windowsError == ERROR_DIRECTORY {
                     throw SubprocessError.failedToChangeWorkingDirectory(
                         self.workingDirectory?.string,
-                        underlyingError: SubprocessError.WindowsError(rawValue: windowsError)
+                        underlyingError: SubprocessError.WindowsError(win32Error: windowsError)
                     )
                 }
 
                 throw SubprocessError.spawnFailed(
-                    withUnderlyingError: SubprocessError.WindowsError(rawValue: windowsError)
+                    withUnderlyingError: SubprocessError.WindowsError(win32Error: windowsError)
                 )
             }
 
@@ -302,7 +302,7 @@ extension Configuration {
         // If we reached this point, all possible executable paths have failed
         throw SubprocessError.executableNotFound(
             self.executable.description,
-            underlyingError: SubprocessError.WindowsError(rawValue: DWORD(ERROR_FILE_NOT_FOUND))
+            underlyingError: SubprocessError.WindowsError(win32Error: DWORD(ERROR_FILE_NOT_FOUND))
         )
     }
 }
@@ -561,7 +561,7 @@ internal func waitForProcessTermination(
                 )
             else {
                 let error: SubprocessError = .failedToMonitor(
-                    withUnderlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                    withUnderlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                 )
                 continuation.resume(
                     throwing: error
@@ -582,7 +582,7 @@ internal func reapProcess(
     var status: DWORD = 0
     guard GetExitCodeProcess(processIdentifier.processDescriptor, &status) else {
         throw SubprocessError.failedToMonitor(
-            withUnderlyingError: .init(rawValue: GetLastError())
+            withUnderlyingError: .init(win32Error: GetLastError())
         )
     }
 
@@ -608,14 +608,14 @@ extension Execution {
             guard TerminateJobObject(self.processIdentifier.jobHandle, exitCode) else {
                 throw SubprocessError.processControlFailed(
                     .terminate,
-                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                    underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                 )
             }
         } else {
             guard TerminateProcess(self.processIdentifier.processDescriptor, exitCode) else {
                 throw SubprocessError.processControlFailed(
                     .terminate,
-                    underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                    underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                 )
             }
         }
@@ -634,13 +634,13 @@ extension Execution {
         guard let NTSuspendProcess = NTSuspendProcess else {
             throw SubprocessError.processControlFailed(
                 .suspend,
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         guard NTSuspendProcess(self.processIdentifier.processDescriptor) >= 0 else {
             throw SubprocessError.processControlFailed(
                 .suspend,
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
     }
@@ -658,13 +658,13 @@ extension Execution {
         guard let NTResumeProcess = NTResumeProcess else {
             throw SubprocessError.processControlFailed(
                 .resume,
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         guard NTResumeProcess(self.processIdentifier.processDescriptor) >= 0 else {
             throw SubprocessError.processControlFailed(
                 .resume,
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
     }
@@ -695,7 +695,7 @@ extension Executable {
                     guard pathLength > 0 else {
                         throw SubprocessError.executableNotFound(
                             executableName,
-                            underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                            underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                         )
                     }
                     return withUnsafeTemporaryAllocation(
@@ -929,13 +929,13 @@ public struct ProcessIdentifier: Sendable, Hashable {
 
     internal func close() {
         guard CloseHandle(self.threadHandle) else {
-            fatalError("Failed to close thread HANDLE: \(SubprocessError.WindowsError(rawValue: GetLastError()))")
+            fatalError("Failed to close thread HANDLE: \(SubprocessError.WindowsError(win32Error: GetLastError()))")
         }
         guard CloseHandle(self.processDescriptor) else {
-            fatalError("Failed to close process HANDLE: \(SubprocessError.WindowsError(rawValue: GetLastError()))")
+            fatalError("Failed to close process HANDLE: \(SubprocessError.WindowsError(win32Error: GetLastError()))")
         }
         guard CloseHandle(self.jobHandle) else {
-            fatalError("Failed to close job HANDLE: \(SubprocessError.WindowsError(rawValue: GetLastError()))")
+            fatalError("Failed to close job HANDLE: \(SubprocessError.WindowsError(win32Error: GetLastError()))")
         }
     }
 }
@@ -1113,7 +1113,7 @@ extension Configuration {
         let attributeList = LPPROC_THREAD_ATTRIBUTE_LIST(attributeListPtr.baseAddress!)
         guard InitializeProcThreadAttributeList(attributeList, 1, 0, &attributeListByteCount) else {
             throw SubprocessError.spawnFailed(
-                withUnderlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                withUnderlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         defer {
@@ -1161,7 +1161,7 @@ extension Configuration {
             jobHandle != INVALID_HANDLE_VALUE
         else {
             throw SubprocessError.spawnFailed(
-                withUnderlyingError: SubprocessError.WindowsError(rawValue: GetLastError()),
+                withUnderlyingError: SubprocessError.WindowsError(win32Error: GetLastError()),
                 reason: "Failed to create Job Object"
             )
         }
@@ -1184,7 +1184,7 @@ extension Configuration {
         // the Job Object before resuming, so it cannot run any user code
         // outside the job.
         guard AssignProcessToJobObject(jobHandle, processInfo.hProcess) else {
-            let assignError = SubprocessError.WindowsError(rawValue: GetLastError())
+            let assignError = SubprocessError.WindowsError(win32Error: GetLastError())
             _ = TerminateProcess(processInfo.hProcess, 1)
             _ = CloseHandle(processInfo.hThread)
             _ = CloseHandle(processInfo.hProcess)
@@ -1211,7 +1211,7 @@ extension Configuration {
         }
 
         guard ResumeThread(processInfo.hThread) != DWORD(bitPattern: -1) else {
-            let resumeError = SubprocessError.WindowsError(rawValue: GetLastError())
+            let resumeError = SubprocessError.WindowsError(win32Error: GetLastError())
             _ = TerminateProcess(processInfo.hProcess, 1)
             _ = CloseHandle(processInfo.hThread)
             _ = CloseHandle(processInfo.hProcess)
@@ -1347,7 +1347,9 @@ extension FileDescriptor {
             guard 0 == _pipe(fds.baseAddress!, 0, _O_BINARY) else {
                 throw SubprocessError.asyncIOFailed(
                     reason: "Failed to create pipe",
-                    underlyingError: nil // FIXME: Errno(rawValue: _subprocess_windows_get_errno())
+                    underlyingError: SubprocessError.WindowsError(
+                        cRuntimeError: _subprocess_windows_get_errno()
+                    )
                 )
             }
         }
@@ -1425,7 +1427,7 @@ extension String {
                 return try withUnsafeTemporaryAllocation(of: WCHAR.self, capacity: Int(dwLength)) { pwszFullPath in
                     guard (1..<dwLength).contains(GetFullPathNameW(pwszPath, DWORD(pwszFullPath.count), pwszFullPath.baseAddress, nil)) else {
                         throw SubprocessError.spawnFailed(
-                            withUnderlyingError: SubprocessError.WindowsError(rawValue: GetLastError()),
+                            withUnderlyingError: SubprocessError.WindowsError(win32Error: GetLastError()),
                             reason: "Invalid Windows Path"
                         )
                     }
@@ -1455,7 +1457,7 @@ extension String {
 
                     throw SubprocessError.spawnFailed(
                         withUnderlyingError: SubprocessError.WindowsError(
-                            rawValue: WIN32_FROM_HRESULT(result)
+                            hresult: result
                         ),
                         reason: "Invalid Windows Path"
                     )
@@ -1528,7 +1530,7 @@ internal func fillNullTerminatedWideStringBuffer(
                     let count = try body(buffer)
                     switch count {
                     case 0:
-                        throw SubprocessError.WindowsError(rawValue: GetLastError())
+                        throw SubprocessError.WindowsError(win32Error: GetLastError())
                     case 1..<DWORD(buffer.count):
                         let result = String(decodingCString: buffer.baseAddress!, as: UTF16.self)
                         assert(result.utf16.count == count, "Parsed UTF-16 count \(result.utf16.count) != reported UTF-16 count \(count)")
@@ -1549,7 +1551,7 @@ internal func fillNullTerminatedWideStringBuffer(
             #endif
         }
     }
-    throw SubprocessError.WindowsError(rawValue: DWORD(ERROR_INSUFFICIENT_BUFFER))
+    throw SubprocessError.WindowsError(win32Error: DWORD(ERROR_INSUFFICIENT_BUFFER))
 }
 
 #endif // canImport(WinSDK)

--- a/Sources/Subprocess/Thread.swift
+++ b/Sources/Subprocess/Thread.swift
@@ -307,7 +307,7 @@ internal func begin_thread_x(
     else {
         // _beginthreadex uses errno instead of GetLastError()
         let capturedError = _subprocess_windows_get_errno()
-        throw SubprocessError.WindowsError(rawValue: DWORD(capturedError))
+        throw SubprocessError.WindowsError(cRuntimeError: capturedError)
     }
 
     return threadHandle

--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -144,7 +144,7 @@ typedef int BOOL;
 #endif
 
 BOOL _subprocess_windows_send_vm_close(DWORD pid);
-unsigned int _subprocess_windows_get_errno(void);
+errno_t _subprocess_windows_get_errno(void);
 
 /// Get the value of `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
 ///

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -877,7 +877,7 @@ BOOL _subprocess_windows_send_vm_close(
     return FALSE;
 }
 
-unsigned int _subprocess_windows_get_errno(void) {
+errno_t _subprocess_windows_get_errno(void) {
     return errno;
 }
 

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -170,7 +170,7 @@ extension SubprocessAsyncIOTests {
             }
 
             #if os(Windows)
-            #expect(subprocessError.underlyingError == SubprocessError.WindowsError(rawValue: DWORD(ERROR_INVALID_HANDLE)))
+            #expect(subprocessError.underlyingError == SubprocessError.WindowsError(win32Error: DWORD(ERROR_INVALID_HANDLE)))
             #elseif canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
             #expect(subprocessError.underlyingError == Errno(rawValue: ECANCELED))
             #else
@@ -208,7 +208,7 @@ extension SubprocessAsyncIOTests {
 
             #if os(Windows)
             #expect(
-                subprocessError.underlyingError == SubprocessError.WindowsError(rawValue: DWORD(ERROR_INVALID_HANDLE)))
+                subprocessError.underlyingError == SubprocessError.WindowsError(win32Error: DWORD(ERROR_INVALID_HANDLE)))
             #elseif canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
             #expect(
                 subprocessError.underlyingError == Errno(rawValue: ECANCELED)

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -79,7 +79,7 @@ extension SubprocessIntegrationTests {
 
     @Test func testExecutableNamedCannotResolve() async throws {
         #if os(Windows)
-        let underlying = SubprocessError.WindowsError(rawValue: DWORD(ERROR_FILE_NOT_FOUND))
+        let underlying = SubprocessError.WindowsError(win32Error: DWORD(ERROR_FILE_NOT_FOUND))
         #else
         let underlying = Errno(rawValue: ENOENT)
         #endif
@@ -126,7 +126,7 @@ extension SubprocessIntegrationTests {
         #if os(Windows)
         let fakePath = FilePath("D:\\does\\not\\exist")
         let underlying = SubprocessError.WindowsError(
-            rawValue: DWORD(ERROR_FILE_NOT_FOUND)
+            win32Error: DWORD(ERROR_FILE_NOT_FOUND)
         )
         #else
         let fakePath = FilePath("/usr/bin/do-not-exist")
@@ -732,7 +732,7 @@ extension SubprocessIntegrationTests {
             arguments: ["/c", "cd"],
             workingDirectory: invalidPath
         )
-        let underlying = SubprocessError.WindowsError(rawValue: DWORD(ERROR_DIRECTORY))
+        let underlying = SubprocessError.WindowsError(win32Error: DWORD(ERROR_DIRECTORY))
         let expectedError: SubprocessError = .failedToChangeWorkingDirectory(
             #"X:\Does\Not\Exist"#, underlyingError: underlying
         )
@@ -3002,7 +3002,7 @@ extension SubprocessIntegrationTests {
         else {
             throw SubprocessError.asyncIOFailed(
                 reason: "Failed to create pipe",
-                underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
             )
         }
         SetHandleInformation(readHandle, HANDLE_FLAG_INHERIT, 0)
@@ -3032,13 +3032,13 @@ extension SubprocessIntegrationTests {
                 else {
                     throw SubprocessError.asyncIOFailed(
                         reason: "Failed to create pipe",
-                        underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                        underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                     )
                 }
                 guard let writeEndHandle else {
                     throw SubprocessError.asyncIOFailed(
                         reason: "Failed to create pipe",
-                        underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                        underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                     )
                 }
                 CloseHandle(pipe.writeEnd) // No longer need the original
@@ -3085,13 +3085,13 @@ extension SubprocessIntegrationTests {
                 else {
                     throw SubprocessError.asyncIOFailed(
                         reason: "Failed to create pipe",
-                        underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                        underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                     )
                 }
                 guard let readEndHandle else {
                     throw SubprocessError.asyncIOFailed(
                         reason: "Failed to create pipe",
-                        underlyingError: SubprocessError.WindowsError(rawValue: GetLastError())
+                        underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
                     )
                 }
                 CloseHandle(pipe.readEnd) // No longer need the original

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -205,7 +205,7 @@ extension SubprocessProcessMonitoringTests {
 
     @Test func testInvalidProcessIdentifier() async throws {
         #if os(Windows)
-        let underlying = SubprocessError.WindowsError(rawValue: DWORD(ERROR_INVALID_PARAMETER))
+        let underlying = SubprocessError.WindowsError(win32Error: DWORD(ERROR_INVALID_PARAMETER))
         let processIdentifier = ProcessIdentifier(
             value: .max,
             processDescriptor: INVALID_HANDLE_VALUE,

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -300,7 +300,7 @@ extension SubprocessWindowsTests {
             // Nest the child inside a user-supplied Job Object. Subprocess
             // already assigned it to its internal job. This nests further.
             guard AssignProcessToJobObject(hJob, execution.processIdentifier.processDescriptor) else {
-                throw SubprocessError.WindowsError(rawValue: GetLastError())
+                throw SubprocessError.WindowsError(win32Error: GetLastError())
             }
         }
         #expect(result.terminationStatus.isSuccess)
@@ -546,7 +546,7 @@ extension SubprocessWindowsTests {
         guard let snapshot = CreateToolhelp32Snapshot(DWORD(TH32CS_SNAPPROCESS), 0),
             snapshot != INVALID_HANDLE_VALUE
         else {
-            throw SubprocessError.WindowsError(rawValue: GetLastError())
+            throw SubprocessError.WindowsError(win32Error: GetLastError())
         }
         defer { _ = CloseHandle(snapshot) }
 


### PR DESCRIPTION
Currently `WindowsError` can only represent win32 errors from `GetLastError()`. This is an incorrect model for Windows errors because Windows has other error subsystems. Update `WindowsError` to the canonical representation recommended by @compnerd.

See the discussion in https://github.com/swiftlang/swift-subprocess/pull/270 for more info.