### PR TITLE
Spelling, wording, and grammar updates

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -162,8 +162,7 @@ public func run<
 
 // MARK: - Configuration Based
 
-/// Runs a configuration asynchronously and returns an ``ExecutionResult`` that
-/// contains the output of the child process.
+/// Runs a subprocess with the given configuration and returns the collected output and exit status.
 ///
 /// - Parameters:
 ///   - configuration: The configuration to run.
@@ -193,8 +192,7 @@ public func run<
     }
 }
 
-/// Runs a ``Configuration`` asynchronously and returns
-/// an ``ExecutionResult`` that contains the output of the child process.
+/// Runs a subprocess with the given configuration and returns the collected output and exit status.
 ///
 /// - Parameters:
 ///   - configuration: The configuration to run.
@@ -217,8 +215,7 @@ public func run<
     }
 }
 
-/// Runs a ``Configuration`` asynchronously and lets a closure manage the running
-/// subprocess.
+/// Runs a subprocess with the given configuration and lets a closure interact with it while it runs.
 ///
 /// Use this overload when you need to interact with the subprocess while it runs,
 /// such as streaming its standard output, writing to its standard input, or sending

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -18,7 +18,7 @@ public import SystemPackage
 // MARK: - Collected Result
 
 /// Runs an executable asynchronously and returns the collected output
-/// of the child process.
+/// of the subprocess.
 ///
 /// - Parameters:
 ///   - executable: The executable to run.
@@ -60,7 +60,7 @@ public func run<
 }
 
 /// Runs an executable asynchronously and returns the collected output
-/// of the child process.
+/// of the subprocess.
 ///
 /// - Parameters:
 ///   - executable: The executable to run.
@@ -125,7 +125,7 @@ public func run<
 ///     an ``Execution`` value that's valid only for the duration of the call.
 ///     Don't let the execution value escape the closure.
 /// - Returns: An ``ExecutionResult`` that contains the closure's return value and
-///   the termination status of the child process.
+///   the termination status of the subprocess.
 public func run<
     Result: ~Copyable,
     Input: InputProtocol,
@@ -233,7 +233,7 @@ public func run<
 ///     an ``Execution`` value that's valid only for the duration of the call.
 ///     Don't let the execution value escape the closure.
 /// - Returns: An ``ExecutionResult`` that contains the closure's return value and
-///   the termination status of the child process.
+///   the termination status of the subprocess.
 public func run<
     Result: ~Copyable,
     Input: InputProtocol,

--- a/Sources/Subprocess/Buffer.swift
+++ b/Sources/Subprocess/Buffer.swift
@@ -63,7 +63,7 @@ extension SubprocessOutputSequence.Buffer {
         }
     }
 
