### PR TITLE
Expand and standardize `Input` and `Output` protocol documentation

### DIFF
--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -38,7 +38,11 @@ import FoundationEssentials
 /// Conform to this protocol and implement ``write(with:)``
 /// to provide a custom input source.
 public protocol InputProtocol: Sendable, ~Copyable {
-    /// Writes the input to the subprocess asynchronously.
+    /// Writes this input source's bytes to the subprocess's standard input.
+    ///
+    /// - Parameter writer: The writer connected to the subprocess's standard
+    ///   input; use it to send the bytes this input source represents.
+    /// - Throws: An error if writing to the subprocess fails.
     func write(with writer: StandardInputWriter) async throws
 }
 
@@ -60,7 +64,12 @@ public struct NoInput: InputProtocol {
         )
     }
 
-    /// Writes the input to the subprocess asynchronously.
+    /// Writes no input to the subprocess.
+    ///
+    /// This method is a no-op. ``NoInput`` redirects the subprocess's standard
+    /// input to the null device, so there is nothing to write here.
+    ///
+    /// - Parameter writer: Ignored; ``NoInput`` has no data to write.
     public func write(with writer: StandardInputWriter) async throws {
         // Intentional no-op
         // NoInput redirects stdin to /dev/null, so there is no
@@ -93,7 +102,14 @@ public struct FileDescriptorInput: InputProtocol {
         )
     }
 
