### PR TITLE
Recover final read buffer when output capture is cancelled on Windows

### DIFF
--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -292,7 +292,16 @@ final class AsyncIO: @unchecked Sendable {
         let bytesRead: DWORD
         do {
             guard let next = try await iterator.next() else {
-                return .finished
+                // `next()` resolved to `nil` because the owning task was cancelled
+                // (`group.cancelAll()` on child termination), not because the read
+                // failed. The `ReadFile` issued above may have already completed,
+                // with its bytes sitting in `resultBuffer`. Those bytes have been
+                // pulled out of the pipe, so the post-cancellation drain cannot
+                // recover them: dropping them here loses exactly one buffer.
+                return self.reconcileOverlappedAfterCancellation(
+                    handle: handle,
+                    overlapped: &overlapped
+                )
             }
             bytesRead = next
         } catch {
@@ -308,6 +317,88 @@ final class AsyncIO: @unchecked Sendable {
             return .finished
         }
         return .read(Int(truncatingIfNeeded: bytesRead))
+    }
+
+    /// Reconciles an overlapped `ReadFile` whose awaiting task was cancelled
+    /// before its completion was delivered through the signal stream.
+    ///
+    /// When the capture task is cancelled, the `ReadFile` this function's caller
+    /// issued is in one of three states, and returning `.finished`
+    /// unconditionally is wrong for two of the three states: for a completed
+    /// read it silently drops the bytes already moved out of the pipe, and for
+    /// a pending read it abandons an operation whose buffer the kernel may still
+    /// be writing into (use-after-free once that buffer goes out of scope). The
+    /// third state, a completed-empty or aborted read, is the one an
+    /// unconditional `.finished` handles correctly. The pending case is reached
+    /// when a surviving descendant holds the write end open and the read is
+    /// parked at cancellation (the same condition as
+    /// `drainBufferedDataAfterCancellation()`).
+    ///
+    /// - Important: `overlapped` must reference the same storage passed to the
+    /// `ReadFile` call, and `resultBuffer` (owned by the caller) must outlive
+    /// this call. On the pending path this function blocks until the cancelled
+    /// read has fully unwound, guaranteeing the kernel is done with both before
+    /// they are freed.
+    private func reconcileOverlappedAfterCancellation(
+        handle: HANDLE,
+        overlapped: inout _OVERLAPPED
+    ) -> OverlappedReadOutcome {
+        var transferred: DWORD = 0
+
+        // Did the read already complete?
+        if GetOverlappedResult(handle, &overlapped, &transferred, false) {
+            // Completed. If it carried bytes, they are in `resultBuffer` and must
+            // be surfaced; the drain can't re-read them (already out of pipe).
+            if transferred > 0 {
+                return .read(Int(truncatingIfNeeded: transferred))
+            }
+            // Completed with zero bytes: EOF-like. Let the caller fall through
+            // to the drain (which will see broken pipe/empty and finish).
+            return .finished
+        }
+
+        let gle = GetLastError()
+        if gle == ERROR_IO_INCOMPLETE {
+            // The read is still pending. Returning now would let `resultBuffer`
+            // and `overlapped` go out of scope while the kernel may still write
+            // into them, so cancel this specific operation and block until it
+            // has fully unwound.
+            //
+            // With `overlapped.hEvent` `NULL`, the wait below falls back to
+            // signaling on `handle` itself. Microsoft discourages that only
+            // because a handle carrying several concurrent overlapped
+            // operations can't disambiguate which one completed. This handle
+            // never does: stdout is read-only and reads on it are strictly
+            // sequential (the capture loop awaits each read before issuing the
+            // next), so at most one operation is in flight, and `ReadFile`
+            // resets the handle to nonsignaled at issue, so no prior read's
+            // signal can satisfy this wait early. `drainBufferedDataAfterCancellation()`
+            // issues its own read and can therefore afford a private event with
+            // the IOCP-suppressing low bit; this operation was already issued
+            // IOCP-bound, so it reuses the handle's own signal instead.
+            _ = CancelIoEx(handle, &overlapped)
+            // Wait for the cancelled operation to finish unwinding. After this
+            // returns (success or failure), the kernel is done with the buffer.
+            //
+            // The pipes are byte-mode (`PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT`),
+            // so a read never sits partially filled: it completes the moment any
+            // byte is available, or stays pending with nothing transferred. So
+            // a cancelled pending read almost always reports zero bytes and falls
+            // through to the drain; the `transferred > 0` arm is defensive. It
+            // fires only in the narrow window where the read produces bytes
+            // between the two checks (byte pipes fill from the front, so the
+            // reported count is a contiguous prefix).
+            if GetOverlappedResult(handle, &overlapped, &transferred, true),
+                transferred > 0
+            {
+                return .read(Int(truncatingIfNeeded: transferred))
+            }
+            return .finished
+        }
+
+        // Any other status: no bytes to recover here. The drain handles anything
+        // still buffered.
+        return .finished
     }
 
     /// Reads bytes already buffered in the pipe after the owning process has


### PR DESCRIPTION
A [nondeterministic Windows failure](https://github.com/swiftlang/swift-subprocess/actions/runs/28302809096/job/83853940726?pr=323) in `testStringInput()` surfaced when running CI on a documentation-only PR (#323).

The test pipes a 100,000-character string through an echo and compares the round-tripped output. Diffing the captured failure against the expected input showed the output was a byte-exact prefix: identical for the first 88,104 characters, then truncated; a pure tail loss of one chunk, where the missing amount is one pipe buffer.

When a child process terminates while output capture has an overlapped `ReadFile()` in flight, the read's completion races the cancellation that termination triggers (`group.cancelAll()`). When the cancellation won, `issueAndAwaitRead()` observed `nil` from the signal stream and returned `.finished`, discarding `resultBuffer`. If the `ReadFile()` had already completed, its bytes were sitting in that buffer and had already been moved out of the pipe, so the post-cancellation drain could not re-read them. The result was a silent loss of up to one pipe buffer (~16 KB) from the tail of the captured output. On non-Windows platforms, the kqueue path reads the file descriptor directly and has no equivalent failure mode.

This PR adds the `reconcileOverlappedAfterCancellation()` method to reconcile the overlapped operation before returning on cancellation instead of discarding it: a completed read surfaces its bytes as `.read`, a completed-empty or aborted read falls through to the drain, and a still-pending read is cancelled with `CancelIoEx()` and waited on before the buffer goes out of scope. The last case also closes a latent use-after-free where the kernel could write into `resultBuffer` after the awaiting frame unwound.

Note: I think `write(_:to:for:)` has the same shape on its cancellation path; its `next() == nil` branch returns the bytes confirmed so far without reconciling a `WriteFile()` that may still be pending. The stranded-bytes concern doesn't apply there (those bytes were destined for a pipe whose reader, the child, has terminated), but the buffer-lifetime concern is similar to this fix: a pending `WriteFile()` is the kernel reading from the caller's span, and the borrow is released once the write returns. I can look into fixing this in a follow-up PR.

<details>
<summary>Code flow, reproduction, and documentation</summary>

### Code flow

1. `waitForProcessTermination()` resolves; the `.processTerminated` task returns and the result loop in `run()` calls `group.cancelAll()`.
2. The output-capture task is parked at `await iterator.next()` in `issueAndAwaitRead()`; cancellation makes that call return `nil`.
3. Pre-fix, the `nil` branch returned `.finished`, dropping `resultBuffer` (including a `ReadFile()` that had already completed and moved its bytes out of the pipe).
4. The drain re-peeks the pipe, but those bytes are gone from it, so they're unrecoverable: one buffer lost from the tail.

### Reproduction

I reproduced the error on `windows-latest` using a harness that deterministically forces the failing interleaving by introducing a delay in the monitor thread before it delivers a read completion, so termination's cancellation reliably wins the race against the in-flight read. Under that forced window, the failure reproduced on the first iteration every run; with the fix, the same forced window recovers the completed buffer deterministically and the round-trip is byte-exact.

The harness exercised the completed-read path. The still-pending branch is reachable when a surviving descendant holds the output write end open and the read is parked at cancellation (the same condition as `drainBufferedDataAfterCancellation()`). `testStringInput()` doesn't trigger that condition since its child leaves no such descendant and the read resolves through `ERROR_BROKEN_PIPE`.

I didn't add a dedicated regression test because as far as I can tell, deterministically forcing this interleaving would require a delay hook in the monitor thread (like in the harness), which I didn't think was suitable to ship. We could add it behind a test-only flag, but that's instrumentation on the monitor's hot path, so I figured it wouldn't be appropriate. `testStringInput()` is the probabilistic guard.

### Documentation

- [`GetOverlappedResult()` hangs](https://devblogs.microsoft.com/oldnewthing/20110303-00/?p=11313)
- [Separate event objects for overlapped operations](https://learn.microsoft.com/en-us/windows/win32/sync/synchronization-and-overlapped-input-and-output)
- [`GetOverlappedResult()` resets a file object's event to nonsignaled](https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresult)
- [Byte-mode pipes](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-type-read-and-wait-modes)

</details>