### PR TITLE
Fix use-after-free when Windows input writing is cancelled

### DIFF
--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -298,7 +298,7 @@ final class AsyncIO: @unchecked Sendable {
                 // with its bytes sitting in `resultBuffer`. Those bytes have been
                 // pulled out of the pipe, so the post-cancellation drain cannot
                 // recover them: dropping them here loses exactly one buffer.
-                return self.reconcileOverlappedAfterCancellation(
+                return self.reconcileReadOverlappedAfterCancellation(
                     handle: handle,
                     overlapped: &overlapped
                 )
@@ -339,7 +339,7 @@ final class AsyncIO: @unchecked Sendable {
     /// this call. On the pending path this function blocks until the cancelled
     /// read has fully unwound, guaranteeing the kernel is done with both before
     /// they are freed.
-    private func reconcileOverlappedAfterCancellation(
+    private func reconcileReadOverlappedAfterCancellation(
         handle: HANDLE,
         overlapped: inout _OVERLAPPED
     ) -> OverlappedReadOutcome {
@@ -399,6 +399,73 @@ final class AsyncIO: @unchecked Sendable {
         // Any other status: no bytes to recover here. The drain handles anything
         // still buffered.
         return .finished
+    }
+
+    /// Reconciles an overlapped `WriteFile` whose awaiting task was cancelled
+    /// before its completion was delivered through the signal stream.
+    ///
+    /// On cancellation, the `WriteFile` this function's caller issued is in
+    /// one of three states. If it already finished, the kernel has released
+    /// both the source buffer and `overlapped`, and there is nothing to do. If
+    /// it is still pending, the kernel is reading from the caller's `span`
+    /// storage and will still write the result into `overlapped`; returning
+    /// now would end the borrow on `span` and pop `overlapped` off the stack
+    /// while the kernel is mid-operation (use-after-free of the kernel's read
+    /// source). This cancels that specific operation and blocks until it has
+    /// fully unwound, so both are provably idle before they are freed.
+    ///
+    /// Unlike the read counterpart, this returns nothing. Whatever
+    /// `GetOverlappedResult` reports as transferred on the cancelled write is
+    /// deliberately not folded into the caller's returned count: cancellation
+    /// here means the only reader of this pipe has terminated, so nothing will
+    /// consume those bytes, and whether any landed before or after the cancel
+    /// is a race upon which the caller cannot act. The count is left as the
+    /// total confirmed through the completion port, truncated by cancellation.
+    ///
+    /// - Important: `overlapped` must reference the same storage passed to the
+    /// `WriteFile` call, and the `span` that call read from must outlive this
+    /// call. On the pending path this function blocks until the cancelled write
+    /// has fully unwound, guaranteeing the kernel is done with both before the
+    /// borrow is released.
+    private func reconcileWriteOverlappedAfterCancellation(
+        handle: HANDLE,
+        overlapped: inout _OVERLAPPED
+    ) {
+        var transferred: DWORD = 0
+
+        // Already finished (completed, aborted, or broken pipe)? The kernel
+        // has released the source buffer and `overlapped`; nothing to reclaim.
+        if GetOverlappedResult(handle, &overlapped, &transferred, false) {
+            return
+        }
+        guard GetLastError() == ERROR_IO_INCOMPLETE else {
+            // `ERROR_OPERATION_ABORTED`, `ERROR_BROKEN_PIPE`, or any other
+            // terminal status: the operation is done and the buffer is idle.
+            return
+        }
+
+        // The write is still pending. Returning now would let `span`'s storage
+        // and `overlapped` go out of scope while the kernel is still reading
+        // the former and poised to write the latter, so cancel this specific
+        // operation and block until it has fully unwound.
+        //
+        // With `overlapped.hEvent` `NULL`, the wait below falls back to
+        // signaling on `handle` itself. Microsoft discourages that only because
+        // a handle carrying several concurrent overlapped operations can't
+        // disambiguate which one completed. This handle never does that: stdin
+        // is write-only and writes on it are strictly sequential (the
+        // `StandardInputWriter` actor serializes them), so at most one
+        // operation is in flight, and `WriteFile` resets the handle to
+        // nonsignaled at issue, so no earlier write's signal can satisfy this
+        // wait early. The operation was issued IOCP-bound (its completion must
+        // reach the monitor to yield the byte count), so it cannot carry a
+        // private IOCP-suppressing event the way the drain path's self-issued
+        // read can; it reuses the handle's own signal instead.
+        _ = CancelIoEx(handle, &overlapped)
+        // After this returns (success or abort), the kernel is done reading
+        // `span` and writing `overlapped`. `transferred` is required by the
+        // signature but intentionally unused.
+        _ = GetOverlappedResult(handle, &overlapped, &transferred, true)
     }
 
     /// Reads bytes already buffered in the pipe after the owning process has
@@ -659,12 +726,22 @@ final class AsyncIO: @unchecked Sendable {
 
             do {
                 guard let next = try await signalStream.next() else {
-                    // The signal stream finished while data remained to
-                    // write — typically because `cancelAsyncIO` ran after
-                    // the child exited. Return whatever bytes the call
-                    // already pushed so the caller observes a partial
-                    // write rather than misreading silence as a successful
-                    // zero-byte write.
+                    // `next()` resolved to `nil` because the owning task was
+                    // cancelled on subprocess termination, not because the
+                    // write failed. A `WriteFile` issued above may still be
+                    // pending, with the kernel reading from `span`'s storage
+                    // and poised to write into `overlapped`; both release once
+                    // this call returns and the borrow on `span` ends.
+                    //
+                    // Reconcile it first so neither is freed while the kernel
+                    // is still using it, then return the bytes confirmed
+                    // through the completion port (a partial or zero count;
+                    // recovered bytes are intentionally not folded in; see
+                    // `reconcileWriteOverlappedAfterCancellation()`).
+                    self.reconcileWriteOverlappedAfterCancellation(
+                        handle: handle,
+                        overlapped: &overlapped
+                    )
                     return writtenLength
                 }
                 bytesWritten = next


### PR DESCRIPTION
Follow-up to #325, which fixed a tail-loss bug on the Windows output-capture path where a completed overlapped `ReadFile()` was discarded when child termination cancelled the read.

On Windows, when a subprocess terminates while its standard input is still being written, the write's completion races the cancellation that termination triggers. When the cancellation won, `write(_:to:for:)` observed `nil` from the signal stream and returned the byte count confirmed so far without reconciling a `WriteFile()` that might still be pending. A pending `WriteFile()` is the kernel reading from the caller's borrowed `span` storage and poised to write its result into the stack `overlapped`; both were released once `write(_:to:for:)` returned and the borrow ended, so the kernel could read freed storage or write a freed `overlapped`. Unlike the analogous read-side bug, this had no functional symptom: the bytes were destined for a pipe whose reader (the child process) had already terminated, so no captured output was affected.

On non-Windows platforms the write path writes the file descriptor directly with a synchronous call, retains no reference to the buffer past return, and has no equivalent exposure.

This PR reconciles the overlapped operation before returning on cancellation. A `WriteFile()` that already finished needs nothing, and one still pending (reachable when a byte-mode write is parked on a full pipe buffer at the moment the child stops draining and terminates) is cancelled with `CancelIoEx()` and waited on with `GetOverlappedResult()` before the borrow is released, so the kernel is provably done with both the buffer and `overlapped`. The returned count is deliberately left unchanged; bytes the reconciliation observes as transferred are not folded in, since the pipe's only reader has terminated and nothing will consume them. The read-side counterpart is renamed to `reconcileReadOverlappedAfterCancellation()` for symmetry with the new `reconcileWriteOverlappedAfterCancellation()`.

Note: The same lifetime exposure exists on both read and write when the signal stream throws rather than finishing, where a pending operation's buffer is likewise released without reconciliation. It's symmetric across read and write, so I've left it out of scope here and will open a separate PR to fix it.

<details>
<summary>Testing and documentation</summary>

Unlike #325, this bug produces no observable behavioral difference: correct output is unaffected, and the returned count is intentionally identical with or without the fix. As far as I can tell, no functional test can guard it since there's nothing to assert. The defect is a borrow-contract violation that would manifest as memory corruption only under a checking allocator with heap reuse landing in the freed window, which isn't a clean assertion.

Below is documentation upon which this fix depends:

- [Ownership of the output buffer during a write operation](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile#remarks):

> [The output] buffer must remain valid for the duration of the write operation. The caller must not use this buffer until the write operation is completed. ... Accessing the output buffer while a write operation is using the buffer may lead to corruption of the data written from that buffer. Applications must not write to, reallocate, or free the output buffer that a write operation is using until the write operation completes.

> Because the write operation starts at the offset that is specified in the [`OVERLAPPED`](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped) structure, and `WriteFile` may return before the system-level write operation is complete (write pending), neither the offset nor any other part of the structure should be modified, freed, or reused by the application until the event is signaled (that is, the write completes).

- [Setting the file handle to nonsignaled/signaled](https://learn.microsoft.com/en-us/windows/win32/fileio/synchronous-and-asynchronous-i-o#synchronous-and-asynchronous-io-considerations):

> Each time an I/O operation is started, the operating system sets the file handle to the nonsignaled state. Each time an I/O operation is completed, the operating system sets the file handle to the signaled state. 

- [`GetOverlappedResult()` `NULL` `hEvent` fallback to file handle](https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresult#remarks):

> If the hEvent member of the [`OVERLAPPED`](https://learn.microsoft.com/en-us/windows/desktop/api/minwinbase/ns-minwinbase-overlapped) structure is `NULL`, the system uses the state of the `hFile` handle to signal when the operation has been completed. Use of file, named pipe, or communications-device handles for this purpose is discouraged. It is safer to use an event object because of the confusion that can occur when multiple simultaneous overlapped operations are performed on the same file, named pipe, or communications device. In this situation, there is no way to know which operation caused the object's state to be signaled.

- [Byte-mode blocking writes pend on a full buffer](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-type-read-and-wait-modes#wait-mode):

> With a blocking-wait handle, the write operation cannot succeed until sufficient space is created in the buffer by a thread reading from the other end of the pipe.

</details>