### PR TITLE
Remove experimental span feature from test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,9 +68,7 @@ let package = Package(
                 "TestResources",
                 .product(name: "SystemPackage", package: "swift-system"),
             ],
-            swiftSettings: [
-                .enableExperimentalFeature("Span")
-            ] + packageSwiftSettings
+            swiftSettings: packageSwiftSettings
         ),
 
         .target(


### PR DESCRIPTION
This experimental feature is no longer necessary in the test target.