-    // Access the storage backing this Buffer
+    /// A read-only span over the buffer's underlying bytes.
     public var bytes: RawSpan {
         return self.data._bytes
     }

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -223,7 +223,7 @@ extension Configuration: CustomStringConvertible, CustomDebugStringConvertible {
 
 // MARK: - Cleanup
 extension Configuration {
-    /// Close each input individually, and throw the first error if there's multiple errors thrown
+    /// Close each input individually, and throw the first error if there are multiple errors thrown
     @Sendable
     internal func safelyCloseMultiple(
         inputRead: consuming IODescriptor?,
@@ -328,11 +328,13 @@ public struct Executable: Sendable, Hashable {
     }
 
     /// Locates the executable by name.
+    ///
     /// The subprocess uses the `PATH` value to determine the full path.
     public static func name(_ executableName: String) -> Self {
         return .init(_config: .executable(executableName))
     }
     /// Locates the executable by its full file path.
+    ///
     /// The subprocess uses this path directly.
     public static func path(_ filePath: FilePath) -> Self {
         return .init(_config: .path(filePath))
@@ -389,8 +391,8 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
         self.executablePathOverride = nil
     }
 
-    /// Creates an ``Arguments`` value using the given values, but
-    /// override the first argument value with `executablePathOverride`.
+    /// Creates an argument list, overriding the first element with the given executable path value.
+    ///
     /// If `executablePathOverride` is `nil`,
     /// ``Arguments`` automatically uses the executable path
     /// as the first argument.
@@ -406,8 +408,8 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
         }
     }
     #if !os(Windows) // Windows does not support non-unicode arguments
-    /// Creates an ``Arguments`` value using the given values, but
-    /// override the first argument value with `executablePathOverride`.
+    /// Creates an argument list, overriding the first element with the given executable path value.
+    ///
     /// If `executablePathOverride` is `nil`,
     /// ``Arguments`` automatically uses the executable path
     /// as the first argument.
@@ -466,7 +468,7 @@ public struct Environment: Sendable, Hashable {
     public static var inherit: Self {
         return .init(config: .inherit([:]))
     }
-    /// Returns an updated environment that applies `newValue` to the current configuration.
+    /// Returns an updated environment with the given overrides applied.
     ///
     /// Keys with `nil` values in `newValue` remove the corresponding entry
     /// from the environment before passing it to the child process.
@@ -512,7 +514,7 @@ public struct Environment: Sendable, Hashable {
 }
 
 extension Environment: CustomStringConvertible, CustomDebugStringConvertible {
-    /// A key used to access values in an ``Environment``.
+    /// A key used to access values in the subprocess environment.
     ///
     /// This type respects the compiled platform's case sensitivity requirements.
     public struct Key {
@@ -721,10 +723,11 @@ extension TerminationStatus: CustomStringConvertible, CustomDebugStringConvertib
 // MARK: - Internal
 
 extension Configuration {
-    /// After Spawn finishes, child side file descriptors
-    /// (input read, output write, error write) will be closed
-    /// by `spawn()`. It returns the parent side file descriptors
-    /// via `SpawnResult` to perform actual reads
+    /// The result of spawning a child process, containing parent-side file descriptors.
+    ///
+    /// After `spawn()` finishes, it closes child-side file descriptors
+    /// (input read, output write, error write). The parent-side file descriptors
+    /// are returned in this value to perform actual reads.
     internal struct SpawnResult: ~Copyable {
         let processIdentifier: ProcessIdentifier
         var _inputWriteEnd: IODescriptor?
@@ -760,8 +763,9 @@ extension Configuration {
     /// The maximum number of `fork`/`exec` attempts, including the first one,
     /// before a transient, retryable spawn failure is surfaced to the caller.
     private static let maxSpawnAttempts = 6
-    /// The base spawn-retry backoff in nanoseconds. The delay doubles each
-    /// attempt up to ``spawnRetryBackoffCapNanoseconds``, with jitter applied.
+    /// The base spawn-retry backoff in nanoseconds.
+    ///
+    /// The delay doubles each attempt up to ``spawnRetryBackoffCapNanoseconds``, with jitter applied.
     private static let spawnRetryBackoffBaseNanoseconds: UInt64 = 1_000_000
     /// The maximum spawn-retry backoff in nanoseconds.
     private static let spawnRetryBackoffCapNanoseconds: UInt64 = 100_000_000
@@ -780,9 +784,9 @@ extension Configuration {
         return half + UInt64.random(in: 0...half)
     }
 
-    /// Runs `attempt`, retrying while `shouldRetryTransientFailure` returns
-    /// `true`, up to ``maxSpawnAttempts``, with bounded jittered backoff
-    /// between attempts.
+    /// Repeatedly invokes a closure with bounded jittered backoff until it succeeds or reaches the retry limit.
+    ///
+    /// Calls `attempt` repeatedly while `shouldRetryTransientFailure` returns `true`, up to ``maxSpawnAttempts`` times.
     ///
     /// `EAGAIN` from `clone3`/`fork`/`posix_spawn` means the kernel could not
     /// create the task because a per-uid or system task-count limit was
@@ -896,7 +900,7 @@ internal func _safelyClose(_ target: _CloseTarget) throws(SubprocessError) {
     #if os(Windows)
     case .handle(let handle):
         /// Windows does not provide a “deregistration” API (the reverse of
-        /// `CreateIoCompletionPort`) for handles and it reuses HANDLE
+        /// `CreateIoCompletionPort`) for handles, and it reuses HANDLE
         /// values once they are closed. Since we rely on the handle value
         /// as the completion key for `CreateIoCompletionPort`, we should
         /// remove the registration when the handle is closed to allow
@@ -957,7 +961,7 @@ internal func _safelyClose(_ target: _CloseTarget) throws(SubprocessError) {
     }
 }
 
-/// An IO descriptor wraps platform-specific file descriptor, which establishes a
+/// An IO descriptor wraps a platform-specific file descriptor, which establishes a
 /// connection to the standard input/output (IO) system during the process of
 /// spawning a child process.
 ///
@@ -1064,11 +1068,13 @@ internal enum PipeNameCounter {
 
 internal struct CreatedPipe: ~Copyable, Sendable {
     internal enum Purpose: CustomStringConvertible {
-        /// This pipe is used for standard input. This option maps to
-        /// `PIPE_ACCESS_OUTBOUND` on Windows where child only reads,
+        /// This pipe is used for standard input.
+        ///
+        /// This option maps to `PIPE_ACCESS_OUTBOUND` on Windows where child only reads,
         /// parent only writes.
         case input
         /// This pipe is used for standard output and standard error.
+        ///
         /// This option maps to `PIPE_ACCESS_INBOUND` on Windows where
         /// child only writes, parent only reads.
         case output
@@ -1117,7 +1123,7 @@ internal struct CreatedPipe: ~Copyable, Sendable {
         /// > not supported by anonymous pipes.
         /// See https://learn.microsoft.com/en-us/windows/win32/ipc/anonymous-pipe-operations
         while true {
-            /// Windows named pipes are system wide. To avoid creating two pipes with the same
+            /// Windows named pipes are system-wide. To avoid creating two pipes with the same
             /// name, create the pipe with `FILE_FLAG_FIRST_PIPE_INSTANCE` such that it will
             /// return error `ERROR_ACCESS_DENIED` if we try to create another pipe with the same name.
             let pipeName = "\\\\.\\pipe\\LOCAL\\subprocess-\(GetCurrentProcessId())-\(purpose)-\(PipeNameCounter.nextValue())"
@@ -1261,7 +1267,7 @@ extension Optional where Wrapped == String {
     }
 }
 
-/// Runs the body close, then runs the on-cleanup closure if the body closure throws an error
+/// Runs the body closure, then runs the on-cleanup closure if the body closure throws an error
 /// or if the parent task is cancelled.
 ///
 /// In the latter case, `onCleanup` may be run concurrently with `body`.
@@ -1401,9 +1407,11 @@ extension HANDLE {
 }
 #endif
 
+/// Bridges untyped throws to typed subprocess errors.
+///
 /// Many standard library functions such as `withCheckedThrowingContinuation`
-/// does not support typed throw yet. This method casts `any Error` thrown by
-/// those methods back to `SubprocessError`
+/// do not support typed throws yet. This method casts `any Error` thrown by
+/// those methods back to `SubprocessError`.
 internal func _castError<Success: Sendable>(
     _ body: () async throws -> Success,
 ) async throws(SubprocessError) -> Success {

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -28,7 +28,7 @@ import Musl
 #endif
 
 /// A collection of configuration parameters to use when
-/// spawning a subprocess.
+/// running a subprocess.
 public struct Configuration: Sendable {
     /// The executable to run.
     public var executable: Executable
@@ -39,7 +39,7 @@ public struct Configuration: Sendable {
     /// The working directory to use when running the executable.
     ///
     /// If this property is `nil`, the subprocess inherits the working
-    /// directory from the parent process.
+    /// directory from the calling process.
     public var workingDirectory: FilePath?
     /// The platform-specific options to use when
     /// running the subprocess.
@@ -471,7 +471,7 @@ public struct Environment: Sendable, Hashable {
     /// Returns an updated environment with the given overrides applied.
     ///
     /// Keys with `nil` values in `newValue` remove the corresponding entry
-    /// from the environment before passing it to the child process.
+    /// from the environment before passing it to the subprocess.
     public func updating(_ newValue: [Key: String?]) -> Self {
         switch config {
         case .inherit(var overrides):
@@ -723,10 +723,10 @@ extension TerminationStatus: CustomStringConvertible, CustomDebugStringConvertib
 // MARK: - Internal
 
 extension Configuration {
-    /// The result of spawning a child process, containing parent-side file descriptors.
+    /// The result of launching a subprocess, containing caller-side file descriptors.
     ///
-    /// After `spawn()` finishes, it closes child-side file descriptors
-    /// (input read, output write, error write). The parent-side file descriptors
+    /// After `spawn()` finishes, it closes subprocess-side file descriptors
+    /// (input read, output write, error write). The caller-side file descriptors
     /// are returned in this value to perform actual reads.
     internal struct SpawnResult: ~Copyable {
         let processIdentifier: ProcessIdentifier
@@ -963,11 +963,11 @@ internal func _safelyClose(_ target: _CloseTarget) throws(SubprocessError) {
 
 /// An IO descriptor wraps a platform-specific file descriptor, which establishes a
 /// connection to the standard input/output (IO) system during the process of
-/// spawning a child process.
+/// launching a subprocess.
 ///
 /// Unlike a file descriptor, the `IODescriptor` does not support
-/// data read/write operations; its primary function is to facilitate the spawning of
-/// child processes by providing a platform-specific file descriptor.
+/// data read/write operations; its primary function is to facilitate the launching of
+/// subprocesses by providing a platform-specific file descriptor.
 internal struct IODescriptor: ~Copyable {
     #if canImport(WinSDK)
     typealias Descriptor = HANDLE
@@ -1070,13 +1070,13 @@ internal struct CreatedPipe: ~Copyable, Sendable {
     internal enum Purpose: CustomStringConvertible {
         /// This pipe is used for standard input.
         ///
-        /// This option maps to `PIPE_ACCESS_OUTBOUND` on Windows where child only reads,
-        /// parent only writes.
+        /// This option maps to `PIPE_ACCESS_OUTBOUND` on Windows where the subprocess only reads,
+        /// the caller only writes.
         case input
         /// This pipe is used for standard output and standard error.
         ///
         /// This option maps to `PIPE_ACCESS_INBOUND` on Windows where
-        /// child only writes, parent only reads.
+        /// the subprocess only writes, the caller only reads.
         case output
 
         var description: String {
@@ -1268,7 +1268,7 @@ extension Optional where Wrapped == String {
 }
 
 /// Runs the body closure, then runs the on-cleanup closure if the body closure throws an error
-/// or if the parent task is cancelled.
+/// or if the calling task is cancelled.
 ///
 /// In the latter case, `onCleanup` may be run concurrently with `body`.
 /// The `body` closure is guaranteed to run exactly once.

--- a/Sources/Subprocess/Documentation.docc/Subprocess.md
+++ b/Sources/Subprocess/Documentation.docc/Subprocess.md
@@ -1,11 +1,11 @@
 # ``Subprocess``
 
-Subprocess is a cross-platform Swift package for spawning child processes, 
+Subprocess is a cross-platform Swift package for launching subprocesses, 
 built from the ground up with Swift concurrency.
 
 ## Overview
 
-Subprocess centers on a family of `run` functions. Each spawns an executable, 
+Subprocess centers on a set of `run` functions. Each launches an executable, 
 waits for it to terminate, and returns an ``ExecutionResult`` carrying the 
 process identifier, the ``TerminationStatus``, and whatever output you asked it 
 to collect. The simplest form runs a command and collects its standard output:
@@ -45,7 +45,7 @@ sequence of buffers you can iterate directly or read line by line. The
 are valid only for the duration of the body closure; don't let them escape it.
 
 If the task running a subprocess is canceled, Subprocess can run a configurable 
-teardown sequence (for example, a graceful shutdown followed by a forced kill) 
+teardown sequence (for example, a graceful shutdown followed by a forced termination) 
 before the call returns. You describe that sequence with ``TeardownStep`` values, 
 and you can trigger one yourself from the body closure.
 
@@ -64,30 +64,17 @@ dependency.
 - ``run(_:arguments:environment:workingDirectory:platformOptions:input:output:error:)-(_,_,_,_,_,Input,_,_)``
 - ``run(_:arguments:environment:workingDirectory:platformOptions:input:output:error:)-(_,_,_,_,_,Span<InputElement>,_,_)``
 - ``run(_:arguments:environment:workingDirectory:platformOptions:input:output:error:body:)``
-- ``run(_:input:output:error:)-(_,Input,_,_)``
-- ``run(_:input:output:error:)-(_,Span<InputElement>,_,_)``
-- ``run(_:input:output:error:body:)``
-
-### Configuring a Subprocess
-
-- ``Configuration``
 - ``Executable``
 - ``Arguments``
 - ``Environment``
 - ``PlatformOptions``
 
-### Providing Input
+### Configuring and running a Subprocess
 
-- ``InputProtocol``
-- ``NoInput``
-- ``StringInput``
-- ``ArrayInput``
-- ``FileDescriptorInput``
-- ``CustomWriteInput``
-- ``StandardInputWriter``
-- ``DataInput``
-- ``DataSequenceInput``
-- ``DataAsyncSequenceInput``
+- ``run(_:input:output:error:)-(_,Input,_,_)``
+- ``run(_:input:output:error:)-(_,Span<InputElement>,_,_)``
+- ``run(_:input:output:error:body:)``
+- ``Configuration``
 
 ### Collecting Output
 
@@ -107,6 +94,19 @@ dependency.
 
 - ``ErrorOutputProtocol``
 - ``CombinedErrorOutput``
+
+### Providing Input
+
+- ``InputProtocol``
+- ``NoInput``
+- ``StringInput``
+- ``ArrayInput``
+- ``FileDescriptorInput``
+- ``CustomWriteInput``
+- ``StandardInputWriter``
+- ``DataInput``
+- ``DataSequenceInput``
+- ``DataAsyncSequenceInput``
 
 ### Interacting with a Running Subprocess
 

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -45,7 +45,7 @@ public struct SubprocessError: Swift.Error, Sendable, Hashable {
     /// The underlying error that caused this error.
     public let underlyingError: UnderlyingError?
 
-    /// Context associated with this error for better error message
+    /// Context associated with this error for better error messages.
     private let context: [Code: Context]
 }
 
@@ -81,9 +81,9 @@ extension SubprocessError {
 extension SubprocessError.Code {
     /// The subprocess failed to spawn.
     public static var spawnFailed: Self { .init(.spawnFailed) }
-    /// The target executable isn't found.
+    /// The subprocess failed to find or execute the target executable.
     public static var executableNotFound: Self { .init(.executableNotFound) }
-    /// The working directory isn't valid, or the subprocess failed to change the working directory.
+    /// The subprocess failed to change the working directory because it is invalid or inaccessible.
     public static var failedToChangeWorkingDirectory: Self { .init(.failedToChangeWorkingDirectory) }
     /// The subprocess failed to monitor the child process's exit status.
     public static var failedToMonitorProcess: Self { .init(.failedToMonitorProcess) }
@@ -375,10 +375,11 @@ extension SubprocessError {
         )
     }
 
-    /// The standard input writer was used after it finished. The writer is only
-    /// valid inside the `run(_:)` body closure; `run()` closes standard input
-    /// automatically when the body returns, so it must not be stored or used
-    /// afterward.
+    /// The standard input writer was used after it finished.
+    ///
+    /// The writer is only valid inside the `run(_:)` body closure; `run()` closes
+    /// standard input automatically when the body returns, so it must not be stored
+    /// or used afterward.
     internal static var standardInputWriterFinished: Self {
         return .failedToWriteToProcess(
             withUnderlyingError: nil,

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -103,6 +103,7 @@ extension SubprocessError.Code {
 
 // MARK: - Underlying types
 extension SubprocessError {
+    /// The platform-specific error type for low-level subprocess failures.
     #if os(Windows)
     public typealias UnderlyingError = WindowsError
     #else

--- a/Sources/Subprocess/Error.swift
+++ b/Sources/Subprocess/Error.swift
@@ -79,25 +79,25 @@ extension SubprocessError {
 }
 
 extension SubprocessError.Code {
-    /// The subprocess failed to spawn.
+    /// The process failed to launch.
     public static var spawnFailed: Self { .init(.spawnFailed) }
-    /// The subprocess failed to find or execute the target executable.
+    /// The executable couldn't be found or run.
     public static var executableNotFound: Self { .init(.executableNotFound) }
-    /// The subprocess failed to change the working directory because it is invalid or inaccessible.
+    /// The working directory couldn't be set because it's invalid or inaccessible.
     public static var failedToChangeWorkingDirectory: Self { .init(.failedToChangeWorkingDirectory) }
-    /// The subprocess failed to monitor the child process's exit status.
+    /// Subprocess couldn't monitor the process's exit status.
     public static var failedToMonitorProcess: Self { .init(.failedToMonitorProcess) }
 
-    /// The subprocess failed to read data from the child process.
+    /// Subprocess couldn't read the process's output.
     public static var failedToReadFromSubprocess: Self { .init(.failedToReadFromSubprocess) }
-    /// The subprocess failed to write data to the child process.
+    /// Subprocess couldn't write to the process's standard input.
     public static var failedToWriteToSubprocess: Self { .init(.failedToWriteToSubprocess) }
-    /// The child process output exceeded the configured limit.
+    /// The process produced more output than the configured limit allows.
     public static var outputLimitExceeded: Self { .init(.outputLimitExceeded) }
     /// A platform-specific asynchronous I/O operation failed.
     public static var asyncIOFailed: Self { .init(.asyncIOFailed) }
 
-    /// The subprocess failed to control the child process, such as sending a signal or terminating.
+    /// Subprocess couldn't control the process, for example by sending a signal or terminating it.
     public static var processControlFailed: Self { .init(.processControlFailed) }
 }
 
@@ -130,7 +130,7 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
     public var description: String {
         switch self.code.storage {
         case .spawnFailed:
-            var message = ["Failed to spawn the new process."]
+            var message = ["Failed to launch the new process."]
 
             if let context = self.context[self.code],
                 case .string(let reason) = context
@@ -161,38 +161,38 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
             }
         case .failedToMonitorProcess:
             if let underlying = self.underlyingError {
-                return "Failed to monitor the child process exit status with underlying error: \(underlying)"
+                return "Failed to monitor the process's exit status with underlying error: \(underlying)"
             } else {
-                return "Failed to monitor the child process exit status."
+                return "Failed to monitor the process's exit status."
             }
 
         case .failedToReadFromSubprocess:
             if let underlying = self.underlyingError {
-                return "Failed to read bytes from the child process with underlying error: \(underlying)"
+                return "Failed to read bytes from the process with underlying error: \(underlying)"
             } else {
-                return "Failed to read bytes from the child process."
+                return "Failed to read bytes from the process."
             }
         case .failedToWriteToSubprocess:
             if let context = self.context[self.code],
                 case .string(let reason) = context
             {
                 if let underlying = self.underlyingError {
-                    return "Failed to write bytes to the child process: \(reason) Underlying error: \(underlying)"
+                    return "Failed to write bytes to the process: \(reason) Underlying error: \(underlying)"
                 }
-                return "Failed to write bytes to the child process: \(reason)"
+                return "Failed to write bytes to the process: \(reason)"
             }
             if let underlying = self.underlyingError {
-                return "Failed to write bytes to the child process with underlying error: \(underlying)"
+                return "Failed to write bytes to the process with underlying error: \(underlying)"
             } else {
-                return "Failed to write bytes to the child process."
+                return "Failed to write bytes to the process."
             }
         case .outputLimitExceeded:
             if let context = self.context[self.code],
                 case .int(let limit) = context
             {
-                return "Child process output exceeded the limit of \(limit) bytes."
+                return "The process's output exceeded the limit of \(limit) bytes."
             } else {
-                return "Child process output exceeded the limit."
+                return "The process's output exceeded the limit."
             }
         case .asyncIOFailed:
             let context = self.context[self.code]
@@ -213,16 +213,16 @@ extension SubprocessError: CustomStringConvertible, CustomDebugStringConvertible
             {
                 switch operation {
                 case .sendSignal(let signal):
-                    return "Failed to send signal \(signal) to child process"
+                    return "Failed to send signal \(signal) to the process."
                 case .terminate:
-                    return "Failed to terminate child process."
+                    return "Failed to terminate the process."
                 case .suspend:
-                    return "Failed to suspend child process."
+                    return "Failed to suspend the process."
                 case .resume:
-                    return "Failed to resume child process."
+                    return "Failed to resume the process."
                 }
             } else {
-                return "Failed to control child process state"
+                return "Failed to control the process state."
             }
         }
     }

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -29,7 +29,7 @@ import Musl
 
 /// A running subprocess.
 ///
-/// Use this type to send signals to the child process, write to its standard
+/// Use this type to send signals to the subprocess, write to its standard
 /// input, and stream its standard output and standard error.
 ///
 /// The three generic parameters determine which streaming properties are

--- a/Sources/Subprocess/IO/AsyncIO+Unix.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Unix.swift
@@ -353,14 +353,18 @@ internal struct Registration {
 
     /// The result of a single attempt to register a file descriptor.
     enum RegisterResult {
-        /// The first time this descriptor was seen. The caller must still
+        /// The first time this descriptor was seen.
+        ///
+        /// The caller must still
         /// attach it to the epoll / kqueue (`epoll_ctl(ADD)` / `kevent(EV_ADD)`).
         case registered
         /// The descriptor was already attached by a previous read or write;
         /// the existing attachment is reused and only the continuation is
         /// replaced, so the caller skips the registration syscall.
         case updated
-        /// The owning process is already cancelled. The caller finishes the
+        /// The owning process is already cancelled.
+        ///
+        /// The caller finishes the
         /// supplied continuation immediately and skips the setup.
         case alreadyCancelled
     }
@@ -391,10 +395,10 @@ internal struct Registration {
     ///     becomes ready or the I/O is cancelled.
     ///   - processIdentifier: The process that owns the descriptor.
     /// - Returns: A ``RegisterResult`` describing what the caller must do next.
-    ///   When the result is ``RegisterResult/registered`` the caller attaches
-    ///   the descriptor to the multiplexer; for ``RegisterResult/updated`` the
+    ///   When the result is ``RegisterResult/registered``, the caller attaches
+    ///   the descriptor to the multiplexer; for ``RegisterResult/updated``, the
     ///   attachment already exists and is reused. For
-    ///   ``RegisterResult/alreadyCancelled`` the caller finishes the supplied
+    ///   ``RegisterResult/alreadyCancelled``, the caller finishes the supplied
     ///   continuation immediately and performs no further setup.
     mutating func register(
         fileDescriptor: PlatformFileDescriptor,
@@ -443,7 +447,7 @@ internal struct Registration {
     /// registrations to abort.
     ///
     /// Once a process is marked cancelled, subsequent calls to `register`
-    /// for that process return `false` until `remove(processIdentifier:)`
+    /// for that process return `.alreadyCancelled` until `remove(processIdentifier:)`
     /// drops the marker.
     ///
     /// - Parameter processIdentifier: The process whose I/O to cancel.
@@ -502,11 +506,14 @@ internal enum RegistrationOutcome {
     /// The descriptor was added successfully.
     case registered
     /// The owning process has already been cancelled, so the registration
-    /// was rejected. The caller finishes the continuation without further
+    /// was rejected.
+    ///
+    /// The caller finishes the continuation without further
     /// setup.
     case alreadyCancelled
-    /// The platform syscall (such as `epoll_ctl` or `kevent`) reported an
-    /// error. The caller finishes the continuation by throwing this error.
+    /// The platform syscall (such as `epoll_ctl` or `kevent`) reported an error.
+    ///
+    /// The caller finishes the continuation by throwing this error.
     case failed(SubprocessError)
 }
 

--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -330,7 +330,7 @@ final class AsyncIO: @unchecked Sendable {
     /// be writing into (use-after-free once that buffer goes out of scope). The
     /// third state, a completed-empty or aborted read, is the one an
     /// unconditional `.finished` handles correctly. The pending case is reached
-    /// when a surviving descendant holds the write end open and the read is
+    /// when a surviving launched process holds the write end open and the read is
     /// parked at cancellation (the same condition as
     /// `drainBufferedDataAfterCancellation()`).
     ///
@@ -404,9 +404,9 @@ final class AsyncIO: @unchecked Sendable {
     /// Reads bytes already buffered in the pipe after the owning process has
     /// been cancelled, without routing through the completion port.
     ///
-    /// Bytes the child already wrote remain in the pipe and must not be
+    /// Bytes the subprocess already wrote remain in the pipe and must not be
     /// dropped, but a fresh read awaited through the monitor could hang: a
-    /// surviving descendant can hold the write end open, so EOF may never
+    /// surviving launched process can hold the write end open, so EOF may never
     /// arrive. `PeekNamedPipe` neither consumes data nor blocks, so it gates
     /// the read; `ReadFile` is issued only when bytes are present, which
     /// then completes promptly.

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -73,7 +73,7 @@ public struct NoInput: InputProtocol {
 /// An input type that reads from a specified file descriptor.
 ///
 /// You can choose to have the subprocess automatically close
-/// the file descriptor after it spawns.
+/// the file descriptor after it launches.
 public struct FileDescriptorInput: InputProtocol {
     private let fileDescriptor: FileDescriptor
     private let closeAfterSpawningProcess: Bool
@@ -175,7 +175,7 @@ extension InputProtocol where Self == FileDescriptorInput {
     /// Creates a subprocess input from a file descriptor.
     ///
     /// Set `closeAfterSpawningProcess` to `true` to close the file
-    /// descriptor after the subprocess spawns.
+    /// descriptor after the subprocess launches.
     public static func fileDescriptor(
         _ fd: FileDescriptor,
         closeAfterSpawningProcess: Bool

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -23,6 +23,7 @@ public import SystemPackage
 
 /// A type that serves as the output target for a subprocess.
 public protocol OutputProtocol: Sendable, ~Copyable {
+    /// The Swift value this output type produces after collecting subprocess output.
     associatedtype OutputType: Sendable
 
     /// Converts the output from a span to the expected output type.

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -38,7 +38,7 @@ extension OutputProtocol {
     public var maxSize: Int { 128 * 1024 }
 }
 
-/// An output type that discards output from the child process.
+/// An output type that discards output from the subprocess.
 ///
 /// On Unix-like systems, ``DiscardedOutput`` redirects standard output
 /// to `/dev/null`. On Windows, it redirects to `NUL`.
@@ -66,7 +66,7 @@ public struct DiscardedOutput: OutputProtocol, ErrorOutputProtocol {
 /// An output type that writes to a specified file descriptor.
 ///
 /// You can choose to have the subprocess automatically close
-/// the file descriptor after it spawns.
+/// the file descriptor after it launches.
 public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
     /// The type for this output.
     public typealias OutputType = Void
@@ -199,7 +199,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
     /// Creates a subprocess output that writes to a file descriptor.
     ///
     /// Set `closeAfterSpawningProcess` to `true` to close the file
-    /// descriptor after the subprocess spawns.
+    /// descriptor after the subprocess launches.
     public static func fileDescriptor(
         _ fd: FileDescriptor,
         closeAfterSpawningProcess: Bool
@@ -243,7 +243,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
 extension OutputProtocol where Self == StringOutput<UTF8> {
     /// Creates a subprocess output that collects output as a UTF-8 string.
     ///
-    /// The subprocess throws an error if the child process
+    /// The subprocess throws an error if the process
     /// produces more bytes than `limit`.
     public static func string(limit: Int) -> Self {
         return .init(limit: limit, encoding: UTF8.self)
@@ -254,7 +254,7 @@ extension OutputProtocol {
     /// Creates a subprocess output that collects output as
     /// a string using the given encoding, up to `limit` bytes.
     ///
-    /// The subprocess throws an error if the child process
+    /// The subprocess throws an error if the process
     /// produces more bytes than `limit`.
     public static func string<Encoding: Unicode.Encoding>(
         limit: Int,
@@ -268,7 +268,7 @@ extension OutputProtocol where Self == BytesOutput {
     /// Creates a subprocess output that collects output as bytes,
     /// up to `limit` bytes.
     ///
-    /// The subprocess throws an error if the child process
+    /// The subprocess throws an error if the process
     /// produces more bytes than `limit`.
     public static func bytes(limit: Int) -> Self {
         return .init(limit: limit)
@@ -296,7 +296,7 @@ public protocol ErrorOutputProtocol: OutputProtocol {}
 /// output with the standard output stream.
 ///
 /// When `CombinedErrorOutput` is used as the error output for a subprocess, both
-/// standard output and standard error from the child process are merged into a
+/// standard output and standard error from the subprocess are merged into a
 /// single output stream. This is equivalent to using shell redirection like `2>&1`.
 ///
 /// This output type is useful when you want to capture or redirect both output
@@ -322,7 +322,7 @@ extension ErrorOutputProtocol where Self == CombinedErrorOutput {
     /// Creates an error output that combines standard error with standard output.
     ///
     /// When using `combinedWithOutput`, both standard output and standard error from
-    /// the child process are merged into a single output stream. This is equivalent
+    /// the subprocess are merged into a single output stream. This is equivalent
     /// to using shell redirection like `2>&1`.
     ///
     /// This is useful when you want to capture or redirect both output streams

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -97,7 +97,7 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
     }
 }
 
-/// An output type that collects the subprocess's output as a `String` with the given encoding.
+/// An output type that collects the subprocess's output as decoded text using the given encoding.
 public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOutputProtocol {
     /// The type for this output.
     public typealias OutputType = String?
@@ -117,7 +117,7 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
     }
 }
 
-/// An output type that collects the subprocess's output as a `[UInt8]` array.
+/// An output type that collects the subprocess's output as a byte array.
 public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
     /// The output type for this output option.
     public typealias OutputType = [UInt8]
@@ -165,7 +165,7 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
         return result
     }
 
-    /// Creates an array from a `RawSpan`.
+    /// Creates a byte array from a contiguous region of raw memory.
     public func output(from span: RawSpan) throws -> [UInt8] {
         span.withUnsafeBytes { Array($0) }
     }
@@ -208,7 +208,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
 
     /// Creates a subprocess output that writes to the current process's standard output.
     ///
-    /// The file descriptor isn't closed afterwards.
+    /// The file descriptor isn't closed afterward.
     public static var currentStandardOutput: Self {
         return Self.fileDescriptor(
             .standardOutput,
@@ -224,7 +224,7 @@ extension OutputProtocol where Self == FileDescriptorOutput {
 
     /// Creates a subprocess output that writes to the current process's standard error.
     ///
-    /// The file descriptor isn't closed afterwards.
+    /// The file descriptor isn't closed afterward.
     public static var currentStandardError: Self {
         return Self.fileDescriptor(
             .standardError,
@@ -275,8 +275,7 @@ extension OutputProtocol where Self == BytesOutput {
 }
 
 extension OutputProtocol where Self == SequenceOutput {
-    /// Creates a subprocess output that the body closure reads from
-    /// ``Execution/standardOutput`` or ``Execution/standardError``.
+    /// Creates a subprocess output that a body closure reads as an asynchronous sequence of buffers.
     ///
     /// Use this output with a `run` overload that takes a body closure.
     public static var sequence: Self {
@@ -327,7 +326,7 @@ extension ErrorOutputProtocol where Self == CombinedErrorOutput {
     ///
     /// This is useful when you want to capture or redirect both output streams
     /// together, making it possible to process all subprocess output as a unified
-    /// stream rather than handling standard output and standard error separately
+    /// stream rather than handling standard output and standard error separately.
     ///
     /// - Returns: A `CombinedErrorOutput` instance that merges standard error
     ///   with standard output.

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -41,20 +41,17 @@ public struct PlatformOptions: Sendable {
     public var qualityOfService: QualityOfService = .default
     /// The user ID for the subprocess.
     public var userID: uid_t? = nil
-    /// The real and effective group ID and the saved
-    /// set-group-ID of the subprocess, equivalent to calling
-    /// `setgid()` on the child process.
+    /// The real, effective, and saved set-group-ID for the subprocess.
     ///
-    /// The group ID controls permissions, particularly
-    /// for file access.
+    /// Setting this value is equivalent to calling `setgid()` on the child process.
+    /// The group ID controls permissions, particularly for file access.
     public var groupID: gid_t? = nil
     /// The list of supplementary group IDs for the subprocess.
     public var supplementaryGroups: [gid_t]? = nil
-    /// The process group for the subprocess, equivalent to
-    /// calling `setpgid()` on the child process.
+    /// The process group for the subprocess.
     ///
-    /// The process group ID groups related processes for
-    /// controlling signals.
+    /// Equivalent to calling `setpgid()` on the child process.
+    /// The process group ID groups related processes for controlling signals.
     public var processGroupID: pid_t? = nil
     /// A Boolean value that indicates whether to create a session
     /// and detach from the terminal.
@@ -102,24 +99,30 @@ extension PlatformOptions {
     /// there’s resource contention.
     public enum QualityOfService: Int, Sendable {
         /// Work directly involved in providing an
-        /// interactive UI. For example, processing control
+        /// interactive UI.
+        ///
+        /// For example, processing control
         /// events or drawing to the screen.
         case userInteractive = 0x21
         /// Work that the user explicitly requested and for which results
         /// must be immediately presented to allow for further user interaction.
+        ///
         /// For example, loading an email after a user selects
         /// it in a message list.
         case userInitiated = 0x19
         /// Work whose results the user is unlikely to be
-        /// immediately waiting for. This work may have been
+        /// immediately waiting for.
+        ///
+        /// This work may have been
         /// requested by the user or initiated automatically, and often
         /// operates at user-visible timescales using a non-modal
         /// progress indicator. For example, periodic content updates
         /// or bulk file operations, such as media import.
         case utility = 0x11
         /// Work that isn’t user-initiated or visible.
+        ///
         /// In general, the user is unaware that this work is even happening.
-        /// For example, pre-fetching content, search indexing, backups,
+        /// For example, prefetching content, search indexing, backups,
         /// or syncing of data with external systems.
         case background = 0x09
         /// No explicit quality-of-service information.
@@ -493,9 +496,9 @@ extension Configuration {
         }
     }
 
-    /// Invokes `_subprocess_spawn` on the shared background worker thread,
-    /// retrying a transient fork-side `EAGAIN` with bounded, jittered backoff.
+    /// Spawns a child process on the background worker thread, retrying transient failures with bounded jittered backoff.
     ///
+    /// Calls `_subprocess_spawn()` on the shared background worker thread.
     /// `posix_spawn` is used directly only when no pre-fork setup is required;
     /// in that path an `EAGAIN` is the internal fork failing with no child
     /// created; this is the clean, retryable case, and the existing error

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -43,36 +43,36 @@ public struct PlatformOptions: Sendable {
     public var userID: uid_t? = nil
     /// The real, effective, and saved set-group-ID for the subprocess.
     ///
-    /// Setting this value is equivalent to calling `setgid()` on the child process.
+    /// Setting this value is equivalent to calling `setgid()` on the subprocess.
     /// The group ID controls permissions, particularly for file access.
     public var groupID: gid_t? = nil
     /// The list of supplementary group IDs for the subprocess.
     public var supplementaryGroups: [gid_t]? = nil
     /// The process group for the subprocess.
     ///
-    /// This is equivalent to calling `setpgid()` on the child process.
+    /// This is equivalent to calling `setpgid()` on the subprocess.
     /// The process group ID groups related processes for controlling signals.
     public var processGroupID: pid_t? = nil
     /// A Boolean value that indicates whether to create a session
     /// and detach from the terminal.
     public var createSession: Bool = false
-    /// An ordered list of steps to tear down the child
-    /// process if the parent task is canceled before
-    /// the child process terminates.
+    /// An ordered list of steps to tear down the subprocess
+    /// if the calling task is canceled before
+    /// the subprocess terminates.
     ///
     /// The sequence always ends by sending a `.kill` signal.
     public var teardownSequence: [TeardownStep] = []
     /// A closure that configures platform-specific
-    /// spawning constructs.
+    /// process-launching constructs.
     ///
     /// Use this closure to directly configure or override
-    /// the underlying platform-specific spawn settings that the
+    /// the underlying platform-specific launch settings that the
     /// library uses internally, when higher-level APIs aren't
     /// available for such modifications.
     ///
     /// On Darwin, Subprocess uses `posix_spawn()` as the
-    /// underlying spawning mechanism. This closure allows
-    /// modification of the `posix_spawnattr_t` spawn attribute
+    /// underlying process-launching mechanism. This closure allows
+    /// modification of the `posix_spawnattr_t` attribute
     /// and file actions `posix_spawn_file_actions_t` before
     /// they are sent to `posix_spawn()`.
     public var preSpawnProcessConfigurator:
@@ -496,7 +496,7 @@ extension Configuration {
         }
     }
 
-    /// Spawns a child process on the background worker thread, retrying transient failures with bounded jittered backoff.
+    /// Spawns a subprocess on the background worker thread, retrying transient failures with bounded jittered backoff.
     ///
     /// Calls `_subprocess_spawn()` on the shared background worker thread.
     /// `posix_spawn` is used directly only when no pre-fork setup is required;

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -50,7 +50,7 @@ public struct PlatformOptions: Sendable {
     public var supplementaryGroups: [gid_t]? = nil
     /// The process group for the subprocess.
     ///
-    /// Equivalent to calling `setpgid()` on the child process.
+    /// This is equivalent to calling `setpgid()` on the child process.
     /// The process group ID groups related processes for controlling signals.
     public var processGroupID: pid_t? = nil
     /// A Boolean value that indicates whether to create a session

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -212,9 +212,9 @@ private func shutdown() {
     pthread_join(storage.monitorThread, nil)
 }
 
-/// See the following page for the complete list of `async-signal-safe` functions
+/// See the following page for the complete list of async-signal-safe functions:
 /// https://man7.org/linux/man-pages/man7/signal-safety.7.html
-/// Only these functions can be used in the signal handler below
+/// Only these functions can be used in the signal handler below.
 private func signalHandler(_ signalNumber: CInt) {
     let savedErrno = errno
     var one: UInt8 = 1
@@ -563,7 +563,7 @@ private func _notifyAllKnownChildProcesses(_ signalFd: CInt, context: MonitorThr
 
 internal func _isWaitprocessDescriptorSupported() -> Bool {
     // waitid(P_PIDFD) is only supported on Linux kernel 5.4 and above
-    // Prob whether the current system supports it by calling it with self pidfd
+    // Probe whether the current system supports it by calling it with self pidfd
     // and checking for EINVAL (waitid sets errno to EINVAL if it does not
     // recognize the id type).
     var siginfo = siginfo_t()

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -67,7 +67,7 @@ public struct Signal: Hashable, Sendable {
     /// `.suspend` signal.
     public static var resume: Self { .init(rawValue: SIGCONT) }
     /// The `.kill` signal is sent to a process to cause it to
-    /// terminate immediately (kill).
+    /// terminate immediately.
     ///
     /// In contrast to `.terminate`
     /// and `.interrupt`, this signal cannot be caught or ignored,
@@ -100,7 +100,7 @@ public struct Signal: Hashable, Sendable {
 }
 
 extension Execution {
-    /// Sends the given signal to the child process.
+    /// Sends the given signal to the subprocess.
     /// - Parameters:
     ///   - signal: The signal to send.
     ///   - shouldSendToProcessGroup: A Boolean value that indicates whether this signal should be sent to
@@ -607,7 +607,7 @@ extension Configuration {
         }
     }
 
-    /// Spawns a child process on the background worker thread, retrying transient failures with bounded jittered backoff.
+    /// Spawns a subprocess on the background worker thread, retrying transient failures with bounded jittered backoff.
     ///
     /// Calls `_subprocess_fork_exec()` on the shared background worker thread.
     ///
@@ -713,22 +713,22 @@ public struct PlatformOptions: Sendable {
     public var userID: uid_t? = nil
     /// The real, effective, and saved set-group-ID for the subprocess.
     ///
-    /// Setting this value is equivalent to calling `setgid()` on the child process.
+    /// Setting this value is equivalent to calling `setgid()` on the subprocess.
     /// The group ID controls permissions, particularly for file access.
     public var groupID: gid_t? = nil
     /// The list of supplementary group IDs for the subprocess.
     public var supplementaryGroups: [gid_t]? = nil
     /// The process group for the subprocess.
     ///
-    /// Equivalent to calling `setpgid()` on the child process.
+    /// Equivalent to calling `setpgid()` on the subprocess.
     /// The process group ID groups related processes for controlling signals.
     public var processGroupID: pid_t? = nil
     /// A Boolean value that indicates whether to create a session
     /// and detach from the terminal.
     public var createSession: Bool = false
-    /// An ordered list of steps to tear down the child
-    /// process if the parent task is canceled before
-    /// the child process terminates.
+    /// An ordered list of steps to tear down the subprocess
+    /// if the calling task is canceled before
+    /// the subprocess terminates.
     ///
     /// The sequence always ends by sending a `.kill` signal.
     public var teardownSequence: [TeardownStep] = []

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -51,9 +51,11 @@ public struct Signal: Hashable, Sendable {
     /// the process.
     public static var interrupt: Self { .init(rawValue: SIGINT) }
     /// The `.terminate` signal is sent to a process to request its
-    /// termination. Unlike the `.kill` signal, it can be caught
+    /// termination.
+    ///
+    /// Unlike the `.kill` signal, it can be caught
     /// and interpreted or ignored by the process. This allows
-    /// the process to perform nice termination releasing resources
+    /// the process to perform graceful termination releasing resources
     /// and saving state if appropriate. `.interrupt` is nearly
     /// identical to `.terminate`.
     public static var terminate: Self { .init(rawValue: SIGTERM) }
@@ -65,13 +67,17 @@ public struct Signal: Hashable, Sendable {
     /// `.suspend` signal.
     public static var resume: Self { .init(rawValue: SIGCONT) }
     /// The `.kill` signal is sent to a process to cause it to
-    /// terminate immediately (kill). In contrast to `.terminate`
+    /// terminate immediately (kill).
+    ///
+    /// In contrast to `.terminate`
     /// and `.interrupt`, this signal cannot be caught or ignored,
     /// and the receiving process cannot perform any
     /// clean-up upon receiving this signal.
     public static var kill: Self { .init(rawValue: SIGKILL) }
     /// The `.terminalClosed` signal is sent to a process when
-    /// its controlling terminal is closed. In modern systems,
+    /// its controlling terminal is closed.
+    ///
+    /// In modern systems,
     /// this signal usually means that the controlling pseudo
     /// or virtual terminal has been closed.
     public static var terminalClosed: Self { .init(rawValue: SIGHUP) }
@@ -97,7 +103,7 @@ extension Execution {
     /// Sends the given signal to the child process.
     /// - Parameters:
     ///   - signal: The signal to send.
-    ///   - shouldSendToProcessGroup: Whether this signal should be sent to
+    ///   - shouldSendToProcessGroup: A Boolean value that indicates whether this signal should be sent to
     ///     the entire process group.
     /// - Throws: ``SubprocessError`` with error code ``SubprocessError/Code/processControlFailed``.
     ///     See ``SubprocessError/underlyingError`` for more details.
@@ -601,8 +607,9 @@ extension Configuration {
         }
     }
 
-    /// Invokes `_subprocess_fork_exec()` on the shared background worker thread,
-    /// retrying a transient fork-side `EAGAIN` with bounded, jittered backoff.
+    /// Spawns a child process on the background worker thread, retrying transient failures with bounded jittered backoff.
+    ///
+    /// Calls `_subprocess_fork_exec()` on the shared background worker thread.
     ///
     /// `EAGAIN` from `clone3()`/`fork()` means the kernel could not create the
     /// task because a per-uid or system task-count limit was momentarily
@@ -704,20 +711,17 @@ extension ProcessIdentifier: CustomStringConvertible, CustomDebugStringConvertib
 public struct PlatformOptions: Sendable {
     /// The user ID for the subprocess.
     public var userID: uid_t? = nil
-    /// The real and effective group ID and the saved
-    /// set-group-ID of the subprocess, equivalent to calling
-    /// `setgid()` on the child process.
+    /// The real, effective, and saved set-group-ID for the subprocess.
     ///
-    /// The group ID controls permissions, particularly
-    /// for file access.
+    /// Setting this value is equivalent to calling `setgid()` on the child process.
+    /// The group ID controls permissions, particularly for file access.
     public var groupID: gid_t? = nil
     /// The list of supplementary group IDs for the subprocess.
     public var supplementaryGroups: [gid_t]? = nil
-    /// The process group for the subprocess, equivalent to
-    /// calling `setpgid()` on the child process.
+    /// The process group for the subprocess.
     ///
-    /// The process group ID groups related processes for
-    /// controlling signals.
+    /// Equivalent to calling `setpgid()` on the child process.
+    /// The process group ID groups related processes for controlling signals.
     public var processGroupID: pid_t? = nil
     /// A Boolean value that indicates whether to create a session
     /// and detach from the terminal.
@@ -776,21 +780,27 @@ internal func reapProcess(
 }
 
 extension ProcessIdentifier {
-    /// Reaps the zombie for the exited process. This function may block.
+    /// Reaps the zombie for the exited process.
+    ///
+    /// This function may block.
     @available(*, noasync)
     internal func blockingReap() throws(Errno) -> TerminationStatus {
         try _blockingReap(pid: value)
     }
 
-    /// Reaps the zombie for the exited process, or returns `nil` if the process is still running. This function will not block.
+    /// Reaps the zombie for the exited process, or returns `nil` if the process is still running.
+    ///
+    /// This function does not block.
     internal func reap() throws(Errno) -> TerminationStatus? {
         try _reap(pid: value)
     }
 
     /// Checks whether the process has already exited without consuming the
-    /// zombie. Returns `true` if a child has exited (or stopped/continued in a
-    /// way `waitid` reports), `false` if the child is still running. The
-    /// zombie remains available for a subsequent call to ``blockingReap()``.
+    /// zombie.
+    ///
+    /// Returns `true` if a child has exited (or stopped/continued in a
+    /// way `waitid` reports), `false` if the child is still running.
+    /// The zombie remains available for a subsequent call to `blockingReap()`.
     internal func peekIfExited() throws(Errno) -> Bool {
         try _peekIfExited(pid: value)
     }

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -326,7 +326,7 @@ public struct PlatformOptions: Sendable {
         public var domain: String?
     }
 
-    /// `ConsoleBehavior` describes how the console appears
+    /// Describes how the console appears
     /// when spawning a new process.
     public struct ConsoleBehavior: Sendable, Hashable {
         internal enum Storage: Sendable, Hashable {
@@ -346,6 +346,7 @@ public struct PlatformOptions: Sendable {
         public static let createNew: Self = .init(.createNew)
         /// For console processes, the new process does not
         /// inherit its parent's console (the default).
+        ///
         /// The new process can call the `AllocConsole`
         /// function at a later time to create a console.
         public static let detach: Self = .init(.detach)
@@ -353,7 +354,7 @@ public struct PlatformOptions: Sendable {
         public static let inherit: Self = .init(.inherit)
     }
 
-    /// `WindowStyle` describes how the window appears
+    /// Describes how the window appears
     /// when spawning a new process.
     public struct WindowStyle: Sendable, Hashable {
         internal enum Storage: Sendable, Hashable {
@@ -592,7 +593,7 @@ internal func reapProcess(
 // MARK: - Subprocess Control
 
 extension Execution {
-    /// Terminate the current subprocess with the given exit code
+    /// Terminate the current subprocess with the given exit code.
     /// - Parameters:
     ///   - exitCode: The exit code to use for the subprocess.
     ///   - toProcessGroup: When `true`, terminates the subprocess and any
@@ -621,7 +622,7 @@ extension Execution {
         }
     }
 
-    /// Suspend the current subprocess
+    /// Suspend the current subprocess.
     public func suspend() throws(SubprocessError) {
         let NTSuspendProcess: (@convention(c) (HANDLE) -> LONG)? =
             unsafeBitCast(
@@ -645,7 +646,7 @@ extension Execution {
         }
     }
 
-    /// Resume the current subprocess after suspension
+    /// Resume the current subprocess after suspension.
     public func resume() throws(SubprocessError) {
         let NTResumeProcess: (@convention(c) (HANDLE) -> LONG)? =
             unsafeBitCast(
@@ -721,8 +722,10 @@ extension Executable {
     }
 
     /// `CreateProcessW` allows users to specify the executable path via
-    /// `lpApplicationName` or via `lpCommandLine`. However, only `lpCommandLine` supports
-    /// path searching, whereas `lpApplicationName` does not. In order to support the
+    /// `lpApplicationName` or via `lpCommandLine`.
+    ///
+    /// However, only `lpCommandLine` supports
+    /// path searching, whereas `lpApplicationName` does not. To support the
     /// "argument 0 override" feature, Subprocess must use `lpApplicationName` instead of
     /// relying on `lpCommandLine` (so we can potentially set a different value for `lpCommandLine`).
     ///
@@ -736,7 +739,7 @@ extension Executable {
     /// 5. The Windows directory.
     /// 6. The directories that are listed in the PATH environment variable.
     ///
-    /// For more info:
+    /// For more information:
     /// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
     internal func possibleExecutablePaths(
         withPathValue pathValue: String?
@@ -833,7 +836,7 @@ extension Executable {
                     storage: &possiblePaths
                 )
 
-                // 5. 16 bit Systen Directory
+                // 5. 16 bit System Directory
                 // Windows documentation stats that "No such standard function
                 // (similar to GetSystemDirectory) exists for the 16-bit system folder".
                 // Use "\(windowsDirectory)\System" instead
@@ -1319,7 +1322,7 @@ extension Configuration {
     /// Builds a `cmd.exe` command line that runs a batch file with arguments
     /// escaped to survive both `cmd.exe` and `CommandLineToArgvW` parsing.
     ///
-    /// This logic was taken from Rust standard library's `make_bat_command_line`, which hardened these after
+    /// This logic was taken from the Rust standard library's `make_bat_command_line`, which was hardened after
     /// CVE-2024-24576 / CVE-2024-43402.
     /// https://github.com/rust-lang/rust/blob/master/library/std/src/sys/args/windows.rs
     ///
@@ -1357,9 +1360,11 @@ extension Configuration {
     }
 
     /// Escapes a single argument destined for a batch file run through
-    /// `cmd.exe`. Applies the `CommandLineToArgvW` quoting ("step 1"), then
-    /// prefixes every `cmd.exe` metacharacter,  including the quotes step 1
-    /// added,  with `^` ("step 2"). After `cmd.exe` consumes the carets, the
+    /// `cmd.exe`.
+    ///
+    /// Applies the `CommandLineToArgvW` quoting ("step 1"), then
+    /// prefixes every `cmd.exe` metacharacter, including the quotes step 1
+    /// added, with `^` ("step 2"). After `cmd.exe` consumes the carets, the
     /// child program decodes exactly the original argument.
     ///
     /// Both steps are from Daniel Colascione's "Everyone quotes command line
@@ -1410,7 +1415,9 @@ extension Configuration {
 
     /// Quotes a single argument so the `CommandLineToArgvW` / C runtime parser
     /// in the child decodes it back to the original string (Colascione's
-    /// "step 1"). Taken from SCF.
+    /// "step 1").
+    ///
+    /// Taken from SCF.
     /// See https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
     private static func quoteWindowsCommandArgument(_ arg: String) -> String {
         // Windows escaping, adapted from Daniel Colascione's "Everyone quotes
@@ -1551,10 +1558,10 @@ extension Optional where Wrapped == String {
 }
 
 extension String {
-    /// Invokes `body` with a resolved and potentially `\\?\`-prefixed version of the pointee,
+    /// Invokes `body` with a resolved and potentially `\\?\`-prefixed version of the path,
     /// to ensure long paths greater than MAX_PATH (260) characters are handled correctly.
     ///
-    /// - parameter relative: Returns the original path without transforming through GetFullPathNameW + PathCchCanonicalizeEx, if the path is relative.
+    /// - parameter relative: If `true`, returns the original path without transforming through GetFullPathNameW + PathCchCanonicalizeEx, if the path is relative.
     /// - seealso: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
     internal func withNTPathRepresentation<Result: Sendable>(
         _ body: (UnsafePointer<WCHAR>) throws(SubprocessError) -> Result
@@ -1686,7 +1693,8 @@ extension UInt8 {
     }
 }
 
-/// Calls a Win32 API function that fills a (potentially long path) null-terminated string buffer by continually attempting to allocate more memory up until the true max path is reached.
+/// Calls a Win32 API function that fills a (potentially long path) null-terminated string buffer by continually attempting to allocate more memory until the true max path is reached.
+///
 /// This is especially useful for protecting against race conditions like with GetCurrentDirectoryW where the measured length may no longer be valid on subsequent calls.
 /// - parameter initialSize: Initial size of the buffer (including the null terminator) to allocate to hold the returned string.
 /// - parameter maxSize: Maximum size of the buffer (including the null terminator) to allocate to hold the returned string.

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -312,7 +312,7 @@ extension Configuration {
 /// The collection of platform-specific settings
 /// to configure the subprocess when running.
 public struct PlatformOptions: Sendable {
-    /// The credentials to use when spawning the subprocess
+    /// The credentials to use when launching the subprocess
     /// as a different user.
     internal struct UserCredentials: Sendable, Hashable {
         /// The name of the user.
@@ -327,7 +327,7 @@ public struct PlatformOptions: Sendable {
     }
 
     /// Describes how the console appears
-    /// when spawning a new process.
+    /// when launching a new process.
     public struct ConsoleBehavior: Sendable, Hashable {
         internal enum Storage: Sendable, Hashable {
             case createNew
@@ -342,20 +342,20 @@ public struct PlatformOptions: Sendable {
         }
 
         /// The subprocess has a new console, instead of
-        /// inheriting its parent's console (the default).
+        /// inheriting the calling process's console (the default).
         public static let createNew: Self = .init(.createNew)
         /// For console processes, the new process does not
-        /// inherit its parent's console (the default).
+        /// inherit the calling process's console (the default).
         ///
         /// The new process can call the `AllocConsole`
         /// function at a later time to create a console.
         public static let detach: Self = .init(.detach)
-        /// The subprocess inherits its parent's console.
+        /// The subprocess inherits the calling process's console.
         public static let inherit: Self = .init(.inherit)
     }
 
     /// Describes how the window appears
-    /// when spawning a new process.
+    /// when launching a new process.
     public struct WindowStyle: Sendable, Hashable {
         internal enum Storage: Sendable, Hashable {
             case normal
@@ -393,7 +393,7 @@ public struct PlatformOptions: Sendable {
     internal var userCredentials: UserCredentials? = nil
     /// The console behavior of the new process.
     ///
-    /// Defaults to inheriting the console from the parent process.
+    /// Defaults to inheriting the console from the calling process.
     public var consoleBehavior: ConsoleBehavior = .inherit
     /// The window style to use when the process starts.
     public var windowStyle: WindowStyle = .normal
@@ -401,46 +401,46 @@ public struct PlatformOptions: Sendable {
     /// group for the new process.
     ///
     /// The process group includes all processes
-    /// that are descendants of this root process.
+    /// that this root process launches, directly or indirectly.
     /// The process identifier of the new process group
     /// is the same as the process identifier.
     public var createProcessGroup: Bool = false
-    /// An ordered list of steps to tear down the child
-    /// process if the parent task is canceled before
-    /// the child process terminates.
+    /// An ordered list of steps to tear down the subprocess
+    /// if the calling task is canceled before
+    /// the subprocess terminates.
     ///
     /// The sequence always ends by forcefully terminating the process.
     public var teardownSequence: [TeardownStep] = []
     /// A closure that configures platform-specific
-    /// spawning constructs.
+    /// process-launching constructs.
     ///
     /// Use this closure to directly configure or override
-    /// the underlying platform-specific spawn settings that the
+    /// the underlying platform-specific launch settings that the
     /// library uses internally, when higher-level APIs aren't
     /// available for such modifications.
     ///
     /// On Windows, Subprocess uses `CreateProcessW()` as the
-    /// underlying spawning mechanism. This closure allows
+    /// underlying process-launching mechanism. This closure allows
     /// modification of the `dwCreationFlags` creation flag
     /// and startup info `STARTUPINFOW` before
     /// they are sent to `CreateProcessW()`.
     ///
-    /// - Important: Subprocess assigns every spawned child to
-    /// an internal Job Object before any user code runs in the child,
+    /// - Important: Subprocess assigns every launched subprocess to
+    /// an internal Job Object before any user code runs in the subprocess,
     /// so teardown sequences targeting the process group can terminate
-    /// the child and all of its descendants together. To make this
-    /// assignment atomic, Subprocess always spawns children with
+    /// the subprocess and everything it launches together. To make this
+    /// assignment atomic, Subprocess always launches subprocesses with
     /// `CREATE_SUSPENDED` set in `dwCreationFlags`, regardless of the
     /// value the configurator leaves in `dwCreationFlags`. By default,
-    /// Subprocess resumes the child after the assignment completes.
+    /// Subprocess resumes the subprocess after the assignment completes.
     /// If the configurator sets `CREATE_SUSPENDED` in `dwCreationFlags`,
     /// Subprocess treats this as a signal that user code will resume
-    /// the child explicitly, and therefore skips the internal `ResumeThread`
+    /// the subprocess explicitly, and therefore skips the internal `ResumeThread`
     /// call. In that case the caller is responsible for calling
     /// `ResumeThread` on the thread handle exposed through
-    /// `Execution.processIdentifier.threadHandle`. Otherwise, the child
+    /// `Execution.processIdentifier.threadHandle`. Otherwise, the subprocess
     /// will remain suspended indefinitely. If user code separately
-    /// assigns the child to its own Job Object after spawn, that
+    /// assigns the subprocess to its own Job Object after launch, that
     /// user-supplied job is nested inside Subprocess's job.
     public var preSpawnProcessConfigurator:
         (
@@ -455,7 +455,7 @@ public struct PlatformOptions: Sendable {
 }
 
 extension PlatformOptions.ConsoleBehavior: CustomStringConvertible, CustomDebugStringConvertible {
-    /// A textual representation of how the console appears when spawning a
+    /// A textual representation of how the console appears when launching a
     /// new process.
     public var description: String {
         switch self.storage {
@@ -469,14 +469,14 @@ extension PlatformOptions.ConsoleBehavior: CustomStringConvertible, CustomDebugS
     }
 
     /// A debug-oriented textual representation of how the console appears when
-    /// spawning a new process.
+    /// launching a new process.
     public var debugDescription: String {
         return self.description
     }
 }
 
 extension PlatformOptions.WindowStyle: CustomStringConvertible, CustomDebugStringConvertible {
-    /// A textual representation of how the window appears when spawning a
+    /// A textual representation of how the window appears when launching a
     /// new process.
     public var description: String {
         switch self.storage {
@@ -492,7 +492,7 @@ extension PlatformOptions.WindowStyle: CustomStringConvertible, CustomDebugStrin
     }
 
     /// A debug-oriented textual representation of how the window appears when
-    /// spawning a new process.
+    /// launching a new process.
     public var debugDescription: String {
         return self.description
     }
@@ -596,11 +596,11 @@ extension Execution {
     /// Terminates the current subprocess with the given exit code.
     /// - Parameters:
     ///   - exitCode: The exit code to use for the subprocess.
-    ///   - toProcessGroup: When `true`, terminates the subprocess and any
-    ///   descendants by terminating the Job Object that contains them. The
+    ///   - toProcessGroup: When `true`, terminates the subprocess and everything
+    ///   it launches by terminating the Job Object that contains them. The
     ///   exit code is propagated to every process in the job. When `false`
-    ///   (the default), terminates only the immediate child process, leaving
-    ///   descendants unaffected.
+    ///   (the default), terminates only the immediate subprocess, leaving
+    ///   the processes it launched unaffected.
     public func terminate(
         withExitCode exitCode: DWORD,
         toProcessGroup: Bool = false
@@ -733,7 +733,7 @@ extension Executable {
     /// `lpCommandLine`. Specifically, it follows the steps listed in `CreateProcessW`'s documentation:
     ///
     /// 1. The directory from which the application loaded.
-    /// 2. The current directory for the parent process.
+    /// 2. The current directory for the calling process.
     /// 3. The 32-bit Windows system directory.
     /// 4. The 16-bit Windows system directory.
     /// 5. The Windows directory.
@@ -915,7 +915,7 @@ public struct ProcessIdentifier: Sendable, Hashable {
     public nonisolated(unsafe) let processDescriptor: HANDLE
     /// The main thread handle for this execution.
     public nonisolated(unsafe) let threadHandle: HANDLE
-    /// The Job Object handle that contains this process and any descendants.
+    /// The Job Object handle that contains this process and everything it launches.
     internal nonisolated(unsafe) let jobHandle: HANDLE
 
     internal init(
@@ -1158,12 +1158,12 @@ extension Configuration {
         return try await body(&info)
     }
 
-    /// Creates a Job Object that will contain a spawned child process and
-    /// any descendants.
+    /// Creates a Job Object that will contain a launched subprocess and
+    /// everything it launches.
     ///
     /// - Important: The handle is created with default security attributes,
-    /// which makes it non-inheritable. Descendants must not receive a duplicate
-    /// of the handle, so the parent can retain exclusive control over the job's
+    /// which makes it non-inheritable. Launched processes must not receive a duplicate
+    /// of the handle, so the calling process can retain exclusive control over the job's
     /// lifetime.
     private static func createJobObject() throws(SubprocessError) -> HANDLE {
         guard let jobHandle = CreateJobObjectW(nil, nil),
@@ -1177,12 +1177,12 @@ extension Configuration {
         return jobHandle
     }
 
-    /// Assigns the child process to the Job Object and, if requested, resumes
-    /// the child process thread.
+    /// Assigns the subprocess to the Job Object and, if requested, resumes
+    /// the subprocess thread.
     ///
     /// When `resumeThread` is `false`, the caller is responsible for resuming
-    /// the child using `ResumeThread` on the thread handle exposed through
-    /// `Execution.processIdentifier.threadHandle`. The child remains
+    /// the subprocess using `ResumeThread` on the thread handle exposed through
+    /// `Execution.processIdentifier.threadHandle`. The subprocess remains
     /// suspended until then.
     private static func assignChildToJobObjectAndResume(
         jobHandle: HANDLE,
@@ -1365,7 +1365,7 @@ extension Configuration {
     /// Applies the `CommandLineToArgvW` quoting ("step 1"), then
     /// prefixes every `cmd.exe` metacharacter, including the quotes step 1
     /// added, with `^` ("step 2"). After `cmd.exe` consumes the carets, the
-    /// child program decodes exactly the original argument.
+    /// launched program decodes exactly the original argument.
     ///
     /// Both steps are from Daniel Colascione's "Everyone quotes command line
     /// arguments the wrong way":
@@ -1414,7 +1414,7 @@ extension Configuration {
     }
 
     /// Quotes a single argument so the `CommandLineToArgvW` / C runtime parser
-    /// in the child decodes it back to the original string (Colascione's
+    /// in the launched program decodes it back to the original string (Colascione's
     /// "step 1").
     ///
     /// Taken from SCF.
@@ -1640,7 +1640,7 @@ extension String {
     }
 
     /// Returns `true` if this path names a Windows batch file (`.bat` or
-    /// `.cmd`), which `CreateProcessW` executes by spawning `cmd.exe`.
+    /// `.cmd`), which `CreateProcessW` executes by launching `cmd.exe`.
     ///
     /// Trailing spaces and dots are ignored first, because Windows strips them
     /// when resolving a path: `deploy.bat. .` still runs as a batch file. Not

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -593,7 +593,7 @@ internal func reapProcess(
 // MARK: - Subprocess Control
 
 extension Execution {
-    /// Terminate the current subprocess with the given exit code.
+    /// Terminates the current subprocess with the given exit code.
     /// - Parameters:
     ///   - exitCode: The exit code to use for the subprocess.
     ///   - toProcessGroup: When `true`, terminates the subprocess and any
@@ -622,7 +622,7 @@ extension Execution {
         }
     }
 
-    /// Suspend the current subprocess.
+    /// Suspends the current subprocess.
     public func suspend() throws(SubprocessError) {
         let NTSuspendProcess: (@convention(c) (HANDLE) -> LONG)? =
             unsafeBitCast(
@@ -646,7 +646,7 @@ extension Execution {
         }
     }
 
-    /// Resume the current subprocess after suspension.
+    /// Resumes the current subprocess after suspension.
     public func resume() throws(SubprocessError) {
         let NTResumeProcess: (@convention(c) (HANDLE) -> LONG)? =
             unsafeBitCast(

--- a/Sources/Subprocess/Result.swift
+++ b/Sources/Subprocess/Result.swift
@@ -110,9 +110,9 @@ where Output.OutputType: CustomDebugStringConvertible, Error.OutputType: CustomD
 // MARK: - ExecutionOutcome
 
 /// The outcome of a subprocess execution, containing the closure's return
-/// value and the termination status of the child process.
+/// value and the termination status of the subprocess.
 internal struct ExecutionOutcome<Result: Sendable & ~Copyable>: Sendable, ~Copyable {
-    /// The termination status of the child process.
+    /// The termination status of the subprocess.
     internal let terminationStatus: TerminationStatus
     /// The value returned by the closure passed to the `run` method.
     internal let value: Result

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -25,11 +25,11 @@ import System
 import SystemPackage
 #endif
 
-/// An input type that reads from a `Data` value.
+/// An input type that provides binary data as subprocess input.
 public struct DataInput: InputProtocol {
     private let data: Data
 
-    /// Asynchronously write the input to the subprocess using the
+    /// Asynchronously writes the input to the subprocess using the
     /// write file descriptor.
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         _ = try await writer.write(self.data)
@@ -40,13 +40,13 @@ public struct DataInput: InputProtocol {
     }
 }
 
-/// An input type that reads from a sequence of `Data` values.
+/// An input type that provides a sequence of binary data values as subprocess input.
 public struct DataSequenceInput<
     InputSequence: Sequence & Sendable
 >: InputProtocol where InputSequence.Element == Data {
     private let sequence: InputSequence
 
-    /// Asynchronously write the input to the subprocess using the
+    /// Asynchronously writes the input to the subprocess using the
     /// write file descriptor.
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         var buffer = Data()
@@ -61,7 +61,7 @@ public struct DataSequenceInput<
     }
 }
 
-/// An input type that reads from an asynchronous sequence of `Data` values.
+/// An input type that asynchronously provides binary data as subprocess input.
 public struct DataAsyncSequenceInput<
     InputSequence: AsyncSequence & Sendable
 >: InputProtocol where InputSequence.Element == Data {
@@ -71,7 +71,7 @@ public struct DataAsyncSequenceInput<
         _ = try await writer.write(chunk)
     }
 
-    /// Asynchronously write the input to the subprocess using the
+    /// Asynchronously writes the input to the subprocess using the
     /// write file descriptor.
     @concurrent
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
@@ -95,19 +95,19 @@ public struct DataAsyncSequenceInput<
 }
 
 extension InputProtocol {
-    /// Creates a subprocess input from a `Data` value.
+    /// Creates a subprocess input from binary data.
     public static func data(_ data: Data) -> Self where Self == DataInput {
         return DataInput(data: data)
     }
 
-    /// Creates a subprocess input from a sequence of `Data` values.
+    /// Creates a subprocess input from a sequence of binary data values.
     public static func sequence<InputSequence: Sequence & Sendable>(
         _ sequence: InputSequence
     ) -> Self where Self == DataSequenceInput<InputSequence> {
         return .init(underlying: sequence)
     }
 
-    /// Creates a subprocess input from an asynchronous sequence of `Data` values.
+    /// Creates a subprocess input from an asynchronous sequence of binary data values.
     public static func sequence<InputSequence: AsyncSequence & Sendable>(
         _ asyncSequence: InputSequence
     ) -> Self where Self == DataAsyncSequenceInput<InputSequence>, InputSequence.Element == Data {
@@ -116,7 +116,7 @@ extension InputProtocol {
 }
 
 extension StandardInputWriter {
-    /// Writes a `Data` value to the subprocess's standard input.
+    /// Writes binary data to the subprocess's standard input.
     /// - Parameter data: The data to write.
     /// - Returns: The number of bytes written.
     public func write(
@@ -125,7 +125,7 @@ extension StandardInputWriter {
         return try await AsyncIO.shared.write(data, to: self.diskIO, for: self.processIdentifier)
     }
 
-    /// Writes an asynchronous sequence of `Data` to the subprocess's standard input.
+    /// Writes an asynchronous sequence of binary data to the subprocess's standard input.
     /// - Parameter asyncSequence: The sequence of data to write.
     /// - Returns: The number of bytes written.
     @concurrent

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -39,7 +39,7 @@ public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
 extension OutputProtocol where Self == DataOutput {
     /// Creates a subprocess output that collects the process's binary output, up to the specified byte limit.
     ///
-    /// The subprocess throws an error if the child process
+    /// The subprocess throws an error if the process
     /// produces more bytes than `limit`.
     public static func data(limit: Int) -> Self {
         return .init(limit: limit)

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -19,7 +19,7 @@ public import Foundation
 public import FoundationEssentials
 #endif
 
-/// An output type that collects the subprocess's output as `Data`.
+/// An output type that collects the subprocess's output as binary data.
 public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
     /// The output type for this output option.
     public typealias OutputType = Data
@@ -37,8 +37,7 @@ public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
 }
 
 extension OutputProtocol where Self == DataOutput {
-    /// Creates a subprocess output that collects output as `Data`,
-    /// up to `limit` bytes.
+    /// Creates a subprocess output that collects the process's binary output, up to the specified byte limit.
     ///
     /// The subprocess throws an error if the child process
     /// produces more bytes than `limit`.
@@ -48,7 +47,7 @@ extension OutputProtocol where Self == DataOutput {
 }
 
 extension Data {
-    /// Creates a `Data` value from a buffer.
+    /// Creates a binary data value from a subprocess output buffer.
     /// - Parameter buffer: The buffer to copy from.
     public init(buffer: SubprocessOutputSequence.Buffer) {
         self = Data(buffer.data)

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -51,7 +51,7 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     internal typealias DiskIO = FileDescriptor
     #endif
 
-    /// An iterator for ``SubprocessOutputSequence``.
+    /// An iterator that yields raw output buffers from the subprocess.
     public struct Iterator: AsyncIteratorProtocol {
         /// The element type for the iterator.
         public typealias Element = Buffer
@@ -241,9 +241,9 @@ extension SubprocessOutputSequence {
         private let bufferingPolicy: BufferingPolicy
         private let separator: Separator
 
-        /// An iterator for ``StringSequence``.
+        /// An iterator that yields individual lines of subprocess output.
         public struct AsyncIterator: nonisolated AsyncIteratorProtocol {
-            /// The element type for this Iterator.
+            /// The element type for this iterator.
             public typealias Element = String
 
             private var source: SubprocessOutputSequence.AsyncIterator
@@ -519,8 +519,7 @@ extension SubprocessOutputSequence.StringSequence {
         case maxLineLength(Int)
     }
 
-    /// A delimiter that determines where a ``StringSequence``
-    /// splits its input.
+    /// A delimiter that determines where the output line sequence splits its input.
     public struct Separator: Sendable, Hashable {
         internal enum Storage: Sendable, Hashable {
             case lineBreaks
@@ -534,6 +533,7 @@ extension SubprocessOutputSequence.StringSequence {
         }
 
         /// Splits on Unicode line break characters.
+        ///
         /// The following Unicode characters are recognized as line
         /// breaks:
         /// ```

--- a/Sources/Subprocess/Teardown.swift
+++ b/Sources/Subprocess/Teardown.swift
@@ -25,7 +25,7 @@ import Musl
 
 /// A step in a graceful shutdown sequence.
 ///
-/// Each step specifies an action to perform on the child process and
+/// Each step specifies an action to perform on the subprocess and
 /// the duration to wait for the process to exit before proceeding
 /// to the next step.
 public struct TeardownStep: Sendable, Hashable {
@@ -46,10 +46,10 @@ public struct TeardownStep: Sendable, Hashable {
     ///
     /// - Important: When sending the signal to the process group, unless you
     /// also set `createSession` to `true`, or `processGroupID` to a
-    /// non-inherited value, the targeted process group includes the parent
+    /// non-inherited value, the targeted process group includes the calling
     /// process. This is almost never what you want. Pair `toProcessGroup`
-    /// with `createSession` to isolate the subprocess and its descendants in
-    /// their own session.
+    /// with `createSession` to isolate the subprocess and the processes it
+    /// launches in their own session.
     public static func send(
         signal: Signal,
         toProcessGroup: Bool = false,
@@ -70,16 +70,16 @@ public struct TeardownStep: Sendable, Hashable {
     ///
     /// - On Unix: Sends `SIGTERM`.
     /// - On Windows:
-    ///   1. Sends `WM_CLOSE` if the child process is a GUI process.
+    ///   1. Sends `WM_CLOSE` if the subprocess is a GUI process.
     ///   2. Sends `CTRL_C_EVENT` to the console.
     ///   3. Sends `CTRL_BREAK_EVENT` to the process group.
     ///
     /// - Important: On Unix, when sending the signal to the process group,
     /// unless you also set `createSession` to `true`, or `processGroupID`
-    /// to a non-inherited value, the targeted process group includes the parent
+    /// to a non-inherited value, the targeted process group includes the calling
     /// process. This is almost never what you want. Pair `toProcessGroup`
-    /// with `createSession` to isolate the subprocess and its descendants in
-    /// their own session. On Windows, the `toProcessGroup` parameter has no
+    /// with `createSession` to isolate the subprocess and the processes it
+    /// launches in their own session. On Windows, the `toProcessGroup` parameter has no
     /// effect; `WM_CLOSE` and `CTRL_C_EVENT` have no process-group equivalent,
     /// and `CTRL_BREAK_EVENT` is always sent to the process group.
     public static func gracefulShutDown(


### PR DESCRIPTION
This updates the doc comments to fix a few spelling, grammar, and punctuation issues - but more generally breaks up and edits some of the content so that abstracts are simple and direct, and don't include monospaced text (aka "code voice") or symbol references. In a few cases, I just dropped the symbol references because they'll be obvious in the signature in the DocC output. In other cases, I broke up the sentence and pushed references to a discussion section where code voice and symbol links are more effective. I also tried to make sure that all the abstracts were a single sentence, followed by blank link so that any following content would appear in the discussion/overview section for that symbol, and not "explode" the abstract into a multi-line thing.

(We generally avoid putting code voice and symbols in abstracts because he abstracts appear in multiple locations within DocC content - in navigation areas and such, where the extra linking either just gets dropped or looks very awkward)

I went ahead and extended this to remove the biological or family metaphors from the documentation content (such as "spawn", "kill", "children", "parent") to use more neutral/agnostic terms. I've also rebased this over main to take advantage of the DocC catalog that was added in #329

I'll follow up with another PR to add more curation (organization, including the types) - and try to expand out the usage scenarios based on what I've seen talked about in threads on the forums and discussions around this overall API as it's developed. Nothing too extensive, just trying to get a baseline of "how to use it" and considerations in place.

/cc @invalidname 