### PR TITLE
Fold `Environment.Key` to uppercase ordinally on Windows

### DIFF
--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -592,7 +592,28 @@ extension Environment.Key {
     /// The value used for equality, hashing, and ordering.
     private var _comparisonValue: String {
         #if os(Windows)
-        return self.rawValue.lowercased()
+        // Windows treats environment-variable names case-insensitively and
+        // requires the environment block to be sorted in case-insensitive,
+        // ordinal order without regard to locale. Its ordinal case-insensitive
+        // comparison folds to uppercase, so '_' (0x5F), and the other scalars
+        // between 'Z' and 'a', sort after letters. Folding to uppercase here
+        // (a–z → A–Z) lands letters in 0x41–0x5A and matches that order;
+        // folding to lowercase would sort '_' before letters.
+        //
+        // The fold is ASCII-only and applies no Unicode case mapping, so unlike
+        // `uppercased()` it never expands a scalar ("ß" stays "ß", not "SS")
+        // and is stable across Unicode versions. It does not case-fold
+        // non-ASCII scalars the way Windows does, which is immaterial because
+        // environment-variable names are ASCII in practice.
+        return String(
+            String.UnicodeScalarView(
+                self.rawValue.unicodeScalars.map { scalar in
+                    (scalar.value >= 0x61 && scalar.value <= 0x7A)
+                        ? Unicode.Scalar(scalar.value - 0x20)! // a–z → A–Z; always valid
+                        : scalar
+                }
+            )
+        )
         #else
         return self.rawValue
         #endif

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -586,6 +586,14 @@ extension SubprocessWindowsTests {
         let keys: [Environment.Key] = ["Banana", "apple", "Kiwi"]
         #expect(keys.sorted().map(\.rawValue) == ["apple", "Banana", "Kiwi"])
     }
+
+    @Test func testEnvironmentKeyOrdinalSortMatchesWindowsBlockOrder() {
+        // Windows sorts the environment block case-insensitively in uppercase
+        // ordinal order, so '_' (0x5F) sorts after letters. "APPDATA" must
+        // therefore precede "APP_NAME".
+        let keys: [Environment.Key] = ["APP_NAME", "APPDATA"]
+        #expect(keys.sorted().map(\.rawValue) == ["APPDATA", "APP_NAME"])
+    }
 }
 
 // MARK: - User Utils


### PR DESCRIPTION
Follow-up to #317.

On Windows, `Environment.Key` compares case-insensitively. #317 routed equality, hashing, and ordering through a shared `_comparisonValue` that folds with `String.lowercased()`, which sorts `_` (`0x5F`) and the other scalars between `Z` and `a` before letters.

Windows [requires](https://learn.microsoft.com/en-us/windows/win32/procthread/changing-environment-variables) the environment block to be sorted case-insensitively in ordinal order, without regard to locale:

> The sort is case-insensitive, Unicode order, without regard to locale.

Its ordinal case-insensitive comparison folds to uppercase, so `_` sorts after letters, not before. This PR switches `_comparisonValue` to an ASCII-only uppercase fold (`a–z → A–Z`, every other scalar byte-identical), landing letters in `0x41-0x5A` so the ordering matches. This is consistent with the [guidance](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage) to normalize to uppercase:

> Use the [`String.ToUpperInvariant`](https://learn.microsoft.com/en-us/dotnet/api/system.string.toupperinvariant) method instead of the [`String.ToLowerInvariant`](https://learn.microsoft.com/en-us/dotnet/api/system.string.tolowerinvariant) method when you normalize strings for comparison.

It's a manual fold rather than `uppercased()`, which applies Unicode case mapping and can expand a scalar (`ß → SS`); the ASCII fold never expands and is stable across Unicode versions. It's [ordinal](https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#ordinal-string-operations) rather than linguistic since environment-variable names are identifiers.