### PR TITLE
Annotate `pthread_t` out-parameter nullability on musl

### DIFF
--- a/Sources/_SubprocessCShims/include/process_shims.h
+++ b/Sources/_SubprocessCShims/include/process_shims.h
@@ -37,12 +37,22 @@
 #include <sys/wait.h>
 #endif // TARGET_OS_LINUX || TARGET_OS_FREEBSD
 
+// musl provides no identifying macro, so it is spelled as Linux that is
+// neither glibc nor Bionic. Correct only after a libc header (<pthread.h>
+// above) has put __GLIBC__ in scope, which is why this lives here and not in
+// target_conditionals.h.
+#if TARGET_OS_LINUX && !defined(__GLIBC__) && !defined(__ANDROID__)
+#define TARGET_LIBC_MUSL 1
+#else
+#define TARGET_LIBC_MUSL 0
+#endif // TARGET_LIBC_MUSL
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int _subprocess_pthread_create(
-#if TARGET_OS_MAC || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if TARGET_OS_MAC || defined(__FreeBSD__) || defined(__OpenBSD__) || TARGET_LIBC_MUSL
     pthread_t _Nullable * _Nonnull ptr,
 #else
     pthread_t * _Nonnull ptr,

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -87,7 +87,11 @@ uint64_t _subprocess_nofile_soft_limit(void) {
 }
 
 int _subprocess_pthread_create(
+#if TARGET_OS_MAC || defined(__FreeBSD__) || defined(__OpenBSD__) || TARGET_LIBC_MUSL
+    pthread_t _Nullable * _Nonnull ptr,
+#else
     pthread_t * _Nonnull ptr,
+#endif
     pthread_attr_t const * _Nullable attr,
     void * _Nullable (* _Nonnull start)(void * _Nullable),
     void * _Nullable context


### PR DESCRIPTION
On musl, `pthread_t` is a pointer `typedef`, so the `ptr` out-parameter of `_subprocess_pthread_create()` left its inner pointer unannotated and tripped `-Wnullability-completeness` on the static Linux SDK build:

```shell
In file included from /__w/swift-subprocess/swift-subprocess/Sources/_SubprocessCShims/process_shims.c:23:
/__w/swift-subprocess/swift-subprocess/Sources/_SubprocessCShims/include/process_shims.h:48:5: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
   48 |     pthread_t * _Nonnull ptr,
      |     ^
/__w/swift-subprocess/swift-subprocess/Sources/_SubprocessCShims/include/process_shims.h:48:5: note: insert '_Nullable' if the pointer may be null
   48 |     pthread_t * _Nonnull ptr,
      |     ^
      |               _Nullable
/__w/swift-subprocess/swift-subprocess/Sources/_SubprocessCShims/include/process_shims.h:48:5: note: insert '_Nonnull' if the pointer should never be null
   48 |     pthread_t * _Nonnull ptr,
      |     ^
      |               _Nonnull
```

This PR extends the existing platform condition that already annotates this pointer on the other pointer-typed `pthread_t` platforms (Darwin, FreeBSD, OpenBSD) to also cover musl. The condition is factored into a `TARGET_LIBC_MUSL` macro so that the declaration and definition, which must carry it identically, share a single source of truth.

Note: I'm working on a separate PR to clear other warnings like `OpaquePointer` `Sendable` conformance.