### PR TITLE
Add `SubprocessError` symbol links to error-throwing docs

### DIFF
--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -283,7 +283,7 @@ public final actor StandardInputWriter: Sendable {
 
     /// Writes an array of bytes to the subprocess's standard input.
     /// - Parameter array: The bytes to write.
-    /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
+    /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/failedToWriteToSubprocess``.
     ///     See ``SubprocessError/underlyingError`` for more details. Also throws
     ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
@@ -299,7 +299,7 @@ public final actor StandardInputWriter: Sendable {
     /// Writes a raw span to the subprocess's standard input.
     ///
     /// - Parameter span: The span to write.
-    /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
+    /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/failedToWriteToSubprocess``.
     ///     See ``SubprocessError/underlyingError`` for more details. Also throws
     ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
@@ -314,7 +314,7 @@ public final actor StandardInputWriter: Sendable {
     /// - Parameters:
     ///   - string: The string to write.
     ///   - encoding: The encoding to use when converting the string to bytes.
-    /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
+    /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/failedToWriteToSubprocess``.
     ///     See ``SubprocessError/underlyingError`` for more details. Also throws
     ///     this error if the writer has already finished (see ``finish()``).
     /// - Returns: The number of bytes written.
@@ -337,7 +337,7 @@ public final actor StandardInputWriter: Sendable {
     /// After finishing, further writes throw a ``SubprocessError`` with the code
     /// ``SubprocessError/Code/failedToWriteToSubprocess``.
     ///
-    /// - Throws: `SubprocessError` with error code `.asyncIOFailed`.
+    /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/asyncIOFailed``.
     ///     See ``SubprocessError/underlyingError`` for more details.
     public func finish() async throws(SubprocessError) {
         guard !self.didFinish else {

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -99,8 +99,8 @@ extension Execution {
     ///   - signal: The signal to send.
     ///   - shouldSendToProcessGroup: Whether this signal should be sent to
     ///     the entire process group.
-    /// - Throws: `SubprocessError` with error code `.processControlFailed`.
-    ///     See `.underlyingError` for more details.
+    /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/processControlFailed``.
+    ///     See ``SubprocessError/underlyingError`` for more details.
     public func send(
         signal: Signal,
         toProcessGroup shouldSendToProcessGroup: Bool = false


### PR DESCRIPTION
This PR converts error-throwing documentation to use symbol links. For example:

```diff
- /// - Throws: `SubprocessError` with error code `.failedToWriteToSubprocess`.
+ /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/failedToWriteToSubprocess``.
```

Note: This depends on #322 since it touches adjacent lines. Once that PR lands, I'll rebase this and convert it from a draft.