### PR TITLE
Fix broken symbol links

### DIFF
--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -284,8 +284,8 @@ public final actor StandardInputWriter: Sendable {
     /// Writes an array of bytes to the subprocess's standard input.
     /// - Parameter array: The bytes to write.
     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
-    ///     See ``underlyingError`` for more details. Also throws this error if
-    ///     the writer has already finished (see ``finish()``).
+    ///     See ``SubprocessError/underlyingError`` for more details. Also throws
+    ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
     public func write(
         _ array: [UInt8]
@@ -300,8 +300,8 @@ public final actor StandardInputWriter: Sendable {
     ///
     /// - Parameter span: The span to write.
     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
-    ///     See ``underlyingError`` for more details. Also throws this error if
-    ///     the writer has already finished (see ``finish()``).
+    ///     See ``SubprocessError/underlyingError`` for more details. Also throws
+    ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
     public func write(_ span: borrowing RawSpan) async throws(SubprocessError) -> Int {
         guard !self.didFinish else {
@@ -315,8 +315,8 @@ public final actor StandardInputWriter: Sendable {
     ///   - string: The string to write.
     ///   - encoding: The encoding to use when converting the string to bytes.
     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
-    ///     See ``underlyingError`` for more details. Also throws this error if
-    ///     the writer has already finished (see ``finish()``).
+    ///     See ``SubprocessError/underlyingError`` for more details. Also throws
+    ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
     public func write<Encoding: Unicode.Encoding>(
         _ string: some StringProtocol,
@@ -338,7 +338,7 @@ public final actor StandardInputWriter: Sendable {
     /// ``SubprocessError/Code/failedToWriteToSubprocess``.
     ///
     /// - Throws: `SubprocessError` with error code `.asyncIOFailed`.
-    ///     See ``underlyingError`` for more details.
+    ///     See ``SubprocessError/underlyingError`` for more details.
     public func finish() async throws(SubprocessError) {
         guard !self.didFinish else {
             return

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -165,7 +165,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
         return result
     }
 
-    /// Creates an array from a ``RawSpan``.
+    /// Creates an array from a `RawSpan`.
     public func output(from span: RawSpan) throws -> [UInt8] {
         span.withUnsafeBytes { Array($0) }
     }

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -210,7 +210,8 @@ extension SubprocessOutputSequence {
     ///
     /// By default, the sequence splits on Unicode line break
     /// characters. You can supply a custom separator with the
-    /// ``Separator/unicodeScalarSequence(_:)`` factory method.
+    /// ``Separator/unicodeScalarSequence(_:)-(Sequence<Unicode.Scalar>)``
+    /// factory method.
     ///
     /// The following Unicode characters are recognized as line
     /// breaks:
@@ -229,9 +230,9 @@ extension SubprocessOutputSequence {
     /// strings, similar to how `.split(separator:)` works.
     ///
     /// When you use a custom separator created with
-    /// ``Separator/unicodeScalarSequence(_:)``, the sequence performs a
-    /// code-unit-level comparison without Unicode normalization.
-    /// See ``Separator/unicodeScalarSequence(_:)`` for details.
+    /// ``Separator/unicodeScalarSequence(_:)-(Sequence<Unicode.Scalar>)``, the
+    /// sequence performs a code-unit-level comparison without Unicode normalization.
+    /// See ``Separator/unicodeScalarSequence(_:)-(Sequence<Unicode.Scalar>)`` for details.
     public struct StringSequence<Encoding: _UnicodeEncoding & Sendable>: AsyncSequence, Sendable {
         /// The element type for the asynchronous sequence.
         public typealias Element = String


### PR DESCRIPTION
This PR fixes various broken symbol links surfaced when generating DocC documentation:

- Qualifies `SubprocessError.underlyingError` symbol links.
- Removes the `RawSpan` symbol link. This is a stdlib type.
- Disambiguates `Separator.unicodeScalarSequence(_:)` symbol links by preferring the more general overload.

<details>
<summary>DocC warnings</summary>

```text
% swift package --disable-sandbox preview-documentation --target Subprocess
...
warning: 'underlyingError' doesn't exist at '/Subprocess/StandardInputWriter/write(_:)'
   --> Sources/Subprocess/IO/Input.swift:287:17-287:32
285 |     /// - Parameter array: The bytes to write.
286 |     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
287 +     ///     See ``underlyingError`` for more details. Also throws this error if
288 |     ///     the writer has already finished (see ``finish()``).
289 |     /// - Returns: The number of bytes written.

warning: 'underlyingError' doesn't exist at '/Subprocess/StandardInputWriter/write(_:)'
   --> Sources/Subprocess/IO/Input.swift:303:17-303:32
301 |     /// - Parameter span: The span to write.
302 |     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
303 +     ///     See ``underlyingError`` for more details. Also throws this error if
304 |     ///     the writer has already finished (see ``finish()``).
305 |     /// - Returns: The number of bytes written.

warning: 'underlyingError' doesn't exist at '/Subprocess/StandardInputWriter/write(_:using:)'
   --> Sources/Subprocess/IO/Input.swift:318:17-318:32
316 |     ///   - encoding: The encoding to use when converting the string to bytes.
317 |     /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
318 +     ///     See ``underlyingError`` for more details. Also throws this error if
319 |     ///     the writer has already finished (see ``finish()``).
320 |     /// - Returns: The number of bytes written.

warning: 'underlyingError' doesn't exist at '/Subprocess/StandardInputWriter/finish()'
   --> Sources/Subprocess/IO/Input.swift:341:17-341:32
339 |     ///
340 |     /// - Throws: `SubprocessError` with error code `.asyncIOFailed`.
341 +     ///     See ``underlyingError`` for more details.
342 |     public func finish() async throws(SubprocessError) {
343 |         guard !self.didFinish else {

warning: 'RawSpan' doesn't exist at '/Subprocess/BytesOutput/output(from:)'
   --> Sources/Subprocess/IO/Output.swift:168:35-168:42
166 |     }
167 |
168 +     /// Creates an array from a ``RawSpan``.
169 |     public func output(from span: RawSpan) throws -> [UInt8] {
170 |         span.withUnsafeBytes { Array($0) }

warning: 'unicodeScalarSequence(_:)' is ambiguous at '/Subprocess/SubprocessOutputSequence/StringSequence/Separator'
   --> Sources/Subprocess/SubprocessOutputSequence.swift:213:21-213:46
211 |     /// By default, the sequence splits on Unicode line break
212 |     /// characters. You can supply a custom separator with the
213 +     /// ``Separator/unicodeScalarSequence(_:)`` factory method.
    |                                              ├─suggestion: Insert '-([Unicode.Scalar])' for 'static func unicodeScalarSequence(_ separators: Array<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
    |                                              ╰─suggestion: Insert '-(Sequence<Unicode.Scalar>)' for 'static func unicodeScalarSequence(_ separators: some Sequence<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
214 |     ///
215 |     /// The following Unicode characters are recognized as line

warning: 'unicodeScalarSequence(_:)' is ambiguous at '/Subprocess/SubprocessOutputSequence/StringSequence/Separator'
   --> Sources/Subprocess/SubprocessOutputSequence.swift:232:21-232:46
230 |     ///
231 |     /// When you use a custom separator created with
232 +     /// ``Separator/unicodeScalarSequence(_:)``, the sequence performs a
    |                                              ├─suggestion: Insert '-([Unicode.Scalar])' for 'static func unicodeScalarSequence(_ separators: Array<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
    |                                              ╰─suggestion: Insert '-(Sequence<Unicode.Scalar>)' for 'static func unicodeScalarSequence(_ separators: some Sequence<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
233 |     /// code-unit-level comparison without Unicode normalization.
234 |     /// See ``Separator/unicodeScalarSequence(_:)`` for details.

warning: 'unicodeScalarSequence(_:)' is ambiguous at '/Subprocess/SubprocessOutputSequence/StringSequence/Separator'
   --> Sources/Subprocess/SubprocessOutputSequence.swift:234:25-234:50
232 |     /// ``Separator/unicodeScalarSequence(_:)``, the sequence performs a
233 |     /// code-unit-level comparison without Unicode normalization.
234 +     /// See ``Separator/unicodeScalarSequence(_:)`` for details.
    |                                                  ├─suggestion: Insert '-([Unicode.Scalar])' for 'static func unicodeScalarSequence(_ separators: Array<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
    |                                                  ╰─suggestion: Insert '-(Sequence<Unicode.Scalar>)' for 'static func unicodeScalarSequence(_ separators: some Sequence<Unicode.Scalar>) -> SubprocessOutputSequence.StringSequence<Encoding>.Separator'
235 |     public struct StringSequence<Encoding: _UnicodeEncoding & Sendable>: AsyncSequence, Sendable {
236 |         /// The element type for the asynchronous sequence.
```
</details>