### PR TITLE
Add a timeout to the `test_linux_kernel` job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -61,6 +61,7 @@ jobs:
   test_linux_kernel:
     name: Test Linux Kernel / ${{ matrix.dist-kern }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
`test_linux_kernel` has no `timeout-minutes`, so a hang runs until GitHub's 6-hour default. On the [CI run](https://github.com/swiftlang/swift-subprocess/actions/runs/27044483180/job/79827502221?pr=300#logs) for #300 the `al2-5.10` cell hung and consumed the full 6 hours (see issue #301).

This PR adds a 60-minute limit (more than 2x the typical ~25 minute run), so it won't trip on a slow run but caps a hang at an hour.