### PR TITLE
Cancel a stalled standard-input writer when the child process exits

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -288,6 +288,13 @@ public func run<
                         try await inputWriter.finish()
                         return .inputWritten
                     }
+                    // The input source can stall indefinitely. Wait for termination here and cancel
+                    // the group when the child exits. Output and error capture respond to cancellation
+                    // by draining whatever is still buffered and returning it, so nothing is truncated.
+                    group.addTask {
+                        _ = try? await waitForProcessTermination(for: processIdentifier)
+                        return .processTerminated
+                    }
                 }
             }
 
@@ -358,6 +365,9 @@ public func run<
                 switch groupResult {
                 case .inputWritten:
                     continue
+                case .processTerminated:
+                    // The child exited. Cancel any still-running tasks so the drain can complete.
+                    group.cancelAll()
                 case .standardOutputCaptured(let output):
                     capturedOutput = output
                 case .standardErrorCaptured(let error):
@@ -395,6 +405,7 @@ private enum _RunGroupResult<Output: OutputProtocol, Error: OutputProtocol> {
     case standardOutputCaptured(Output.OutputType)
     case standardErrorCaptured(Error.OutputType)
     case inputWritten
+    case processTerminated
 }
 
 private struct _RunOutcome<

--- a/Sources/Subprocess/IO/AsyncIO+KQueue.swift
+++ b/Sources/Subprocess/IO/AsyncIO+KQueue.swift
@@ -225,21 +225,21 @@ final class AsyncIO: Sendable {
         }
 
         pthread_join(currentState.monitorThread, nil)
-        var closeError: Errno? = nil
+        var closeError: SubprocessError? = nil
         do {
-            try kqueueFd.close()
+            try _safelyClose(.fileDescriptor(kqueueFd))
         } catch {
-            closeError = error as? Errno
+            closeError = error
         }
         do {
-            try shutdownReadFd.close()
+            try _safelyClose(.fileDescriptor(shutdownReadFd))
         } catch {
-            closeError = error as? Errno
+            closeError = error
         }
         do {
-            try shutdownWriteFd.close()
+            try _safelyClose(.fileDescriptor(shutdownWriteFd))
         } catch {
-            closeError = error as? Errno
+            closeError = error
         }
 
         if let closeError {

--- a/Sources/Subprocess/IO/AsyncIO+Linux.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Linux.swift
@@ -210,16 +210,16 @@ final class AsyncIO: Sendable {
         // Clean up the monitor thread.
         pthread_join(currentState.monitorThread, nil)
 
-        var closeError: Errno? = nil
+        var closeError: SubprocessError? = nil
         do {
-            try epollFd.close()
+            try _safelyClose(.fileDescriptor(epollFd))
         } catch {
-            closeError = error as? Errno
+            closeError = error
         }
         do {
-            try shutdownFd.close()
+            try _safelyClose(.fileDescriptor(shutdownFd))
         } catch {
-            closeError = error as? Errno
+            closeError = error
         }
 
         if let closeError {

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -572,7 +572,7 @@ internal func _isWaitprocessDescriptorSupported() -> Bool {
         // If we can not retrieve pidfd, the system does not support waitid(P_PIDFD)
         return false
     }
-    defer { try? FileDescriptor(rawValue: selfPidfd).close() }
+    defer { try? _safelyClose(.fileDescriptor(FileDescriptor(rawValue: selfPidfd))) }
     /// The following call will fail either with
     /// - ECHILD: in this case we know P_PIDFD is supported and waitid correctly
     ///     reported that we don't have a child with the same selfPidfd;

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -537,10 +537,10 @@ extension Configuration {
                         // If exec fails we retry with the next candidate path, so
                         // close the pidfd here to avoid leaking it across retries.
                         if processDescriptor != .invalidDescriptor {
-                            do {
-                                try FileDescriptor(rawValue: processDescriptor).close()
+                            do throws(SubprocessError) {
+                                try _safelyClose(.fileDescriptor(FileDescriptor(rawValue: processDescriptor)))
                             } catch {
-                                throw SubprocessError.spawnFailed(withUnderlyingError: error as? SubprocessError.UnderlyingError)
+                                throw SubprocessError.spawnFailed(withUnderlyingError: error.underlyingError)
                             }
                         }
                         // Move on to another possible path
@@ -628,7 +628,7 @@ public struct ProcessIdentifier: Sendable, Hashable {
 
     internal func close() {
         if self.processDescriptor != .invalidDescriptor {
-            try? FileDescriptor(rawValue: self.processDescriptor).close()
+            try? _safelyClose(.fileDescriptor(FileDescriptor(rawValue: self.processDescriptor)))
         }
     }
 }

--- a/Tests/SubprocessTests/AsyncIOTests.swift
+++ b/Tests/SubprocessTests/AsyncIOTests.swift
@@ -319,6 +319,167 @@ extension SubprocessAsyncIOTests {
     }
 }
 
+// MARK: - Partial Read/Write, Backpressure & Boundary Tests
+extension SubprocessAsyncIOTests {
+    // Ported intent: swift-nio NonBlockingFileIOTest.testReadingShortWorks.
+    // AsyncIO returns after a single underlying read, so a request larger than
+    // what's available yields a SHORT read rather than blocking for the full
+    // amount.
+    @Test func testShortRead() async throws {
+        let payload = randomData(count: 64)
+        try await runReadWriteTest { readIO, readTestBed in
+            let chunk = try await readIO.read(from: readTestBed.ioDescriptor, upTo: 64 * 1024)
+            #expect(chunk == payload)
+        } writer: { writeIO, writeTestBed in
+            _ = try await writeIO.write(payload, to: writeTestBed.ioDescriptor)
+            try await writeTestBed.finish()
+        }
+    }
+
+    // Ported intent: swift-nio ChannelTests.testPendingWritesWorkWithPartialWrites.
+    // A write much larger than the pipe buffer must fill the pipe, block on
+    // EAGAIN, wait for the reader to drain, and resume looping until every
+    // byte is written. The reader drains in small, delayed chunks to keep the
+    // pipe full and force many wait cycles. Asserts the write reports the full
+    // count (proving the partial-write loop) and the bytes survive intact.
+    func testWriteCompletesUnderBackpressure() async throws {
+        let payload = randomData(count: 512 * 1024)
+        try await runReadWriteTest { readIO, readTestBed in
+            var received: [UInt8] = []
+            while let chunk = try await readIO.read(from: readTestBed.ioDescriptor, upTo: 16 * 1024) {
+                received.append(contentsOf: chunk)
+                try await readTestBed.delay(.milliseconds(1))
+            }
+            #expect(received == payload)
+        } writer: { writeIO, writeTestBed in
+            let written = try await writeIO.write(payload, to: writeTestBed.ioDescriptor)
+            #expect(written == payload.count)
+            try await writeTestBed.finish()
+        }
+    }
+
+    // Ported intent: swift-nio NonBlockingFileIOTest.testReadManyChunks
+    // (2000 × 1-byte reads). Reading one byte at a time must deliver every byte
+    // in order with no loss or misalignment.
+    @Test func testReadManyTinyChunks() async throws {
+        let payload = randomData(count: 2048)
+        try await runReadWriteTest { readIO, readTestBed in
+            var received: [UInt8] = []
+            while let chunk = try await readIO.read(from: readTestBed.ioDescriptor, upTo: 1) {
+                received.append(contentsOf: chunk)
+            }
+            #expect(received == payload)
+        } writer: { writeIO, writeTestBed in
+            _ = try await writeIO.write(payload, to: writeTestBed.ioDescriptor)
+            try await writeTestBed.finish()
+        }
+    }
+
+    // Ported intent: swift-nio PipeChannelTest.testWriteEndGoingAway.
+    // Data written before the write end closes must be fully delivered, and only
+    // then EOF (`nil`) which exercises AsyncIO's final-drain path. Ordered
+    // deterministically (write + close, then read) via a manually-wired pipe.
+    @Test func testReadDrainsBufferedDataThenEOF() async throws {
+        var pipe = try CreatedPipe(closeWhenDone: true, purpose: .input)
+        var writeChannel = try _require(pipe.writeFileDescriptor())
+        var readChannel = try _require(pipe.readFileDescriptor())
+        defer {
+            try? readChannel.safelyClose()
+        }
+
+        let payload = randomData(count: 4096)
+        // Write everything, then close the write end so the reader observes
+        // buffered data followed by EOF (not EOF first).
+        _ = try await AsyncIO.shared.write(payload, to: writeChannel)
+        try writeChannel.safelyClose()
+
+        var received: [UInt8] = []
+        while let chunk = try await AsyncIO.shared.read(from: readChannel, upTo: 64 * 1024) {
+            received.append(contentsOf: chunk)
+        }
+        #expect(received == payload)
+    }
+
+    // Reading with `upTo: .max` exercises the branch where AsyncIO sizes its
+    // buffer from `queryPipeBufferSize` instead of the requested length. It must
+    // return a (short) chunk rather than over-allocating or hanging.
+    @Test func testReadUpToMax() async throws {
+        let payload = randomData(count: 100)
+        try await runReadWriteTest { readIO, readTestBed in
+            var received: [UInt8] = []
+            while let chunk = try await readIO.read(from: readTestBed.ioDescriptor, upTo: .max) {
+                received.append(contentsOf: chunk)
+            }
+            #expect(received == payload)
+        } writer: { writeIO, writeTestBed in
+            _ = try await writeIO.write(payload, to: writeTestBed.ioDescriptor)
+            try await writeTestBed.finish()
+        }
+    }
+
+    @Test func testQueryPipeBufferSizeIsPositive() async throws {
+        var pipe = try CreatedPipe(closeWhenDone: true, purpose: .input)
+        var writeChannel = try _require(pipe.writeFileDescriptor())
+        var readChannel = try _require(pipe.readFileDescriptor())
+        defer {
+            try? writeChannel.safelyClose()
+            try? readChannel.safelyClose()
+        }
+        #expect(AsyncIO.queryPipeBufferSize(for: readChannel.descriptor()) > 0)
+        #expect(AsyncIO.queryPipeBufferSize(for: writeChannel.descriptor()) > 0)
+    }
+}
+
+// MARK: - Concurrency & Write-Error Tests
+extension SubprocessAsyncIOTests {
+    // Ported intent: swift-nio concurrent read/write tests. Drives many
+    // independent pipe round-trips through the shared `AsyncIO` at once to
+    // stress its registration/signal machinery for races.
+    func testConcurrentReadWriteAcrossManyPipes() async throws {
+        let pipeCount = 32
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<pipeCount {
+                group.addTask {
+                    let payload = randomData(count: Int.random(in: 1..<8192))
+                    try await self.runReadWriteTest { readIO, readTestBed in
+                        let received = try await self.readUntilEOF(
+                            from: readTestBed.ioDescriptor, with: readIO
+                        )
+                        #expect(received == payload)
+                    } writer: { writeIO, writeTestBed in
+                        _ = try await writeIO.write(payload, to: writeTestBed.ioDescriptor)
+                        try await writeTestBed.finish()
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    // Ported intent: swift-nio PipeChannelTest.testWriteErrorsCloseChannel /
+    // testReadEndGoingAway. Writing to a pipe whose read end has gone away must
+    // surface as a write error rather than hang or silently succeed.
+    @Test func testWriteToPipeWithClosedReadEndThrows() async throws {
+        var pipe = try CreatedPipe(closeWhenDone: true, purpose: .input)
+        var writeChannel = try _require(pipe.writeFileDescriptor())
+        var readChannel = try _require(pipe.readFileDescriptor())
+        defer {
+            try? writeChannel.safelyClose()
+        }
+        // Close the read end; the write descriptor remains valid and ours.
+        try readChannel.safelyClose()
+
+        await #expect {
+            _ = try await AsyncIO.shared.write(randomData(count: 64 * 1024), to: writeChannel)
+        } throws: { error in
+            guard let subprocessError = error as? SubprocessError else {
+                return false
+            }
+            return subprocessError.code == .init(.failedToWriteToSubprocess)
+        }
+    }
+}
+
 // MARK: - Utils
 extension SubprocessAsyncIOTests {
     final class TestBed: Sendable {

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -3527,6 +3527,170 @@ extension SubprocessIntegrationTests {
     }
 }
 
+// MARK: - Streaming, Identity, and Input File Descriptor Tests
+extension SubprocessIntegrationTests {
+    @Test func testStreamingInputAndOutput() async throws {
+        // Stream input and output through one live process concurrently: a
+        // writer task feeds lines into standard input while a reader task reads
+        // the echoes back, in separate tasks (as in `testInteractiveShell`) so
+        // neither blocks the other.
+        #if os(Windows)
+        // A PowerShell loop that echoes each stdin line back and flushes so the
+        // reader sees it promptly.
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: [
+                "-NoProfile",
+                "-Command",
+                "while (($line = [Console]::In.ReadLine()) -ne $null) { [Console]::Out.WriteLine($line); [Console]::Out.Flush() }",
+            ]
+        )
+        #else
+        // `cat -u` echoes each line unbuffered, so the reader sees lines as they
+        // stream rather than only when the child exits.
+        let setup = TestSetup(
+            executable: .path("/bin/cat"),
+            arguments: ["-u"]
+        )
+        #endif
+
+        let lines = (0..<50).map { "line-\($0)" }
+        let result = try await _run(
+            setup,
+            input: .inputWriter,
+            output: .sequence,
+            error: .discarded
+        ) { execution in
+            return try await withThrowingTaskGroup(of: [String].self) { group in
+                // Writer: stream every line, then close stdin so the child exits.
+                group.addTask {
+                    for line in lines {
+                        _ = try await execution.standardInputWriter.write("\(line)\n")
+                    }
+                    try await execution.standardInputWriter.finish()
+                    return []
+                }
+                // Reader: collect the echoes concurrently until EOF.
+                group.addTask {
+                    var received: [String] = []
+                    for try await line in execution.standardOutput.strings() {
+                        let trimmed = line.trimmingNewLineAndQuotes()
+                        if !trimmed.isEmpty {
+                            received.append(trimmed)
+                        }
+                    }
+                    return received
+                }
+                var received: [String] = []
+                for try await partial in group where !partial.isEmpty {
+                    received = partial
+                }
+                return received
+            }
+        }
+        #expect(result.terminationStatus.isSuccess)
+        #expect(result.closureResult == lines)
+    }
+
+    @Test func testReadProcessIdentifier() async throws {
+        // The child reports its own process identifier. It must match the
+        // identifier Subprocess hands us via `execution.processIdentifier`.
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("powershell.exe"),
+            arguments: ["-NoProfile", "-Command", "Write-Output $PID"]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", "echo $$"]
+        )
+        #endif
+        let result = try await _run(
+            setup,
+            input: .none,
+            output: .string(limit: 32),
+            error: .discarded
+        ) { execution in
+            return execution.processIdentifier.value
+        }
+        #expect(result.terminationStatus.isSuccess)
+        let reportedPid = try #require(result.standardOutput)
+            .trimmingNewLineAndQuotes()
+        #expect("\(result.closureResult)" == reportedPid)
+    }
+
+    @Test func testInputFromUnownedFileDescriptor() async throws {
+        // `closeAfterSpawningProcess: false` means the parent keeps ownership of
+        // the descriptor. The existing file-descriptor input tests all pass
+        // `true`, so this pins down the unowned case: after the run, the parent
+        // must still be able to close the descriptor itself.
+        let content = randomString(length: 64)
+        let fileURL = URL.temporaryDirectory
+            .appendingPathComponent("UnownedFDInput-\(UUID().uuidString).txt")
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        let inputFD: FileDescriptor = try .open(
+            FilePath(fileURL._fileSystemPath),
+            .readOnly
+        )
+
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("cmd.exe"),
+            arguments: ["/c", "findstr x*"]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/cat"),
+            arguments: []
+        )
+        #endif
+
+        let result = try await _run(
+            setup,
+            input: .fileDescriptor(inputFD, closeAfterSpawningProcess: false),
+            output: .string(limit: 256),
+            error: .discarded
+        )
+        #expect(result.terminationStatus.isSuccess)
+        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == content)
+        // The parent retained ownership, so closing here must succeed. If
+        // Subprocess had wrongly closed it, this might throw `.badFileDescriptor`.
+        try inputFD.close()
+    }
+
+    #if SubprocessFoundation
+    func testProcessExitsBeforeInputComplete() async throws {
+        // An input source that never yields and never finishes, paired with a
+        // child that exits immediately.
+        let neverEndingInput = AsyncStream<Data> { _ in
+            // Never yield, never finish.
+        }
+        #if os(Windows)
+        let setup = TestSetup(
+            executable: .name("cmd.exe"),
+            arguments: ["/c", "exit 0"]
+        )
+        #else
+        let setup = TestSetup(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", "exit 0"]
+        )
+        #endif
+        let result = try await _run(
+            setup,
+            input: .sequence(neverEndingInput),
+            output: .discarded,
+            error: .discarded
+        )
+        #expect(result.terminationStatus == .exited(0))
+    }
+    #endif // SubprocessFoundation
+}
+
 // MARK: - Utilities
 extension String {
     func trimmingNewLineAndQuotes() -> String {

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -999,4 +999,93 @@ extension SubprocessUnixTests {
     #endif
 }
 
+// MARK: - Standard Input Inheritance
+extension SubprocessUnixTests {
+    @Test func testInheritStandardInput() async throws {
+        // Exercises the public `InputProtocol.standardInput`: the child inherits
+        // the parent's own standard input (fd 0). We temporarily point fd 0 at a
+        // pipe we control, feed it a line, and confirm the child reads it back.
+        //
+        // Not ported to Windows: the equivalent would require swapping the test
+        // host's own `STD_INPUT_HANDLE` / CRT fd 0 — global console state that
+        // can't be changed safely or verified from here.
+        let savedStdin = dup(STDIN_FILENO)
+        try #require(savedStdin >= 0, "dup(STDIN_FILENO) failed: \(errno)")
+        defer {
+            _ = dup2(savedStdin, STDIN_FILENO)
+            _ = close(savedStdin)
+        }
+
+        let pipe = try FileDescriptor.pipe()
+        // Point our own stdin at the pipe's read end so the child inherits it.
+        try #require(
+            dup2(pipe.readEnd.rawValue, STDIN_FILENO) >= 0,
+            "dup2 onto STDIN_FILENO failed: \(errno)"
+        )
+
+        // Send one line and close the write end so the child sees EOF.
+        try pipe.writeEnd.writeLine("hello from parent stdin")
+        try pipe.writeEnd.close()
+
+        let result = try await Subprocess.run(
+            .path("/bin/cat"),
+            arguments: [],
+            input: .standardInput,
+            output: .string(limit: 256),
+            error: .discarded
+        )
+        try pipe.readEnd.close()
+
+        #expect(result.terminationStatus.isSuccess)
+        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "hello from parent stdin")
+    }
+}
+
+// MARK: - Pseudo-Terminal Input
+extension SubprocessUnixTests {
+    @Test func testInheritStdinFromPseudoTerminal() async throws {
+        // Hand the child a pseudo-terminal replica as its standard input,
+        // proving an arbitrary inherited file descriptor (not a regular file or
+        // ordinary pipe) works as input.
+        //
+        // Not ported to Windows: there is no `openpty`/`termios` equivalent; the
+        // Windows pseudo-console (ConPTY) is an unrelated API.
+        var primaryFD: CInt = -1
+        var replicaFD: CInt = -1
+        try #require(
+            openpty(&primaryFD, &replicaFD, nil, nil, nil) == 0,
+            "openpty failed: \(errno)"
+        )
+        let primary = FileDescriptor(rawValue: primaryFD)
+        let replica = FileDescriptor(rawValue: replicaFD)
+
+        // Raw mode so bytes pass through verbatim (no echo or line editing).
+        var settings = termios()
+        try #require(tcgetattr(replicaFD, &settings) == 0, "tcgetattr failed: \(errno)")
+        cfmakeraw(&settings)
+        try #require(tcsetattr(replicaFD, TCSANOW, &settings) == 0, "tcsetattr failed: \(errno)")
+
+        let payload = "pty stdin works"
+        // Pre-fill the pty buffer; the child reads exactly this many bytes and
+        // then exits, closing its inherited replica.
+        try Array(payload.utf8).withUnsafeBytes { buffer in
+            _ = try primary.write(buffer)
+        }
+
+        let result = try await Subprocess.run(
+            .name("head"),
+            arguments: ["-c", "\(payload.utf8.count)"],
+            // The replica is owned by Subprocess (closed after spawn); we keep
+            // and close the primary ourselves.
+            input: .fileDescriptor(replica, closeAfterSpawningProcess: true),
+            output: .string(limit: 256),
+            error: .discarded
+        )
+        try primary.close()
+
+        #expect(result.terminationStatus.isSuccess)
+        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == payload)
+    }
+}
+
 #endif // !os(Windows)


### PR DESCRIPTION
When `run()` feeds standard input from a source that can stall and the child process exits before consuming that input, `run()` could hang indefinitely. The input-writing task was parked awaiting its source rather than blocked inside a pipe write, so the existing `cancelAsyncIO` path (which only unblocks in-flight pipe I/O) could not release it, and the I/O task group never finished draining. Spawn a `waitForProcessTermination` waiter alongside the input-writing task that cancels the I/O group once the child exits.

Also add edge-case coverage for process I/O and AsyncIO, ported from `swift-async-process` and `swift-nio` and replace `FileDescriptor.close` with `_safelyClosed`.