### PR TITLE
Validate environment variables before spawning

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -205,7 +205,7 @@ extension Configuration {
         var outputPipeBox: CreatedPipe? = consume outputPipe
         var errorPipeBox: CreatedPipe? = consume errorPipe
 
-        return try await self.preSpawn { args throws -> SpawnResult in
+        func spawnFunc(_ args: PreSpawnArgs) async throws -> SpawnResult {
             let (env, uidPtr, gidPtr, supplementaryGroups) = args
             var _inputPipe = inputPipeBox.take()!
             var _outputPipe = outputPipeBox.take()!
@@ -412,7 +412,21 @@ extension Configuration {
                 }
                 // Run additional config
                 if let spawnConfig = self.platformOptions.preSpawnProcessConfigurator {
-                    try spawnConfig(&spawnAttributes, &fileActions)
+                    do {
+                        try spawnConfig(&spawnAttributes, &fileActions)
+                    } catch {
+                        // If the configurator throws, make sure we clean up
+                        // the file descriptors before propagating the error.
+                        try self.safelyCloseMultiple(
+                            inputRead: inputReadFileDescriptor,
+                            inputWrite: inputWriteFileDescriptor,
+                            outputRead: outputReadFileDescriptor,
+                            outputWrite: outputWriteFileDescriptor,
+                            errorRead: errorReadFileDescriptor,
+                            errorWrite: errorWriteFileDescriptor
+                        )
+                        throw error
+                    }
                 }
 
                 // Spawn
@@ -490,6 +504,25 @@ extension Configuration {
                 self.executable.description,
                 underlyingError: Errno(rawValue: ENOENT)
             )
+        }
+
+        do {
+            return try await self.preSpawn(spawnFunc)
+        } catch {
+            var _inputPipe = inputPipeBox.take()
+            var _outputPipe = outputPipeBox.take()
+            var _errorPipe = errorPipeBox.take()
+            // If any part of spawning failed, make sure we clean up pipes
+            try? self.safelyCloseMultiple(
+                inputRead: _inputPipe?.readFileDescriptor(),
+                inputWrite: _inputPipe?.writeFileDescriptor(),
+                outputRead: _outputPipe?.readFileDescriptor(),
+                outputWrite: _outputPipe?.writeFileDescriptor(),
+                errorRead: _errorPipe?.readFileDescriptor(),
+                errorWrite: _errorPipe?.writeFileDescriptor()
+            )
+
+            throw error
         }
     }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -147,7 +147,7 @@ extension Execution {
     }
 }
 