-    /// Writes the input to the subprocess asynchronously.
+    /// Writes no input to the subprocess.
+    ///
+    /// This method is a no-op. ``FileDescriptorInput`` has the subprocess read
+    /// directly from the provided file descriptor, so there is nothing to
+    /// write here.
+    ///
+    /// - Parameter writer: Ignored; ``FileDescriptorInput`` has no data to
+    ///   write.
     public func write(with writer: StandardInputWriter) async throws {
         // Intentional no-op
         // FileDescriptorInput reads from a pre-existing file
@@ -119,7 +135,6 @@ public struct StringInput<
 >: InputProtocol {
     private let string: InputString
 
-    /// Writes the input to the subprocess asynchronously.
     public func write(with writer: StandardInputWriter) async throws {
         guard let array = self.string.byteArray(using: Encoding.self) else {
             return
@@ -136,7 +151,6 @@ public struct StringInput<
 public struct ArrayInput: InputProtocol {
     private let array: [UInt8]
 
-    /// Writes the input to the subprocess asynchronously.
     public func write(with writer: StandardInputWriter) async throws {
         _ = try await writer.write(self.array)
     }
@@ -154,11 +168,14 @@ public struct ArrayInput: InputProtocol {
 /// input through ``Execution/standardInputWriter`` and calls
 /// ``StandardInputWriter/finish()`` to signal end-of-file.
 public struct CustomWriteInput: InputProtocol {
-    /// Writes the input to the subprocess asynchronously.
+    /// Writes no input to the subprocess.
     ///
-    /// This method is a no-op. ``CustomWriteInput`` exposes the
-    /// ``StandardInputWriter`` directly to the body closure, which writes
-    /// to the subprocess.
+    /// This method is a no-op. ``CustomWriteInput`` exposes
+    /// ``StandardInputWriter`` to the body closure, which performs the writes
+    /// instead.
+    ///
+    /// - Parameter writer: Ignored; ``CustomWriteInput`` performs no write
+    ///   here.
     public func write(with writer: StandardInputWriter) async throws {
         // Intentional no-op.
     }

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -26,15 +26,26 @@ public protocol OutputProtocol: Sendable, ~Copyable {
     /// The Swift value this output type produces after collecting subprocess output.
     associatedtype OutputType: Sendable
 
-    /// Converts the output from a span to the expected output type.
+    /// Converts the bytes collected from the subprocess's output stream into
+    /// ``OutputType``.
+    ///
+    /// - Parameter span: The collected output bytes, valid only for the
+    ///   duration of the call.
+    /// - Returns: The converted output value.
+    /// - Throws: An error if the conversion fails.
     func output(from span: RawSpan) throws -> OutputType
 
-    /// The maximum number of bytes to collect.
+    /// The maximum number of bytes to collect from the subprocess's output
+    /// stream.
+    ///
+    /// If the subprocess produces more than this many bytes, `Subprocess`
+    /// throws ``SubprocessError`` with the code
+    /// ``SubprocessError/Code/outputLimitExceeded``.
     var maxSize: Int { get }
 }
 
 extension OutputProtocol {
-    /// The maximum number of bytes to collect.
+    /// The default maximum number of bytes to collect: 128 KB.
     public var maxSize: Int { 128 * 1024 }
 }
 
@@ -43,7 +54,6 @@ extension OutputProtocol {
 /// On Unix-like systems, ``DiscardedOutput`` redirects standard output
 /// to `/dev/null`. On Windows, it redirects to `NUL`.
 public struct DiscardedOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The type for the output.
     public typealias OutputType = Void
 
     internal func createPipe() throws(SubprocessError) -> CreatedPipe {
@@ -68,7 +78,6 @@ public struct DiscardedOutput: OutputProtocol, ErrorOutputProtocol {
 /// You can choose to have the subprocess automatically close
 /// the file descriptor after it launches.
 public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The type for this output.
     public typealias OutputType = Void
 
     private let closeAfterSpawningProcess: Bool
@@ -100,12 +109,9 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
 
 /// An output type that collects the subprocess's output as decoded text using the given encoding.
 public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOutputProtocol {
-    /// The type for this output.
     public typealias OutputType = String?
-    /// The maximum number of bytes to collect.
     public let maxSize: Int
 
-    /// Creates a string from a raw span.
     public func output(from span: RawSpan) throws -> String? {
         span.withUnsafeBytes { ptr in
             let array = Array(ptr)
@@ -120,9 +126,7 @@ public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOut
 
 /// An output type that collects the subprocess's output as a byte array.
 public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The output type for this output option.
     public typealias OutputType = [UInt8]
-    /// The maximum number of bytes to collect.
     public let maxSize: Int
 
     internal func captureOutput(
@@ -166,7 +170,6 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
         return result
     }
 
-    /// Creates a byte array from a contiguous region of raw memory.
     public func output(from span: RawSpan) throws -> [UInt8] {
         span.withUnsafeBytes { Array($0) }
     }
@@ -184,7 +187,6 @@ public struct BytesOutput: OutputProtocol, ErrorOutputProtocol {
 /// output by iterating ``Execution/standardOutput`` or
 /// ``Execution/standardError``.
 public struct SequenceOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The output type for this output option.
     public typealias OutputType = Void
 
     internal init() {}
@@ -303,7 +305,6 @@ public protocol ErrorOutputProtocol: OutputProtocol {}
 /// streams together, making it possible to process all subprocess output as a unified
 /// stream rather than handling standard output and standard error separately.
 public struct CombinedErrorOutput: ErrorOutputProtocol {
-    /// The output type for this output option.
     public typealias OutputType = Void
 
     internal init() {}
@@ -420,7 +421,10 @@ extension OutputProtocol where OutputType == Void {
         for processIdentifier: ProcessIdentifier
     ) async throws {}
 
-    /// Converts the output from a raw span to the expected output type.
+    /// Produces no output value, because ``OutputType`` is `Void`.
+    ///
+    /// - Parameter span: Ignored; a `Void` output type has no value to
+    ///   produce.
     public func output(from span: RawSpan) throws {
         // When OutputType is Void, there is no output to process,
         // So this is effectively a no-op.

--- a/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift
@@ -29,8 +29,6 @@ import SystemPackage
 public struct DataInput: InputProtocol {
     private let data: Data
 
-    /// Asynchronously writes the input to the subprocess using the
-    /// write file descriptor.
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         _ = try await writer.write(self.data)
     }
@@ -46,8 +44,6 @@ public struct DataSequenceInput<
 >: InputProtocol where InputSequence.Element == Data {
     private let sequence: InputSequence
 
-    /// Asynchronously writes the input to the subprocess using the
-    /// write file descriptor.
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         var buffer = Data()
         for chunk in self.sequence {
@@ -71,8 +67,6 @@ public struct DataAsyncSequenceInput<
         _ = try await writer.write(chunk)
     }
 
-    /// Asynchronously writes the input to the subprocess using the
-    /// write file descriptor.
     @concurrent
     public func write(with writer: StandardInputWriter) async throws(SubprocessError) {
         do {

--- a/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
+++ b/Sources/Subprocess/SubprocessFoundation/Output+Foundation.swift
@@ -21,12 +21,9 @@ public import FoundationEssentials
 
 /// An output type that collects the subprocess's output as binary data.
 public struct DataOutput: OutputProtocol, ErrorOutputProtocol {
-    /// The output type for this output option.
     public typealias OutputType = Data
-    /// The maximum number of bytes to collect.
     public let maxSize: Int
 
-    /// Creates data from a raw span.
     public func output(from span: RawSpan) throws(SubprocessError) -> Data {
         return Data(span)
     }


### PR DESCRIPTION
Partially-addresses and closes #324.

Several `InputProtocol` and `OutputProtocol` requirements were thinly documented, so a witness page rendered no explanation of its parameter, return type, or throwing behavior.

This PR expands the `write(with:)`, `output(from:)`, and `maxSize` requirements with parameter, return, and throwing documentation, and document the 128 KB default on the `maxSize` default implementation, which previously appeared nowhere. It also removes the redundant per-witness comments so each witness inherits the requirement documentation through DocC. Witnesses whose behavior departs from the contract keep bespoke documentation: the no-op inputs and the `Void` `output(from:)` override.

Documentation builds without errors; inheritance verified on local preview.