### PR TITLE
Docs: fix README to use strings(), document separator behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ let result = try await run(
     error: .string(limit: 4096)
 ) { execution in
     var lineCount = 0
-    for try await _ in execution.standardOutput.lines() {
+    for try await _ in execution.standardOutput.strings() {
         lineCount += 1
     }
     return lineCount
@@ -155,10 +155,10 @@ try await run(
 ) { execution in
     try await withThrowingTaskGroup { group in
         group.addTask {
-            for try await line in execution.standardOutput.lines() { /* ... */ }
+            for try await line in execution.standardOutput.strings() { /* ... */ }
         }
         group.addTask {
-            for try await line in execution.standardError.lines() { /* ... */ }
+            for try await line in execution.standardError.strings() { /* ... */ }
         }
         group.addTask {
             _ = try await execution.standardInputWriter.write("Hello Subprocess")
@@ -171,12 +171,12 @@ try await run(
 
 In the closure-based API, output streams are delivered as an `SubprocessOutputSequence` — an asynchronous sequence of `Buffer` values. Each `Buffer` provides access to its bytes via `withUnsafeBytes(_:)` or the `bytes` property (a `RawSpan`).
 
-The preferred way to convert `Buffer` to `String` is to read output line by line using `.lines()`. You can optionally specify an encoding and buffering policy:
+The preferred way to convert `Buffer` to `String` is to read output line by line using `.strings()`. You can optionally specify an encoding and buffering policy:
 
 ```swift
-for try await line in execution.standardOutput.lines(
-    encoding: UTF16.self,
-    bufferingPolicy: .maxLineLength(1024)
+for try await line in execution.standardOutput.strings(
+    bufferingPolicy: .maxLineLength(1024),
+    as: UTF16.self
 ) {
     // ...
 }

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -119,6 +119,9 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
 
     /// Splits the buffer into strings using the specified separator.
     ///
+    /// The separator characters are not included in the returned strings,
+    /// similar to how `.split(separator:)` works. See ``StringSequence``.
+    ///
     /// - Parameters:
     ///   - separator: The delimiter to split on. The default
     ///     value is `.lineBreaks`.
@@ -141,6 +144,9 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
 
     /// Splits the buffer into strings with the given encoding
     /// and separator.
+    ///
+    /// The separator characters are not included in the returned strings,
+    /// similar to how `.split(separator:)` works. See ``StringSequence``.
     ///
     /// - Parameters:
     ///   - separator: The delimiter to split on. The default


### PR DESCRIPTION
Refs #286.

**README:** several examples used `execution.standardOutput.lines()`, but the API is `strings(separatedBy:bufferingPolicy:)` / `strings(separatedBy:bufferingPolicy:as:)` — there is no `lines()`, so those snippets don't compile. This aligns them with the shipping API, including the parameterized form where the encoding is passed via `as:` (not `encoding:`):

```swift
for try await line in execution.standardOutput.strings(
    bufferingPolicy: .maxLineLength(1024),
    as: UTF16.self
) { ... }
```

**Doc comment:** `strings()` didn't state whether the separator is kept. Added a note that the separator characters are not included in the returned strings, matching the existing `StringSequence` type documentation.

Docs-only change. I've intentionally left the `strings()` → `lines()` rename proposed in #286 to the maintainers — happy to follow up with that if you'd like to go that way (in which case the README would move the other direction).