-// MARK: - Environment Resolution
+// MARK: - Environment Resolution and Validation
 extension Environment {
     internal func pathValue() -> String? {
         switch self.config {
@@ -254,6 +254,84 @@ extension Environment {
         defer { values.forEach { free($0) } }
         return body(values)
     }
+
+    /// POSIX standard imposes restrictions on environment keys and values:
+    /// 1. Names shall not contain the character '='.
+    /// 2. Names shall not begin with a digit.
+    /// 3. Names and values shall be composed of characters from the portable character set except NUL
+    /// See https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
+    internal func validate() throws(SubprocessError) {
+        let equals = UInt8(ascii: "=")
+        let nul = UInt8(ascii: "\0")
+        let digit0 = UInt8(ascii: "0")
+        let digit9 = UInt8(ascii: "9")
+
+        func _validateError(_ reason: String) -> SubprocessError {
+            return .spawnFailed(withUnderlyingError: nil, reason: reason)
+        }
+
+        func _validate(_ dict: [Key: String?]) throws(SubprocessError) {
+            for (key, value) in dict {
+                let keyBytes = key.rawValue.utf8
+                // Rule 1/3: key shall not contain = nor null bytes
+                let ruleOneViolation = keyBytes.contains {
+                    $0 == equals || $0 == nul
+                }
+                if ruleOneViolation {
+                    throw _validateError("Environment key '\(key)' must not contain '=' or null bytes.")
+                }
+                // Rule 2: key shall not begin with a digit
+                if let first = keyBytes.first, (digit0...digit9).contains(first) {
+                    throw _validateError("Environment key '\(key)' must not begin with a digit.")
+                }
+                // Rule 3: value shall not contain null bytes
+                if let value, value.utf8.contains(nul) {
+                    throw _validateError("Environment value '\(value)' must not contain null bytes.")
+                }
+            }
+        }
+
+        func _validate(rawBytes rawBytesArray: [[UInt8]]) throws(SubprocessError) {
+            for rawBytes in rawBytesArray {
+                // Each entry is passed to `strdup` in `createEnv()`, which stops
+                // at the first null byte. A single trailing null terminator is
+                // allowed, but reject any earlier null byte since it would
+                // silently truncate the entry.
+                var bytes = rawBytes
+                if bytes.last == nul {
+                    bytes = bytes.dropLast()
+                }
+                // Rule 1/3: entry shall not contain null bytes
+                if bytes.contains(nul) {
+                    throw _validateError(
+                        "Environment entry '\(String(decoding: bytes, as: UTF8.self))' must not contain null bytes."
+                    )
+                }
+                // Each entry is a key and value pair joined by '='
+                guard let equalsIndex = bytes.firstIndex(of: equals) else {
+                    throw _validateError(
+                        "Environment entry '\(String(decoding: bytes, as: UTF8.self))' must contain '='."
+                    )
+                }
+                // Rule 2: key shall not begin with a digit
+                let keyBytes = bytes[bytes.startIndex..<equalsIndex]
+                if let first = keyBytes.first, (digit0...digit9).contains(first) {
+                    throw _validateError(
+                        "Environment key '\(String(decoding: keyBytes, as: UTF8.self))' must not begin with a digit."
+                    )
+                }
+            }
+        }
+
+        switch self.config {
+        case .inherit(let updates):
+            try _validate(updates)
+        case .custom(let custom):
+            try _validate(custom.mapValues { Optional($0) })
+        case .rawBytes(let rawBytesArray):
+            try _validate(rawBytes: rawBytesArray)
+        }
+    }
 }
 
 // MARK: Args Creation
@@ -342,6 +420,8 @@ extension Configuration {
         _ work: (PreSpawnArgs) async throws -> Result
     ) async throws -> Result {
         // Prepare environment
+        try self.environment.validate()
+
         let env = self.environment.createEnv()
         defer {
             for ptr in env { ptr?.deallocate() }
@@ -460,7 +540,7 @@ extension Configuration {
         var outputPipeBox: CreatedPipe? = consume outputPipe
         var errorPipeBox: CreatedPipe? = consume errorPipe
 
-        return try await self.preSpawn { args throws -> SpawnResult in
+        func spawnFunc(_ args: PreSpawnArgs) async throws -> SpawnResult {
             let (env, uidPtr, gidPtr, supplementaryGroups) = args
 
             var _inputPipe = inputPipeBox.take()!
@@ -598,6 +678,25 @@ extension Configuration {
                 self.executable.description,
                 underlyingError: Errno(rawValue: ENOENT)
             )
+        }
+
+        do {
+            return try await self.preSpawn(spawnFunc)
+        } catch {
+            var _inputPipe = inputPipeBox.take()
+            var _outputPipe = outputPipeBox.take()
+            var _errorPipe = errorPipeBox.take()
+            // If any part of spawning failed, make sure we clean up pipes
+            try? self.safelyCloseMultiple(
+                inputRead: _inputPipe?.readFileDescriptor(),
+                inputWrite: _inputPipe?.writeFileDescriptor(),
+                outputRead: _outputPipe?.readFileDescriptor(),
+                outputWrite: _outputPipe?.writeFileDescriptor(),
+                errorRead: _errorPipe?.readFileDescriptor(),
+                errorWrite: _errorPipe?.writeFileDescriptor()
+            )
+
+            throw error
         }
     }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -43,6 +43,22 @@ extension Configuration {
         let errorReadFileDescriptor: IODescriptor? = errorPipe.readFileDescriptor()
         let errorWriteFileDescriptor: IODescriptor? = errorPipe.writeFileDescriptor()
 
+        // Validate the environment once before spawning. If validation fails,
+        // clean up the file descriptors before propagating the error.
+        do {
+            try self.environment.validate()
+        } catch {
+            try self.safelyCloseMultiple(
+                inputRead: inputReadFileDescriptor,
+                inputWrite: inputWriteFileDescriptor,
+                outputRead: outputReadFileDescriptor,
+                outputWrite: outputWriteFileDescriptor,
+                errorRead: errorReadFileDescriptor,
+                errorWrite: errorWriteFileDescriptor
+            )
+            throw error
+        }
+
         // Create the Job Object up front. It persists across all candidate path
         // attempts, and is owned by this function until ownership transfers to
         // the `ProcessIdentifier` on the success path.
@@ -900,6 +916,51 @@ extension Environment {
         defer { values.forEach { free($0) } }
         return body(values)
     }
+
+    /// Windows documentation states the following restrictions on environments:
+    /// 1. The name of an environment variable cannot include an equal sign (=).
+    /// 2. The maximum size of a user-defined environment variable is 32,767 characters.
+    /// See https://learn.microsoft.com/en-us/windows/win32/procthread/environment-variables
+    internal func validate() throws(SubprocessError) {
+        let equals = UInt8(ascii: "=")
+        let nul = UInt8(ascii: "\0")
+
+        func _validateError(_ reason: String) -> SubprocessError {
+            return .spawnFailed(withUnderlyingError: nil, reason: reason)
+        }
+
+        func _validate(_ dict: [Key: String?]) throws(SubprocessError) {
+            for (key, value) in dict {
+                // Rule 1: key shall not contain =
+                if key.rawValue.utf8.contains(equals) {
+                    throw _validateError("Environment key '\(key)' must not contain '='.")
+                }
+                // Key and value shall not contain null bytes, otherwise the
+                // null-separated environment block would be silently truncated.
+                if key.rawValue.utf8.contains(nul) {
+                    throw _validateError("Environment key '\(key)' must not contain null bytes.")
+                }
+                if let value, value.utf8.contains(nul) {
+                    throw _validateError("Environment value '\(value)' must not contain null bytes.")
+                }
+
+                // Rule 2: the serialized "key=value" entry must not exceed
+                // 32,767 UTF-16 code units, accounting for the '=' separator
+                // and the null terminator.
+                let entryLength = key.rawValue.utf16.count + 1 + (value?.utf16.count ?? 0) + 1
+                if entryLength > 32767 {
+                    throw _validateError("Environment key and value pair must not exceed 32,767 characters.")
+                }
+            }
+        }
+
+        switch self.config {
+        case .inherit(let updates):
+            try _validate(updates)
+        case .custom(let custom):
+            try _validate(custom)
+        }
+    }
 }
 
 // MARK: - ProcessIdentifier
@@ -971,7 +1032,7 @@ extension Configuration {
             env = Environment.currentEnvironmentValues()
             for (key, value) in updateValues {
                 if let value {
-                    // Update env with ew value
+                    // Update env with new value
                     env.updateValue(value, forKey: key)
                 } else {
                     // If `value` is `nil`, unset this value from env

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -810,6 +810,60 @@ extension SubprocessUnixTests {
             }
         }
     }
+
+    @Test func testRejectInvalidEnvironment() async throws {
+        func _runTest(withEnvironment environment: Environment, errorReason: String) async {
+            let expectedError: SubprocessError = .spawnFailed(
+                withUnderlyingError: nil,
+                reason: errorReason
+            )
+
+            await #expect(throws: expectedError) {
+                _ = try await Subprocess.run(
+                    .path("/bin/echo"),
+                    environment: environment,
+                    output: .discarded
+                )
+            }
+        }
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key=": "value"]),
+            errorReason: "Environment key 'key=' must not contain '=' or null bytes."
+        )
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key\0": "value"]),
+            errorReason: "Environment key 'key\0' must not contain '=' or null bytes."
+        )
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["0key": "value"]),
+            errorReason: "Environment key '0key' must not begin with a digit."
+        )
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key": "value\0"]),
+            errorReason: "Environment value 'value\0' must not contain null bytes."
+        )
+
+        // Raw bytes: a trailing null terminator is allowed, but an embedded
+        // null byte must be rejected since `strdup` would silently truncate it.
+        await _runTest(
+            withEnvironment: .custom([Array("key=va\0lue".utf8)]),
+            errorReason: "Environment entry 'key=va\0lue' must not contain null bytes."
+        )
+
+        await _runTest(
+            withEnvironment: .custom([Array("keyvalue\0".utf8)]),
+            errorReason: "Environment entry 'keyvalue' must contain '='."
+        )
+
+        await _runTest(
+            withEnvironment: .custom([Array("0key=value\0".utf8)]),
+            errorReason: "Environment key '0key' must not begin with a digit."
+        )
+    }
 }
 
 // MARK: - Utils

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -570,7 +570,7 @@ extension SubprocessWindowsTests {
     }
 }
 
