### PR TITLE
Narrow `StringOutput.OutputType` to non-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ let result = try await run(
     return lineCount
 }
 
-print(result.closureResult)         // The line count returned from the closure.
-print(result.standardError ?? "")   // The captured standard error.
+print(result.closureResult) // The line count returned from the closure.
+print(result.standardError) // The captured standard error.
 ```
 
 Stream both standard output and standard error, writing to standard input from the same closure:

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -109,10 +109,10 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
 
 /// An output type that collects the subprocess's output as decoded text using the given encoding.
 public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOutputProtocol {
-    public typealias OutputType = String?
+    public typealias OutputType = String
     public let maxSize: Int
 
-    public func output(from span: RawSpan) throws -> String? {
+    public func output(from span: RawSpan) throws -> String {
         span.withUnsafeBytes { ptr in
             let array = Array(ptr)
             return String(decodingBytes: array, as: Encoding.self)

--- a/Tests/SubprocessTests/DarwinTests.swift
+++ b/Tests/SubprocessTests/DarwinTests.swift
@@ -65,9 +65,8 @@ struct SubprocessDarwinTests {
             output: .string(limit: .max)
         )
         #expect(pwdResult.terminationStatus.isSuccess)
-        let currentDir = try #require(
-            pwdResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentDir = pwdResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // On Darwin, /var is linked to /private/var; /tmp is linked /private/tmp
         var expected = FilePath(intendedWorkingDir)
         if expected.starts(with: "/var") || expected.starts(with: "/tmp") {

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -71,8 +71,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         // Windows echo includes quotes
         #expect(output == message)
     }
@@ -116,9 +115,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let maybePath = result.standardOutput?
-            .trimmingNewLineAndQuotes()
-        let path = try #require(maybePath)
+        let path = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(directory(path, isSameAs: expected))
     }
 
@@ -187,7 +184,7 @@ extension SubprocessIntegrationTests {
                 output: .string(limit: 8)
             )
             #expect(first.terminationStatus.isSuccess)
-            #expect(first.standardOutput?.trimmingNewLineAndQuotes() == "FIRST")
+            #expect(first.standardOutput.trimmingNewLineAndQuotes() == "FIRST")
 
             let second = try await Subprocess.run(
                 .name(executableName),
@@ -197,7 +194,7 @@ extension SubprocessIntegrationTests {
                 output: .string(limit: 8)
             )
             #expect(second.terminationStatus.isSuccess)
-            #expect(second.standardOutput?.trimmingNewLineAndQuotes() == "SECOND")
+            #expect(second.standardOutput.trimmingNewLineAndQuotes() == "SECOND")
         }
     }
     #endif
@@ -226,8 +223,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output == message
         )
@@ -259,8 +255,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output == "apple"
         )
@@ -281,7 +276,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
+        let output = result.standardOutput
             .trimmingCharacters(in: .whitespacesAndNewlines)
         #expect(
             output == "Data Content"
@@ -313,7 +308,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        let pathValue = try #require(result.standardOutput)
+        let pathValue = result.standardOutput
         #if os(Windows)
         let expectedPathValue = ProcessInfo.processInfo.environment["Path"] ?? ProcessInfo.processInfo.environment["PATH"] ?? ProcessInfo.processInfo.environment["path"]
         let expected = try #require(expectedPathValue)
@@ -363,8 +358,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output == path
         )
@@ -411,8 +405,7 @@ extension SubprocessIntegrationTests {
         )
         #expect(result.terminationStatus.isSuccess)
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(output == "value")
 
         // Now make sure we can remove `SubprocessTest`
@@ -439,7 +432,7 @@ extension SubprocessIntegrationTests {
         )
         // The new echo/printenv should not find `SubprocessTest`
         #if os(Windows)
-        #expect(result2.standardOutput?.trimmingNewLineAndQuotes() == "%SubprocessTest%")
+        #expect(result2.standardOutput.trimmingNewLineAndQuotes() == "%SubprocessTest%")
         #else
         #expect(result2.terminationStatus == .exited(1))
         #endif
@@ -477,9 +470,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        let output = try #require(
-            result.standardOutput
-        ).trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #if os(Windows)
         // Make sure the newly launched process does
         // NOT have `SystemRoot` in environment
@@ -527,8 +518,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output == customPath
         )
@@ -567,7 +557,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #if os(Windows)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "%REMOVEME%")
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == "%REMOVEME%")
         #else
         #expect(result.terminationStatus == .exited(1))
         #endif
@@ -592,8 +582,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
+        let output = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output == customValue
         )
@@ -640,7 +629,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "testEnvironmentPathWithNonDirectoryPaths")
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == "testEnvironmentPathWithNonDirectoryPaths")
     }
     #endif
 }
@@ -673,9 +662,7 @@ extension SubprocessIntegrationTests {
         // There shouldn't be any other environment variables besides
         // `PATH` that we set
         // https://github.com/swiftlang/swift/issues/77235
-        let output = result.standardOutput?
-            .trimmingNewLineAndQuotes()
-        let path = try #require(output)
+        let path = result.standardOutput.trimmingNewLineAndQuotes()
         #expect(directory(path, isSameAs: workingDirectory))
     }
 
@@ -706,8 +693,7 @@ extension SubprocessIntegrationTests {
         #expect(result.terminationStatus.isSuccess)
         // There shouldn't be any other environment variables besides
         // `PATH` that we set
-        let resultPath = try #require(result.standardOutput)
-            .trimmingNewLineAndQuotes()
+        let resultPath = result.standardOutput.trimmingNewLineAndQuotes()
         #if canImport(Darwin)
         // On Darwin, /var is linked to /private/var; /tmp is linked to /private/tmp
         var expected = workingDirectory
@@ -805,7 +791,7 @@ extension SubprocessIntegrationTests {
         #expect(catResult.terminationStatus.isSuccess)
         // Output should match the input content
         #expect(
-            catResult.standardOutput?.trimmingNewLineAndQuotes() == content
+            catResult.standardOutput.trimmingNewLineAndQuotes() == content
         )
     }
 
@@ -831,7 +817,7 @@ extension SubprocessIntegrationTests {
         #expect(catResult.terminationStatus.isSuccess)
         // Output should match the input content
         #expect(
-            catResult.standardOutput?.trimmingNewLineAndQuotes() == content.trimmingNewLineAndQuotes()
+            catResult.standardOutput.trimmingNewLineAndQuotes() == content.trimmingNewLineAndQuotes()
         )
     }
 
@@ -1061,10 +1047,10 @@ extension SubprocessIntegrationTests {
             error: .string(limit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes().isEmpty == true)
+        #expect(result.standardOutput.trimmingNewLineAndQuotes().isEmpty == true)
         #if !os(Windows)
         // cmd.exe emits an error
-        #expect(result.standardError?.trimmingNewLineAndQuotes().isEmpty == true)
+        #expect(result.standardError.trimmingNewLineAndQuotes().isEmpty == true)
         #endif
     }
 }
@@ -1102,7 +1088,7 @@ extension SubprocessIntegrationTests {
             try await writer.finish()
         }
         #expect(result.terminationStatus.isSuccess)
-        #expect((result.standardOutput ?? "").contains("Hello, world!"))
+        #expect(result.standardOutput.contains("Hello, world!"))
     }
 }
 
@@ -1155,9 +1141,7 @@ extension SubprocessIntegrationTests {
             output: .string(limit: 2048 * 1024, encoding: UTF8.self),
             error: .discarded
         )
-        let output = try #require(
-            catResult.standardOutput?.trimmingNewLineAndQuotes()
-        )
+        let output = catResult.standardOutput.trimmingNewLineAndQuotes()
         #expect(
             output
                 == String(
@@ -1426,9 +1410,7 @@ extension SubprocessIntegrationTests {
             output: .discarded,
             error: .string(limit: 2048 * 1024, encoding: UTF8.self)
         )
-        let output = try #require(
-            catResult.standardError?.trimmingNewLineAndQuotes()
-        )
+        let output = catResult.standardError.trimmingNewLineAndQuotes()
         #expect(
             output
                 == String(
@@ -1779,8 +1761,8 @@ extension SubprocessIntegrationTests {
                 error: .string(limit: 4)
             )
             #expect(result.terminationStatus.isSuccess)
-            #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "x")
-            #expect(result.standardError?.trimmingNewLineAndQuotes() == "y")
+            #expect(result.standardOutput.trimmingNewLineAndQuotes() == "x")
+            #expect(result.standardError.trimmingNewLineAndQuotes() == "y")
         }
     }
 
@@ -1805,8 +1787,8 @@ extension SubprocessIntegrationTests {
                 error: .string(limit: 4)
             )
             #expect(result.terminationStatus.isSuccess)
-            #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "x")
-            #expect(result.standardError?.trimmingNewLineAndQuotes() == "y")
+            #expect(result.standardOutput.trimmingNewLineAndQuotes() == "x")
+            #expect(result.standardError.trimmingNewLineAndQuotes() == "y")
         }
     }
 
@@ -1882,7 +1864,7 @@ extension SubprocessIntegrationTests {
             error: .string(limit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardError?.utf8.count == lineCount * lineWidth)
+        #expect(result.standardError.utf8.count == lineCount * lineWidth)
     }
     #endif
 
@@ -1905,8 +1887,8 @@ extension SubprocessIntegrationTests {
             error: .string(limit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "")
-        #expect(result.standardError?.trimmingNewLineAndQuotes() == "")
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == "")
+        #expect(result.standardError.trimmingNewLineAndQuotes() == "")
     }
 
     @Test func testCustomStreamingBufferSize() async throws {
@@ -1976,7 +1958,7 @@ extension SubprocessIntegrationTests {
             error: .combinedWithOutput
         )
         #expect(result.terminationStatus.isSuccess)
-        let output = try #require(result.standardOutput)
+        let output = result.standardOutput
         #expect(output.contains("Hello Stdout"))
         #expect(output.contains("Hello Stderr"))
     }
@@ -2244,7 +2226,7 @@ extension SubprocessIntegrationTests {
         }
         #expect(result.terminationStatus.isSuccess)
         #expect(result.closureResult == "closure-value")
-        let output = try #require(result.standardOutput)
+        let output = result.standardOutput
         #expect(output.contains("hello"))
     }
 
@@ -2329,7 +2311,7 @@ extension SubprocessIntegrationTests {
         }
         #expect(result.terminationStatus.isSuccess)
         #expect(result.closureResult.contains("Hello Stdout"))
-        let stderr = try #require(result.standardError)
+        let stderr = result.standardError
         #expect(stderr.contains("Hello Stderr"))
     }
 
@@ -2359,7 +2341,7 @@ extension SubprocessIntegrationTests {
         }
         #expect(result.terminationStatus.isSuccess)
         #expect(result.closureResult.contains("Hello Stderr"))
-        let stdout = try #require(result.standardOutput)
+        let stdout = result.standardOutput
         #expect(stdout.contains("Hello Stdout"))
     }
 
@@ -2388,7 +2370,7 @@ extension SubprocessIntegrationTests {
             // Intentionally don't call finish(); run() should do it.
         }
         #expect(result.terminationStatus.isSuccess)
-        let output = try #require(result.standardOutput)
+        let output = result.standardOutput
         #expect(output.contains("hello"))
     }
 }
@@ -2506,7 +2488,7 @@ extension SubprocessIntegrationTests {
         sleepPidToKill = result.closureResult
         #expect(sleepPidToKill != 0)
         #expect(result.terminationStatus == .exited(0))
-        #expect((result.standardOutput ?? "").contains("GO"))
+        #expect(result.standardOutput.contains("GO"))
     }
 
     @Test func testWeDoNotHangIfStandardErrorRemainsOpenButProcessExits() async throws {
@@ -2549,7 +2531,7 @@ extension SubprocessIntegrationTests {
         sleepPidToKill = result.closureResult
         #expect(sleepPidToKill != 0)
         #expect(result.terminationStatus == .exited(0))
-        #expect((result.standardError ?? "").contains("GO"))
+        #expect(result.standardError.contains("GO"))
     }
 }
 #else
@@ -2666,7 +2648,7 @@ extension SubprocessIntegrationTests {
         grandchildPidToKill = result.closureResult
         #expect(grandchildPidToKill != 0)
         #expect(result.terminationStatus == .exited(0))
-        #expect((result.standardOutput ?? "").contains("GO"))
+        #expect(result.standardOutput.contains("GO"))
     }
 
     @Test func testWeDoNotHangIfStandardErrorRemainsOpenButProcessExits() async throws {
@@ -2707,7 +2689,7 @@ extension SubprocessIntegrationTests {
         grandchildPidToKill = result.closureResult
         #expect(grandchildPidToKill != 0)
         #expect(result.terminationStatus == .exited(0))
-        #expect((result.standardError ?? "").contains("GO"))
+        #expect(result.standardError.contains("GO"))
     }
 }
 #endif // !os(Windows)
@@ -3297,7 +3279,7 @@ extension SubprocessIntegrationTests {
                 )
 
                 #expect(result.terminationStatus.isSuccess)
-                #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "APPLE")
+                #expect(result.standardOutput.trimmingNewLineAndQuotes() == "APPLE")
             }
 
             try await group.waitForAll()
@@ -3733,8 +3715,7 @@ extension SubprocessIntegrationTests {
             return execution.processIdentifier.value
         }
         #expect(result.terminationStatus.isSuccess)
-        let reportedPid = try #require(result.standardOutput)
-            .trimmingNewLineAndQuotes()
+        let reportedPid = result.standardOutput.trimmingNewLineAndQuotes()
         #expect("\(result.closureResult)" == reportedPid)
     }
 
@@ -3774,7 +3755,7 @@ extension SubprocessIntegrationTests {
             error: .discarded
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == content)
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == content)
         // The parent retained ownership, so closing here must succeed. If
         // Subprocess had wrongly closed it, this might throw `.badFileDescriptor`.
         try inputFD.close()
@@ -3873,7 +3854,7 @@ extension SubprocessIntegrationTests {
                     output: .string(limit: .max)
                 )
                 precondition(result.terminationStatus.isSuccess)
-                precondition(result.standardOutput?.contains("hello-\(i)") == true)
+                precondition(result.standardOutput.contains("hello-\(i)") == true)
             }
 
             guard let after = openResourceCount() else {

--- a/Tests/SubprocessTests/LinterTests.swift
+++ b/Tests/SubprocessTests/LinterTests.swift
@@ -84,9 +84,10 @@ struct SubprocessLintingTest {
             lintResult.terminationStatus.isSuccess,
             "❌ `swift-format lint --recursive \(sourcePath)` failed"
         )
-        if let error = lintResult.standardError?.trimmingCharacters(
+        let error = lintResult.standardError.trimmingCharacters(
             in: .whitespacesAndNewlines
-        ), !error.isEmpty {
+        )
+        if !error.isEmpty {
             print("\(error)\n")
         } else {
             print("✅ Linting passed")

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -104,15 +104,15 @@ extension SubprocessUnixTests {
             output: .string(limit: .max),
             error: .string(limit: .max),
         )
-        #expect(idResult.terminationStatus.isSuccess, Comment(rawValue: idResult.standardError ?? ""))
-        let ids = try #require(
-            idResult.standardOutput
-        ).split(separator: " ")
+        #expect(idResult.terminationStatus.isSuccess, Comment(rawValue: idResult.standardError))
+        let ids =
+            try idResult
+            .standardOutput.split(separator: " ")
             .map { try #require(gid_t($0.trimmingCharacters(in: .whitespacesAndNewlines))) }
         // id -G includes the effective GID (0 for root) along with
         // supplementary groups, so filter to just the expected range
         let actualGroups = Set(ids.filter { expectedGroups.contains($0) })
-        #expect(actualGroups == expectedGroups, Comment(rawValue: idResult.standardError ?? ""))
+        #expect(actualGroups == expectedGroups, Comment(rawValue: idResult.standardError))
     }
 
     @Test(
@@ -138,9 +138,7 @@ extension SubprocessUnixTests {
             output: .string(limit: .max)
         )
         #expect(psResult.terminationStatus.isSuccess)
-        let resultValue = try #require(
-            psResult.standardOutput
-        )
+        let resultValue = psResult.standardOutput
         let match = try #require(try #/\s*PID\s*PGID\s*(?<pid>[\-]?[0-9]+)\s*(?<pgid>[\-]?[0-9]+)\s*/#.wholeMatch(in: resultValue), "ps output was in an unexpected format:\n\n\(resultValue)")
         // PGID should == PID
         #expect(match.output.pid == match.output.pgid)
@@ -725,9 +723,9 @@ extension SubprocessUnixTests {
             error: .string(limit: .max)
         )
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardError?.trimmingNewLineAndQuotes().isEmpty == true)
+        #expect(result.standardError.trimmingNewLineAndQuotes().isEmpty == true)
         var checklist = Set(openedFileDescriptors)
-        let closeResult = try #require(result.standardOutput)
+        let closeResult = result.standardOutput
             .trimmingNewLineAndQuotes()
             .split(separator: "\n")
         #expect(checklist.count == closeResult.count)
@@ -778,7 +776,7 @@ extension SubprocessUnixTests {
             }
             #expect(readCount == 0)
             #expect(
-                result.standardOutput?.trimmingNewLineAndQuotes() == "wrote into \(testWriteEnd.rawValue), echo exit code 1"
+                result.standardOutput.trimmingNewLineAndQuotes() == "wrote into \(testWriteEnd.rawValue), echo exit code 1"
             )
         }
     }
@@ -880,7 +878,7 @@ extension SubprocessUnixTests {
             output: .string(limit: 32)
         )
         #expect(idResult.terminationStatus.isSuccess)
-        let id = try #require(idResult.standardOutput)
+        let id = idResult.standardOutput
         #expect(
             id.trimmingCharacters(in: .whitespacesAndNewlines) == "\(expected)"
         )
@@ -896,7 +894,7 @@ internal func assertNewSessionCreated<Output: OutputProtocol>(
 ) throws {
     try assertNewSessionCreated(
         terminationStatus: result.terminationStatus,
-        output: #require(result.standardOutput)
+        output: result.standardOutput
     )
 }
 
@@ -922,7 +920,7 @@ internal func assertNewSessionCreated<Output: OutputProtocol>(
     fromProcStat result: ExecutionResult<Void, StringOutput<UTF8>, Output>
 ) throws {
     #expect(result.terminationStatus.isSuccess)
-    let statLine = try #require(result.standardOutput)
+    let statLine = result.standardOutput
     // `comm` can contain spaces and parentheses, so bracket it by the first
     // '(' and the last ')' rather than splitting the whole line on whitespace.
     let openParen = try #require(
@@ -1111,7 +1109,7 @@ extension SubprocessUnixTests {
         try pipe.readEnd.close()
 
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == "hello from parent stdin")
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == "hello from parent stdin")
     }
 }
 
@@ -1158,7 +1156,7 @@ extension SubprocessUnixTests {
         try primary.close()
 
         #expect(result.terminationStatus.isSuccess)
-        #expect(result.standardOutput?.trimmingNewLineAndQuotes() == payload)
+        #expect(result.standardOutput.trimmingNewLineAndQuotes() == payload)
     }
 }
 

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -56,11 +56,10 @@ extension SubprocessWindowsTests {
                 output: .string(limit: .max)
             )
 
-            try withKnownIssue {
+            withKnownIssue {
                 #expect(whoamiResult.terminationStatus.isSuccess)
-                let result = try #require(
-                    whoamiResult.standardOutput
-                ).trimmingCharacters(in: .whitespacesAndNewlines)
+                let result = whoamiResult.standardOutput
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
                 // whoami returns `computerName\userName`.
                 let userInfo = result.split(separator: "\\")
                 guard userInfo.count == 2 else {
@@ -103,9 +102,8 @@ extension SubprocessWindowsTests {
             output: .string(limit: .max)
         )
         #expect(sameConsoleResult.terminationStatus.isSuccess)
-        let sameConsoleValue = try #require(
-            sameConsoleResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let sameConsoleValue = sameConsoleResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // Make sure the child console is same as parent
         #expect(
             "\(intptr_t(bitPattern: parentConsole))" == sameConsoleValue
@@ -123,9 +121,8 @@ extension SubprocessWindowsTests {
             output: .string(limit: .max)
         )
         #expect(differentConsoleResult.terminationStatus.isSuccess)
-        let differentConsoleValue = try #require(
-            differentConsoleResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let differentConsoleValue = differentConsoleResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // Make sure the child console is different from parent
         #expect(
             "\(intptr_t(bitPattern: parentConsole))" != differentConsoleValue
@@ -145,9 +142,8 @@ extension SubprocessWindowsTests {
             output: .string(limit: .max)
         )
         #expect(detachConsoleResult.terminationStatus.isSuccess)
-        let detachConsoleValue = try #require(
-            detachConsoleResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let detachConsoleValue = detachConsoleResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // Detached process should NOT have a console
         #expect(detachConsoleValue.isEmpty)
     }
@@ -169,9 +165,8 @@ extension SubprocessWindowsTests {
             output: .string(limit: .max)
         )
         #expect(newConsoleResult.terminationStatus.isSuccess)
-        let newConsoleValue = try #require(
-            newConsoleResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let newConsoleValue = newConsoleResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // Make sure the child console is different from parent
         #expect(
             "\(intptr_t(bitPattern: parentConsole))" != newConsoleValue
@@ -199,9 +194,8 @@ extension SubprocessWindowsTests {
             output: .string(limit: 32)
         )
         #expect(changeTitleResult.terminationStatus.isSuccess)
-        let newTitle = try #require(
-            changeTitleResult.standardOutput
-        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        let newTitle = changeTitleResult.standardOutput
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         // Make sure the child console is different from parent\
         #expect(newTitle == title)
     }
@@ -251,9 +245,8 @@ extension SubprocessWindowsTests {
                 output: .string(limit: .max)
             )
             #expect(checkResult.terminationStatus.isSuccess)
-            var isSuspended = try #require(
-                checkResult.standardOutput
-            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            var isSuspended = checkResult.standardOutput
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(isSuspended == "true")
 
             // Now resume the process
@@ -268,9 +261,8 @@ extension SubprocessWindowsTests {
                 output: .string(limit: .max)
             )
             #expect(checkResult.terminationStatus.isSuccess)
-            isSuspended = try #require(
-                checkResult.standardOutput
-            ).trimmingCharacters(in: .whitespacesAndNewlines)
+            isSuspended = checkResult.standardOutput
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             #expect(isSuspended == "false")
 
             // Now finally kill the process since it's intentionally hung
@@ -556,7 +548,7 @@ extension SubprocessWindowsTests {
             // ...and its only output is the sentinel (proving the argument was
             // not interpreted as a redirection that swallowed the output).
             #expect(
-                result.standardOutput?.trimmingCharacters(in: .whitespacesAndNewlines) == "RAN",
+                result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines) == "RAN",
                 "Unexpected output for payload \(payload.name)"
             )
             // No injected command ran.


### PR DESCRIPTION
`StringOutput.output(from:)` never returns an optional string, so the associated `OutputType` does not need to be optional. This PR narrows its type to `String`. This is a breaking API change, but one I think is worth landing before 1.0.

The current behavior is that the user always gets a non-optional `String`. Invalid byte sequences are replaced with the Unicode replacement character (U+FFFD), which is the behavior of `String(decoding:as:)` that `output(from:)` already uses via `String(decodingBytes:as:)`. This also makes `StringOutput` consistent with `DataOutput`, whose `OutputType` is non-optional `Data`.

The optional type was introduced in [iCharlesHu/Subprocess/main@`7f9cea8`](https://github.com/iCharlesHu/Subprocess/commit/7f9cea8f5e632f6af33d3fb8006386c582777e35#diff-104673b9ef276affe58f7b7f1b81cf357f8d67a32e1608cc2f969927c170608a) and brought over to this repository in the initial commit. I couldn't find a reason the type was optional. The type permits `nil`, but no code path produces it; if returning `nil` on invalid input is behavior we want, let me know and I'll look into it as a follow-up PR. [`String(validating:as:)`](https://developer.apple.com/documentation/swift/string/init(validating:as:)-84qr9) would be the appropriate API, but it's gated on macOS 15+ (Subprocess supports macOS 13+), so the implementation will require availability-gated fallbacks.