### PR TITLE
Adopt SE-0456 `Span` and `Data` accessors

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -188,7 +188,7 @@ public func run<
         output: output,
         error: error
     ) { execution in
-        _ = try await execution.standardInputWriter.write(input._bytes)
+        _ = try await execution.standardInputWriter.write(input.bytes)
         try await execution.standardInputWriter.finish()
     }
 }

--- a/Sources/Subprocess/Buffer.swift
+++ b/Sources/Subprocess/Buffer.swift
@@ -63,14 +63,8 @@ extension SubprocessOutputSequence.Buffer {
         }
     }
 
-    // swift-format-ignore
     // Access the storage backing this Buffer
     public var bytes: RawSpan {
-        @_lifetime(borrow self)
-        borrowing get {
-            let ptr = self.data.withUnsafeBytes { $0 }
-            let bytes = RawSpan(_unsafeBytes: ptr)
-            return _overrideLifetime(of: bytes, to: self)
-        }
+        return self.data._bytes
     }
 }

--- a/Sources/Subprocess/Span+Subprocess.swift
+++ b/Sources/Subprocess/Span+Subprocess.swift
@@ -37,21 +37,14 @@ public func _overrideLifetime<
     dependent
 }
 
-extension Span where Element: BitwiseCopyable {
-    internal var _bytes: RawSpan {
-        @_lifetime(copy self)
-        @_alwaysEmitIntoClient
-        get {
-            let rawSpan = RawSpan(_elements: self)
-            return _overrideLifetime(of: rawSpan, copyingFrom: self)
-        }
-    }
-}
-
 extension Array where Element: BitwiseCopyable {
     // swift-format-ignore
     // Access the storage backing this Buffer
     internal var _bytes: RawSpan {
+        // `Array.span` (SE-0456) is gated to macOS 26 and does not back-deploy,
+        // but Subprocess deploys to macOS 13, so hand-roll the `RawSpan`. There
+        // is no back-deployed `Array.span`. Replace with `self.span.bytes` once
+        // the deployment floor reaches macOS 26.
         @_lifetime(borrow self)
         borrowing get {
             let ptr = self.withUnsafeBytes { $0 }

--- a/Sources/Subprocess/SubprocessFoundation/Span+SubprocessFoundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Span+SubprocessFoundation.swift
@@ -23,50 +23,6 @@ extension Data {
     init(_ s: borrowing RawSpan) {
         self = s.withUnsafeBytes { Data($0) }
     }
-
-    internal var bytes: RawSpan {
-        // FIXME: For demo purpose only
-        let ptr = self.withUnsafeBytes { ptr in
-            return ptr
-        }
-        let span = RawSpan(_unsafeBytes: ptr)
-        return _overrideLifetime(of: span, to: self)
-    }
-}
-
-extension DataProtocol {
-    var bytes: RawSpan {
-        _read {
-            if self.regions.isEmpty {
-                let empty = UnsafeRawBufferPointer(start: nil, count: 0)
-                let span = RawSpan(_unsafeBytes: empty)
-                yield _overrideLifetime(of: span, to: self)
-            } else if self.regions.count == 1 {
-                // Easy case: there is only one region in the data
-                let ptr = self.regions.first!.withUnsafeBytes { ptr in
-                    return ptr
-                }
-                let span = RawSpan(_unsafeBytes: ptr)
-                yield _overrideLifetime(of: span, to: self)
-            } else {
-                // This data contains discontiguous chunks. We have to
-                // copy and make a contiguous chunk
-                var contiguous: ContiguousArray<UInt8>?
-                for region in self.regions {
-                    if contiguous != nil {
-                        contiguous?.append(contentsOf: region)
-                    } else {
-                        contiguous = .init(region)
-                    }
-                }
-                let ptr = contiguous!.withUnsafeBytes { ptr in
-                    return ptr
-                }
-                let span = RawSpan(_unsafeBytes: ptr)
-                yield _overrideLifetime(of: span, to: self)
-            }
-        }
-    }
 }
 
 #endif // SubprocessFoundation

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -921,6 +921,8 @@ extension SubprocessIntegrationTests {
         let expected: Data = try Data(
             contentsOf: URL(filePath: theMysteriousIsland.string)
         )
+        // TODO: Pass `expected.span` directly to `_run()`.
+        // https://github.com/swiftlang/swift/issues/90259
         let ptr = expected.withUnsafeBytes { return $0 }
         let span: Span<UInt8> = Span(_unsafeBytes: ptr)
         let catResult = try await _run(


### PR DESCRIPTION
[SE-0456](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0456-stdlib-span-properties.md) added `Span`-providing properties to standard library types; Foundation also added `Data.bytes` and `Data.span` accordingly. These additions subsume the need for the `Data.bytes` and `Span._bytes` shims.

The only caller of `Data.bytes` is `AsyncIO.write(_:to:for:)`, which now binds to Foundation's accessor. The removed accessor also escaped the pointer vended by `withUnsafeBytes(_:)`; Foundation's borrowing accessor avoids this. `DataProtocol.bytes` had no callers and is removed as dead code.

The only caller of `Span._bytes` is `run(_:input:output:error:)`, which now uses `input.bytes`. `Buffer.bytes` duplicated the hand-rolled `RawSpan` construction and now delegates to `Array._bytes`, leaving a single implementation.

`Array._bytes` remains because `Array.span` does not back-deploy below macOS 26, but Subprocess deploys to macOS 13. This can move to `self.span.bytes` once the deployment floor reaches macOS 26.