-// MARK: - Environment.Key Case-Insensitive Comparison
+// MARK: - Environment
 extension SubprocessWindowsTests {
     @Test func testEnvironmentKeyComparableMatchesEquatable() {
         let upper: Environment.Key = "PATH"
@@ -593,6 +593,45 @@ extension SubprocessWindowsTests {
         // therefore precede "APP_NAME".
         let keys: [Environment.Key] = ["APP_NAME", "APPDATA"]
         #expect(keys.sorted().map(\.rawValue) == ["APPDATA", "APP_NAME"])
+    }
+
+    @Test func testRejectInvalidEnvironment() async throws {
+        func _runTest(withEnvironment environment: Environment, errorReason: String) async {
+            let expectedError: SubprocessError = .spawnFailed(
+                withUnderlyingError: nil,
+                reason: errorReason
+            )
+
+            await #expect(throws: expectedError) {
+                _ = try await Subprocess.run(
+                    self.cmdExe,
+                    environment: environment,
+                    output: .discarded
+                )
+            }
+        }
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key=": "value"]),
+            errorReason: "Environment key 'key=' must not contain '='."
+        )
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key\0": "value"]),
+            errorReason: "Environment key 'key\0' must not contain null bytes."
+        )
+
+        await _runTest(
+            withEnvironment: .inherit.updating(["key": "value\0"]),
+            errorReason: "Environment value 'value\0' must not contain null bytes."
+        )
+
+        let longKey = randomString(length: 32767 / 2 + 1)
+        let longValue = randomString(length: 32767 / 2 + 1)
+        await _runTest(
+            withEnvironment: .inherit.updating([.init(longKey): longValue]),
+            errorReason: "Environment key and value pair must not exceed 32,767 characters."
+        )
     }
 }
 


### PR DESCRIPTION
Reject environment keys and values that would be malformed or silently corrupted when handed to the child process, surfacing a clear SubprocessError before the child is created rather than spawning it with a broken environment.

POSIX (Subprocess+Unix.swift):
- Reject keys containing '=' or NUL, and keys beginning with a digit.
- Reject values containing NUL.

Windows (Subprocess+Windows.swift):
- Reject keys containing '=' or NUL and values containing NUL; an embedded NUL would truncate the null-separated environment block passed to CreateProcessW.
- Reject serialized "key=value" entries exceeding 32,767 UTF-16 code units, counting the '=' and null terminator, to match the documented Windows limit (measured in UTF-16 code units, not grapheme clusters).