### PR TITLE
Migrate CI from Amazon Linux 2 to Amazon Linux 2023

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_os_versions: '["amazonlinux2", "bookworm", "noble", "jammy", "rhel-ubi9"]'
+      linux_os_versions: '["bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_swift_versions: '["6.2", "nightly-main"]'
       linux_pre_build_command: |
         if command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
@@ -29,11 +29,6 @@ jobs:
 
           # Test dependencies
           dnf install -y procps
-        elif command -v yum >/dev/null 2>&1 ; then # amazonlinux2
-          yum update -y
-
-          # Test dependencies
-          yum install -y procps
         fi
       linux_build_command: "swift test && swift test -c release && swift test --disable-default-traits"
       enable_freebsd_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
-      linux_os_versions: '["bookworm", "noble", "jammy", "rhel-ubi9"]'
+      linux_os_versions: '["amazonlinux2023", "bookworm", "noble", "jammy", "rhel-ubi9"]'
       linux_swift_versions: '["6.2", "nightly-main"]'
       linux_pre_build_command: |
         if command -v apt-get >/dev/null 2>&1 ; then # bookworm, noble, jammy
@@ -24,12 +24,14 @@ jobs:
             apt-get update -y
             apt-get install -y procps
           fi
-        elif command -v dnf >/dev/null 2>&1 ; then # rhel-ubi9
+        elif command -v dnf >/dev/null 2>&1 ; then # amazonlinux2023, rhel-ubi9
           dnf update -y
 
           # Test dependencies
           dnf install -y procps
         fi
+      linux_exclude_swift_versions: '[{"swift_version": "6.2", "os_version": "amazonlinux2023"}]'
+      linux_static_sdk_exclude_swift_versions: '[{"swift_version": "6.2", "os_version": "amazonlinux2023"}]'
       linux_build_command: "swift test && swift test -c release && swift test --disable-default-traits"
       enable_freebsd_checks: true
       freebsd_build_command: "swift test && swift test -c release && swift test --disable-default-traits"

--- a/README.md
+++ b/README.md
@@ -354,7 +354,6 @@ See the `PlatformOptions` documentation for a complete list of configurable para
 | **Ubuntu 24.04**                   | Automated             |
 | **Red Hat Universal Base Image 9** | Automated             |
 | **Debian 12**                      | Automated             |
-| **Amazon Linux 2**                 | Automated             |
 | **Windows 11**                     | Automated             |
 | **Android**                        | Automated             |
 | **FreeBSD**                        | Automated             |

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ See the `PlatformOptions` documentation for a complete list of configurable para
 | **Ubuntu 24.04**                   | Automated             |
 | **Red Hat Universal Base Image 9** | Automated             |
 | **Debian 12**                      | Automated             |
+| **Amazon Linux 2023**              | Automated             |
 | **Windows 11**                     | Automated             |
 | **Android**                        | Automated             |
 | **FreeBSD**                        | Automated             |


### PR DESCRIPTION
Amazon Linux 2 reached end of life on 2026-06-30, and Swift.org has [stopped publishing](https://forums.swift.org/t/dropping-support-for-amazon-linux-2/87920) the nightly toolchains for main and release/6.4.x. The static Linux SDK build on the amazonlinux2 host now fails.

This PR drops Amazon Linux 2 from CI and also removes the now-dead yum branch from the pre-build command, since Amazon Linux 2 was the only distribution in the matrix that used yum.

It is replaced with Amazon Linux 2023. There is no `swift:6.2-amazonlinux2023` image, so 6.2 is excluded on that OS for both the native test and the static-SDK build. AL2023 is otherwise covered natively on `nightly-main`; it is dnf-based, so it uses the existing dnf pre-build branch.

Note that AL2023 is enabled for `nightly-main`. This cell will fail whenever the latest static-SDK snapshot is ahead of the AL2023 nightly container; the install step won't find a matching nightly toolchain. When it happens, it's easy to spot in the log ("Toolchain not found", exit 44).