### PR TITLE
Prevent process-descriptor and zombie leaks on spawn exec failure

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -532,6 +532,21 @@ extension Configuration {
                         errorRead: errorReadFileDescriptor,
                         errorWrite: errorWriteFileDescriptor
                     )
+                    // A fork/clone3 that succeeded but failed to execve still
+                    // produced a process descriptor. The fork-vs-exec retry
+                    // discriminator has already run on this outcome, so closing
+                    // it here cannot make the exec-side failure look fork-side.
+                    // Unlike the branch above, close best-effort (mirroring
+                    // ProcessIdentifier.close()) so the spawn error remains as
+                    // the thrown error. Descriptor-less fallbacks returned
+                    // .invalidDescriptor and need no close. This comes after
+                    // the safelyCloseMultiple call, since if that throws, the
+                    // worst case here is one pidfd leaking; otherwise, if this
+                    // came first and throws, the worst case would be six fds
+                    // never closing and their deinit methods fatal-erroring.
+                    if processDescriptor != .invalidDescriptor {
+                        try? _safelyClose(.fileDescriptor(FileDescriptor(rawValue: processDescriptor)))
+                    }
                     throw SubprocessError.spawnFailed(withUnderlyingError: Errno(rawValue: spawnError))
                 }
                 // After spawn finishes, close all child side fds

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -104,6 +104,15 @@ vm_size_t _subprocess_vm_size(void) {
 }
 #endif
 
+#if TARGET_OS_MAC || TARGET_OS_UNIX
+static void _subprocess_reap_pid(pid_t pid) {
+    siginfo_t info;
+    int rc;
+    do {
+        rc = waitid(P_PID, pid, &info, WEXITED);
+    } while (rc == -1 && errno == EINTR);
+}
+#endif
 
 // MARK: - Darwin (posix_spawn)
 #if TARGET_OS_MAC
@@ -231,18 +240,25 @@ static int _subprocess_spawn_prefork(
                 // exec worked!
                 close(pipefd[0]);
                 return 0;
-            } else if (read_rc > 0) {
-                // Child exec failed and reported back
-                close(pipefd[0]);
+            }
+            // Capture errno now, before close()/waitid() can overwrite it.
+            int read_errno = errno;
+            if (read_rc < 0 && read_errno == EINTR) {
+                // Interrupted by a signal. Retry the read. Do not reap here;
+                // the child is reaped exactly once below.
+                continue;
+            }
+            // Setup or exec failed and the child has _exit()'d; reap it to
+            // avoid a zombie. The plain (non-prefork) path delegates to
+            // posix_spawn(), which reaps its own child on failure, so only
+            // this manual-fork path needs an explicit reap.
+            _subprocess_reap_pid(childPid);
+            close(pipefd[0]);
+            if (read_rc > 0) {
+                // Child reported its errno back
                 return childError;
             } else {
-                // Read failed
-                if (errno == EINTR) {
-                    continue;
-                } else {
-                    close(pipefd[0]);
-                    return errno;
-                }
+                return read_errno;
             }
         }
     }
@@ -520,14 +536,6 @@ static void _set_cloexec_to_open_fds(const char *fd_dir) {
 // This function is only used on non-Linux systems.
 static int _highest_possibly_open_fd(void) {
     return sysconf(_SC_OPEN_MAX);
-}
-
-static void _subprocess_reap_pid(pid_t pid) {
-    siginfo_t info;
-    int rc;
-    do {
-        rc = waitid(P_PID, pid, &info, WEXITED);
-    } while (rc == -1 && errno == EINTR);
 }
 
 int _subprocess_fork_exec(

--- a/Tests/SubprocessTests/LinuxTests.swift
+++ b/Tests/SubprocessTests/LinuxTests.swift
@@ -27,6 +27,7 @@ import SystemPackage
 #endif
 
 import FoundationEssentials
+import _SubprocessCShims
 
 import Testing
 @testable import Subprocess
@@ -55,4 +56,120 @@ struct SubprocessLinuxTests {
         }
     }
 }
