### PR TITLE
Make `testTeardownSequence()` resilient to scheduling latency

### DIFF
--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -189,13 +189,20 @@ extension SubprocessUnixTests {
             arguments: [
                 "-c",
                 """
-                set -e
-                trap 'echo saw SIGQUIT;' QUIT
-                trap 'echo saw SIGTERM;' TERM
-                trap 'echo saw SIGINT; exit 42;' INT
+                trap 'echo saw SIGQUIT' QUIT
+                trap 'echo saw SIGTERM' TERM
+                trap 'echo saw SIGINT; exit 42' INT
                 echo ready
-                while true; do sleep 0.1; done
-                exit 2
+                # A trapped signal interrupts `wait` immediately, so the handler runs
+                # without waiting for a sleep interval to elapse, unlike a foreground
+                # `sleep`, whose completion (and the trap deferred behind it) can slip
+                # past the teardown window under load. The backgrounded sleep is short
+                # so a signal landing as bash enters the wait is still serviced within
+                # one interval rather than stranding on a long-lived child.
+                while true; do
+                    sleep 0.2 &
+                    wait $!
+                done
                 """,
             ],
             input: .none,
@@ -205,8 +212,8 @@ extension SubprocessUnixTests {
             return try await withThrowingTaskGroup(of: Void.self) { group in
                 // Gate the teardown task on bash having actually installed
                 // its signal traps. The reader signals readiness when it
-                // sees the `ready` marker the script prints after the
-                // `trap` lines.
+                // sees the `ready` marker the script prints once its traps are
+                // installed, just before it begins waiting.
                 let (readyStream, readyContinuation) = AsyncStream.makeStream(of: Void.self)
 
                 group.addTask {


### PR DESCRIPTION
`testTeardownSequence()` failed on a [CI run](https://github.com/swiftlang/swift-subprocess/actions/runs/27040934838/job/79816509201?pr=296#logs) for an unrelated Windows-only change in #296:

```
✘ Test testTeardownSequence() recorded an issue at UnixTests.swift:233:21: Expectation failed: outputs == ["saw SIGQUIT", "saw SIGTERM", "saw SIGINT"]
↳ outputs == ["saw SIGQUIT", "saw SIGTERM", "saw SIGINT"] → false
↳   outputs → ["saw SIGQUIT", "saw SIGTERM"]
✘ Test testTeardownSequence() recorded an issue at UnixTests.swift:238:9: Expectation failed: result.terminationStatus == .exited(42)
↳ result.terminationStatus == .exited(42) → false
↳   result.terminationStatus → signaled(9)
↳     signaled → 9
↳   .exited(42) → exited(42)
↳     exited → 42
```
<br/>

The test drove a `teardown(using:)` sequence (`SIGQUIT`, `SIGTERM`, then `SIGINT`, each with a grace period, ending in an implicit `SIGKILL`) against a bash child whose `INT` trap echoes and `exit 42`s, and which otherwise looped in a foreground `sleep 0.1`. On a loaded Linux runner it failed with `signaled(9)` and a transcript missing the final `saw SIGINT`.

Bash defers a trapped signal until the running foreground command completes. When scheduling pressure delayed the deferred `INT` trap past the grace period, the implicit `SIGKILL` reached the child before its deferred `INT` trap ran, so it died on the signal instead of exiting `42`. Only the `SIGINT` step gates anything; the `QUIT` and `TERM` traps just echo, so those steps always run their full duration regardless of timing, which is why the sequence got that far and no further.

This PR idles in `wait` on a backgrounded `sleep` instead. A trapped signal interrupts `wait` immediately and runs the handler at once, with no dependence on a sleep interval elapsing, so the `INT` trap fires well inside the grace period even under load. The backgrounded `sleep` is short, so a signal that lands as bash enters the `wait` is serviced at the next safe point within one interval, rather than blocking on a long-lived child.

I ran the pre-fix test on GitHub Actions under heavy CPU oversubscription on the same amazonlinux2 nightly image, but wasn't able to reproduce the failure across 500 iterations. The failure is load-dependent so it's possible I didn't recreate the exact scenario, or this reproduces too rarely to surface in 500 runs.