### PR TITLE
Spawn `cat` in its own session in `testSuspendResumeProcess()`

### DIFF
--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -378,10 +378,19 @@ extension SubprocessUnixTests {
         let flags = fcntl(outputPipe.readEnd.rawValue, F_GETFL)
         try #require(fcntl(outputPipe.readEnd.rawValue, F_SETFL, flags | O_NONBLOCK) == 0)
 
+        // Isolate cat in its own session: the SIGSTOP below would otherwise
+        // leave a stopped process in the test runner's process group, and a
+        // concurrent child exit that orphans that group makes the kernel
+        // deliver SIGHUP+SIGCONT to every member of the group, including this
+        // test process, killing the run.
+        var platformOptions = PlatformOptions()
+        platformOptions.createSession = true
+
         try await outputPipe.readEnd.closeAfter {
             try await inputPipe.writeEnd.closeAfter {
                 _ = try await Subprocess.run(
                     .path("/bin/cat"),
+                    platformOptions: platformOptions,
                     // cat reads from inputPipe.readEnd. The parent keeps writeEnd to feed it.
                     input: .fileDescriptor(inputPipe.readEnd, closeAfterSpawningProcess: true),
                     // cat writes to outputPipe.writeEnd. The parent keeps readEnd to drain it.


### PR DESCRIPTION
`testSuspendResumeProcess()` intermittently terminates the entire test process with `SIGHUP` under the full suite, surfacing as a bare signal-1 exit with no recorded test failure. I found this during a [failed CI run](https://github.com/swiftlang/swift-subprocess/actions/runs/27294953824/job/80625088291?pr=261) for unrelated changes in #261.

> error: Process '.../swift-subprocessPackageTests --testing-library swift-testing' exited with unexpected signal code 1

The test spawns `/bin/cat` with default `PlatformOptions`, so `cat` inherits the test runner's process group, then sends it `SIGSTOP`, leaving a stopped process in the runner's own process group.

On POSIX, when a process group becomes orphaned and any member is stopped, `SIGHUP` followed by `SIGCONT` is sent to every process in the group. Per the [POSIX `_Exit` docs](https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html):

> If the exit of the process causes a process group to become orphaned, and if any member of the newly-orphaned process group is stopped, then a `SIGHUP` signal followed by a `SIGCONT` signal shall be sent to each process in the newly-orphaned process group.

Under the full suite's concurrent process churn, that group intermittently became orphaned while `cat` was stopped, and the kernel delivered `SIGHUP` to every member of the group, including the test process, which exited on the signal. This surfaced only when the suite ran in parallel.

This PR spawns `cat` with `createSession` so it runs in its own session, and stopping it no longer leaves a stopped member in the runner's group. `cat`'s own group is orphaned at `setsid()` time, which POSIX exempts from the `SIGHUP`, so the suspend/resume assertions are unaffected:

> It is possible for a process group to be orphaned by a call to [`setpgid()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setpgid.html) or [`setsid()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html), as well as by process termination. This volume of POSIX.1-2017 does not require sending `SIGHUP` and `SIGCONT` in those cases, because, unlike process termination, those cases are not caused accidentally by applications that are unaware of job control.

`processGroupID` would also work here, but using `createSession` matches `measureCancelledTeardown()`.

Tested this across 30 iterations of the full suite on a macOS GitHub Actions runner where it previously failed.