### PR TITLE
Relocate `pthread_t` `Sendable` conformance off `OpaquePointer` on musl

### DIFF
--- a/Sources/Subprocess/IO/AsyncIO+Linux.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Linux.swift
@@ -55,10 +55,17 @@ final class AsyncIO: Sendable {
         }
     }
 
-    private struct State {
+    private struct State: Sendable {
         let epollFileDescriptor: CInt
         let shutdownFileDescriptor: CInt
+        // `pthread_t` is a non-`Sendable` pointer on musl but a `Sendable`
+        // integer on glibc/Bionic; scope the opt-out to musl so it isn't
+        // flagged as unnecessary on the integer platforms.
+        #if canImport(Musl)
+        nonisolated(unsafe) let monitorThread: pthread_t
+        #else
         let monitorThread: pthread_t
+        #endif
     }
 
     static let shared: AsyncIO = AsyncIO()

--- a/Sources/Subprocess/Platforms/Subprocess+Linux.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Linux.swift
@@ -155,15 +155,18 @@ internal func waitForProcessTermination(
     }
 }
 
-#if canImport(Musl)
-extension pthread_t: @retroactive @unchecked Sendable {}
-#endif
-
-private enum ProcessMonitorState {
-    struct Storage {
+private enum ProcessMonitorState: Sendable {
+    struct Storage: Sendable {
         let epollFileDescriptor: CInt
         let shutdownFileDescriptor: CInt
+        // `pthread_t` is a non-`Sendable` pointer on musl but a `Sendable`
+        // integer on glibc/Bionic; scope the opt-out to musl so it isn't
+        // flagged as unnecessary on the integer platforms.
+        #if canImport(Musl)
+        nonisolated(unsafe) let monitorThread: pthread_t
+        #else
         let monitorThread: pthread_t
+        #endif
         var continuations: [PlatformFileDescriptor: [CheckedContinuation<Void, any Error>]]
     }
 


### PR DESCRIPTION
On musl, `pthread_t` is a pointer `typedef` that Swift imports as `OpaquePointer`, so the retroactive unchecked `Sendable` conformance on `pthread_t` restated a conformance the standard library already declares as unavailable, tripping warnings on the static Linux SDK build:

```shell
/__w/swift-subprocess/swift-subprocess/Sources/Subprocess/Platforms/Subprocess+Linux.swift:159:46: warning: conformance of 'OpaquePointer' to protocol 'Sendable' was already stated in the type's module 'Swift'
157 | 
158 | #if canImport(Musl)
159 | extension pthread_t: @retroactive @unchecked Sendable {}
    |                                              `- warning: conformance of 'OpaquePointer' to protocol 'Sendable' was already stated in the type's module 'Swift'
160 | #endif
161 | 

Swift.OpaquePointer:2:11: note: 'OpaquePointer' declares conformance to protocol 'Sendable' here
1 | @available(*, unavailable)
2 | extension OpaquePointer : Sendable {
  |           `- note: 'OpaquePointer' declares conformance to protocol 'Sendable' here
3 | }
```

Because the conformance was keyed on the type rather than a wrapper, it also silently made every `OpaquePointer` in the module `Sendable` on musl, which could mask a genuine data race.

The conformance existed only so a `pthread_t` could be stored in the `Sendable` monitor-state structs. Remove it and opt the two stored handles out of `Sendable` checking with `nonisolated(unsafe)` instead; the thread handle is written once during setup and read only at shutdown to join, so it is never mutated concurrently. The opt-out is scoped to musl, since `pthread_t` is a pointer only there and is a `Sendable` integer on glibc and Bionic, where an unconditional `nonisolated(unsafe)` would warn as unnecessary. The kqueue and BSD monitor-state structs opt the handle out unconditionally because every platform that compiles them has a pointer `pthread_t`; the Linux structs are the only ones compiled under both `pthread_t` types, so only they have to branch.