### PR TITLE
Fix Windows `Environment.Key` `Comparable` and `Equatable` conformance

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -588,10 +588,20 @@ extension Environment.Key {
 
 extension Environment.Key: CodingKeyRepresentable {}
 
+extension Environment.Key {
+    /// The value used for equality, hashing, and ordering.
+    private var _comparisonValue: String {
+        #if os(Windows)
+        return self.rawValue.lowercased()
+        #else
+        return self.rawValue
+        #endif
+    }
+}
+
 extension Environment.Key: Comparable {
     public static func < (lhs: Self, rhs: Self) -> Bool {
-        // Even on windows use a stable sort order.
-        lhs.rawValue < rhs.rawValue
+        lhs._comparisonValue < rhs._comparisonValue
     }
 }
 
@@ -607,11 +617,7 @@ extension Environment.Key: Encodable {
 
 extension Environment.Key: Equatable {
     public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
-        #if os(Windows)
-        lhs.rawValue.lowercased() == rhs.rawValue.lowercased()
-        #else
-        lhs.rawValue == rhs.rawValue
-        #endif
+        lhs._comparisonValue == rhs._comparisonValue
     }
 }
 
@@ -629,11 +635,7 @@ extension Environment.Key: Decodable {
 
 extension Environment.Key: Hashable {
     public func hash(into hasher: inout Hasher) {
-        #if os(Windows)
-        self.rawValue.lowercased().hash(into: &hasher)
-        #else
-        self.rawValue.hash(into: &hasher)
-        #endif
+        self._comparisonValue.hash(into: &hasher)
     }
 }
 

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -570,6 +570,24 @@ extension SubprocessWindowsTests {
     }
 }
 
+// MARK: - Environment.Key Case-Insensitive Comparison
+extension SubprocessWindowsTests {
+    @Test func testEnvironmentKeyComparableMatchesEquatable() {
+        let upper: Environment.Key = "PATH"
+        let lower: Environment.Key = "path"
+        #expect(upper == lower)
+        #expect(!(upper < lower))
+        #expect(!(lower < upper))
+        #expect(!(upper > lower))
+        #expect(!(lower > upper))
+    }
+
+    @Test func testEnvironmentKeySortsCaseInsensitively() {
+        let keys: [Environment.Key] = ["Banana", "apple", "Kiwi"]
+        #expect(keys.sorted().map(\.rawValue) == ["apple", "Banana", "Kiwi"])
+    }
+}
+
 // MARK: - User Utils
 extension SubprocessWindowsTests {
     private func withTemporaryUser(


### PR DESCRIPTION
Closes #316.

The `Equatable` conformance of `Environment.Key` on Windows used case-insensitive comparison (via `lowercased()`), while the `Comparable` conformance used case-sensitive comparison. This violated the `Comparable` contract, in which exactly one of `==`, `<`, or `>` must be true for any two values.

This PR adds `Environment.Key._comparisonValue` to centralize comparison logic, and uses it for equality, hashing, and ordering.

Note: I preserved the existing equality semantics using `String.lowercased()`. Windows treats environment variable names as [case-insensitive ordinal identifiers](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#ordinal-string-operations), whereas `lowercased()` is a linguistic (and locale-independent) fold. The two can differ only on non-ASCII names, which generally exclude environment variable names; so on real inputs, the two are equivalent and this PR's behavior is already correct. An ordinal fold would be a self-contained change to `_comparisonValue` that provides a fixed, Unicode-version-independent comparison key; I'll follow up with that unless we'd rather keep the current behavior.