### PR TITLE
Fix crash in `fillNullTerminatedWideStringBuffer()`

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -1691,36 +1691,42 @@ extension UInt8 {
 internal func fillNullTerminatedWideStringBuffer(
     initialSize: DWORD,
     maxSize: DWORD,
-    _ body: (UnsafeMutableBufferPointer<WCHAR>) throws(SubprocessError.WindowsError) -> DWORD
+    _ body: (UnsafeMutableBufferPointer<WCHAR>) -> DWORD
 ) throws(SubprocessError.WindowsError) -> String {
+    enum FillResult {
+        case filled(String)
+        case insufficient
+        case failed(DWORD)
+    }
     var bufferCount = max(1, min(initialSize, maxSize))
     while bufferCount <= maxSize {
-        do {
-            if let result = try withUnsafeTemporaryAllocation(
-                of: WCHAR.self, capacity: Int(bufferCount),
-                { buffer throws(SubprocessError.WindowsError) in
-                    let count = try body(buffer)
-                    switch count {
-                    case 0:
-                        throw SubprocessError.WindowsError(win32Error: GetLastError())
-                    case 1..<DWORD(buffer.count):
-                        let result = String(decodingCString: buffer.baseAddress!, as: UTF16.self)
-                        assert(result.utf16.count == count, "Parsed UTF-16 count \(result.utf16.count) != reported UTF-16 count \(count)")
-                        return result
-                    default:
-                        bufferCount *= 2
-                        return nil
-                    }
-                })
-            {
-                return result
+        let result: FillResult = withUnsafeTemporaryAllocation(
+            of: WCHAR.self,
+            capacity: Int(bufferCount)
+        ) { buffer in
+            let count = body(buffer)
+            switch count {
+            case 0:
+                return .failed(GetLastError())
+            case 1..<DWORD(buffer.count):
+                // `count` is in-range, so the buffer holds a null-terminated
+                // string of `count` units.
+                return .filled(
+                    String(
+                        decodingCString: buffer.baseAddress!,
+                        as: UTF16.self
+                    ))
+            default:
+                return .insufficient
             }
-        } catch {
-            #if swift(>=6.3)
-            throw error
-            #else
-            throw error as! SubprocessError.WindowsError
-            #endif
+        }
+        switch result {
+        case .filled(let string):
+            return string
+        case .failed(let win32Error):
+            throw SubprocessError.WindowsError(win32Error: win32Error)
+        case .insufficient:
+            bufferCount *= 2
         }
     }
     throw SubprocessError.WindowsError(win32Error: DWORD(ERROR_INSUFFICIENT_BUFFER))


### PR DESCRIPTION
The function passed a typed-throwing closure to `withUnsafeTemporaryAllocation(of:capacity:_:)`, which is `rethrows`. Bridging the typed throw into `rethrows` crashes under release optimization on the Swift 6.2.x Windows toolchain (debug builds and `nightly-main` are unaffected).

This PR restructures it so the allocation closure no longer throws. Instead, it returns a result enum, and the enclosing loop throws or grows the buffer accordingly. This drops the typed-throws-into-`rethrows` bridge, which in turn drops the `#if swift(>=6.3)` workaround guarding the same path, and allows `body` to be non-throwing, since no caller throws from it.

The original implementation used an `assert()`; this was the only use in the package, and I removed it based on a [review comment](https://github.com/swiftlang/swift-subprocess/pull/280#discussion_r3363927170) on #280 explaining that Subprocess tries not to use `assert()`.

Found this when running CI for #261. `Windows (6.2 - windows-2022)` [crashed](https://github.com/swiftlang/swift-subprocess/actions/runs/27145244647/job/80121055786?pr=261), while all other CI including `Windows (nightly-main - windows-2022)` passed.

On `main` this function is reached only through paths that run without crashing in release CI. #261 adds a new caller, `currentWorkingDirectory()`, invoked from the spawn path in `Configuration.run()`, which is where the crash occurs.