### PR TITLE
Prevent `gid_t` leak when spawning with `processGroupID`

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -480,6 +480,9 @@ extension Configuration {
                     processGroupIDPtr = .allocate(capacity: 1)
                     processGroupIDPtr?.pointee = gid_t(processGroupID)
                 }
+                defer {
+                    processGroupIDPtr?.deallocate()
+                }
                 // Setup Arguments
                 let argv: [UnsafeMutablePointer<CChar>?] = self.arguments.createArgs(
                     withExecutablePath: possibleExecutablePath


### PR DESCRIPTION
When `PlatformOptions.processGroupID` is set, `spawn()` allocates a `gid_t` for `processGroupIDPtr` inside the candidate-path loop, but never deallocates it. This leaks one allocation per spawn and one per skipped candidate path when earlier paths fail with `ENOENT`/`EACCES`/`ENOTDIR`.

This PR adds `defer`-based deallocation of `processGroupIDPtr`. The pointer is only read by the shim during the synchronous `_subprocess_fork_exec()` call and isn't stored in `ProcessIdentifier` or `SpawnResult`, so iteration-scoped deallocation is safe.