### PR TITLE
dropping the 6.1 requirement for building docs for this package

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,5 @@
 version: 1
 builder:
   configs:
-    - swift_version: 6.1
-      documentation_targets: [Subprocess]
+    - documentation_targets: [Subprocess]
       scheme: Subprocess


### PR DESCRIPTION
drops the requirement in the Swift Package Index configuration to only build the docs using Swift 6.1