+
+// MARK: FileDescriptor Leak Tests
+#if os(Linux)
+extension SubprocessLinuxTests {
+    /// A `clone3()`/`fork()` that succeeds and then fails at `execve()` used to
+    /// leak the process descriptor (the `clone3(CLONE_PIDFD)` fd, or its
+    /// `pidfd_open()` fallback) on the non-retried spawn-error branch. This
+    /// runs many spawns that fail at `execve()` with `ENOEXEC` and asserts the
+    /// open `pidfd` count does not grow.
+    ///
+    /// Run inside an exit test so the count is unaffected by subprocesses that
+    /// other suites spawn concurrently in the shared test process; isolation is
+    /// what lets the assertion be exact rather than a sampled threshold (see
+    /// `testConcurrentRun()`).
+    ///
+    /// Linux only: exit tests are unavailable on Android and the `pidfd` marker
+    /// is read from `/proc`. On kernels predating pidfd support (< 5.3), the
+    /// spawn creates no descriptor and this passes vacuously.
+    @Test(.timeLimit(.minutes(1)))
+    func testProcessDescriptorNotLeakedOnExecFailure() async {
+        await #expect(processExitsWith: .success) {
+            // A mode-0755 file whose contents are neither `ELF` nor a `#!`
+            // script. `execve(2)` rejects it with `ENOEXEC`, which is outside
+            // `{ENOENT, EACCES, ENOTDIR}` and therefore reaches the leaking
+            // branch, after the child has already been created.
+            var pathBuffer = Array("/tmp/subprocess-noexec-XXXXXX\u{0}".utf8).map { CChar(bitPattern: $0) }
+            let fd = pathBuffer.withUnsafeMutableBufferPointer { mkstemp($0.baseAddress!) }
+            try #require(fd >= 0, "mkstemp failed: \(errno)")
+
+            let executablePath = pathBuffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+            defer { _ = unlink(executablePath) }
+            try #require(fchmod(fd, 0o755) == 0, "fchmod failed: \(errno)")
+
+            let contents = Array("not an executable\n".utf8)
+            let written = contents.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+            try #require(written == contents.count, "write failed: \(errno)")
+            try #require(close(fd) == 0, "close failed: \(errno)")
+
+            // Confirm the counter recognizes a pidfd on this kernel before
+            // relying on it; otherwise a link-format change (as in the 6.9
+            // pidfs move) makes the leak assertion silently vacuous. Skip when
+            // pidfds are unsupported (pre-5.3), where the spawn path creates
+            // none and there is no leak to detect.
+            let probe = _pidfd_open(getpid())
+            if probe >= 0 {
+                try #require(
+                    countOpenProcessDescriptors() >= 1,
+                    "process-descriptor counter did not recognize a live pidfd on this kernel"
+                )
+                _ = close(probe)
+            }
+
+            let iterations = 64
+            let before = countOpenProcessDescriptors()
+            for _ in 0..<iterations {
+                let spawnError: SubprocessError?
+                do {
+                    _ = try await Subprocess.run(
+                        .path(FilePath(executablePath)),
+                        output: .discarded,
+                        error: .discarded
+                    )
+                    spawnError = nil
+                } catch let error as SubprocessError {
+                    spawnError = error
+                }
+                // A non-executable cannot exec, so a failure is mandatory.
+                // `ENOENT`/`EACCES`/`ENOTDIR` take the `continue` path, which
+                // already closes the descriptor.
+                let error = try #require(
+                    spawnError, "spawn unexpectedly succeeded for a non-executable file"
+                )
+                try #require(error.code == .spawnFailed)
+                try #require(error.underlyingError == Errno(rawValue: ENOEXEC))
+            }
+            let after = countOpenProcessDescriptors()
+            try #require(
+                after == before,
+                "leaked \(after - before) process descriptor(s) across \(iterations) failed spawns"
+            )
+        }
+    }
+}
+
+/// Counts the open process descriptors in the current process by scanning
+/// `/proc/self/fd` for symlinks that point at a pidfd.
+///
+/// The link target differs by kernel: pre-6.9 backs pidfds with `anon_inode`
+/// (`"anon_inode:[pidfd]"`); 6.9+ moved them to pidfs, whose target carries a
+/// per-fd inode. Both contain `"pidfd"`, and no other descriptor this process
+/// holds would contain that, so a substring match identifies them across
+/// kernels.
+private func countOpenProcessDescriptors() -> Int {
+    guard let dir = opendir("/proc/self/fd") else { return 0 }
+    defer { closedir(dir) }
+    var count = 0
+    while let entry = readdir(dir) {
+        let name = withUnsafeBytes(of: entry.pointee.d_name) { raw -> String in
+            String(cString: raw.baseAddress!.assumingMemoryBound(to: CChar.self))
+        }
+        if name == "." || name == ".." { continue }
+        var linkBuffer = [CChar](repeating: 0, count: 256)
+        let length = ("/proc/self/fd/" + name).withCString { path in
+            readlink(path, &linkBuffer, linkBuffer.count - 1)
+        }
+        guard length > 0 else { continue }
+        linkBuffer[length] = 0
+        let target = linkBuffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+        if target.contains("pidfd") {
+            count += 1
+        }
+    }
+    return count
+}
+#endif
+
 #endif // canImport(Glibc) || canImport(Bionic) || canImport(Musl)


### PR DESCRIPTION
Follow-up to #312.

### Leaked process descriptor on exec-failure spawn errors (Linux/Android/FreeBSD)

A `clone3()`/`fork()` that succeeds and then fails at `execve()` still produces a process descriptor (`clone3(CLONE_PIDFD)`, its `pidfd_open()` fallback, or `pdfork()`). `_subprocess_fork_exec()` reaps the child but returns that descriptor open, and the `spawnFailed` branch in `spawn()` closed only the stdio pipes, leaking it. (The `ENOENT`/`EACCES`/`ENOTDIR` branch already closes it before moving to the next candidate path.)

This PR closes it on that branch, after `safelyCloseMultiple()` and guarded on a valid descriptor, best-effort (`try?`, mirroring `ProcessIdentifier.close()`) so the spawn error remains the thrown error. The close is Swift-side rather than in the shim because the `EAGAIN` retry from #312 distinguishes a fork-side failure (no descriptor) from an exec-side one (descriptor present) by that value; clearing it in the shim would defeat the discriminator.

### Unreaped prefork child on exec failure (Darwin)

On Darwin, `_subprocess_spawn_prefork()` forks and execs via `posix_spawn(POSIX_SPAWN_SETEXEC)`. When setup or exec fails the child `_exit()`s, but the parent returned the error without reaping it, leaving a zombie. Unlike Linux, there is no `SIGCHLD` reaper, and the Swift spawn-failure path does not reap either. The plain path delegates to `posix_spawn()`, which reaps its own child, so only the manual-fork path is affected.

This PR reaps the child on the failure return, matching `_subprocess_fork_exec()`, and hoists `_subprocess_reap_pid()` above both spawn blocks under `TARGET_OS_MAC || TARGET_OS_UNIX` so the Darwin block can use it.