### PR TITLE
deeper curation, revising some wording to less formal structures

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -162,7 +162,7 @@ public func run<
 
 // MARK: - Configuration Based
 
-/// Runs a subprocess with the given configuration and returns the collected output and exit status.
+/// Runs a subprocess with the configuration you provide and returns the collected output and exit status.
 ///
 /// - Parameters:
 ///   - configuration: The configuration to run.
@@ -192,7 +192,7 @@ public func run<
     }
 }
 
-/// Runs a subprocess with the given configuration and returns the collected output and exit status.
+/// Runs a subprocess with the configuration you provide and returns the collected output and exit status.
 ///
 /// - Parameters:
 ///   - configuration: The configuration to run.
@@ -215,7 +215,7 @@ public func run<
     }
 }
 
-/// Runs a subprocess with the given configuration and lets a closure interact with it while it runs.
+/// Runs a subprocess with the configuration you provide and lets a closure interact with it while it runs.
 ///
 /// Use this overload when you need to interact with the subprocess while it runs,
 /// such as streaming its standard output, writing to its standard input, or sending

--- a/Sources/Subprocess/Configuration.swift
+++ b/Sources/Subprocess/Configuration.swift
@@ -329,7 +329,9 @@ public struct Executable: Sendable, Hashable {
 
     /// Locates the executable by name.
     ///
-    /// The subprocess uses the `PATH` value to determine the full path.
+    /// Subprocess searches for the executable by name in the directories listed
+    /// in the `PATH` environment variable, in order, and runs the first match it
+    /// finds. To run an executable at a known location instead, use ``path(_:)``.
     public static func name(_ executableName: String) -> Self {
         return .init(_config: .executable(executableName))
     }
@@ -339,7 +341,7 @@ public struct Executable: Sendable, Hashable {
     public static func path(_ filePath: FilePath) -> Self {
         return .init(_config: .path(filePath))
     }
-    /// Resolves the full executable path using the given environment.
+    /// Resolves the full executable path using the environment you provide.
     public func resolveExecutablePath(in environment: Environment) async throws(SubprocessError) -> FilePath {
         try await runOnBackgroundThread { () throws(SubprocessError) -> FilePath in
             let path = try self.resolveExecutablePath(withPathValue: environment.pathValue())
@@ -380,18 +382,18 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
     internal let storage: [StringOrRawBytes]
     internal let executablePathOverride: StringOrRawBytes?
 
-    /// Creates an arguments value from the given literal values.
+    /// Creates an arguments value from the literal values you provide.
     public init(arrayLiteral elements: String...) {
         self.storage = elements.map { .string($0) }
         self.executablePathOverride = nil
     }
-    /// Creates an arguments value from the given array.
+    /// Creates an arguments value from the array you provide.
     public init(_ array: [String]) {
         self.storage = array.map { .string($0) }
         self.executablePathOverride = nil
     }
 
-    /// Creates an argument list, overriding the first element with the given executable path value.
+    /// Creates an argument list, overriding the first element with the executable path value you provide.
     ///
     /// If `executablePathOverride` is `nil`,
     /// ``Arguments`` automatically uses the executable path
@@ -408,7 +410,7 @@ public struct Arguments: Sendable, ExpressibleByArrayLiteral, Hashable {
         }
     }
     #if !os(Windows) // Windows does not support non-unicode arguments
-    /// Creates an argument list, overriding the first element with the given executable path value.
+    /// Creates an argument list, overriding the first element with the executable path value you provide.
     ///
     /// If `executablePathOverride` is `nil`,
     /// ``Arguments`` automatically uses the executable path
@@ -468,7 +470,7 @@ public struct Environment: Sendable, Hashable {
     public static var inherit: Self {
         return .init(config: .inherit([:]))
     }
-    /// Returns an updated environment with the given overrides applied.
+    /// Returns an updated environment with the overrides you provide applied.
     ///
     /// Keys with `nil` values in `newValue` remove the corresponding entry
     /// from the environment before passing it to the subprocess.

--- a/Sources/Subprocess/Documentation.docc/Subprocess.md
+++ b/Sources/Subprocess/Documentation.docc/Subprocess.md
@@ -1,14 +1,15 @@
 # ``Subprocess``
 
-Subprocess is a cross-platform Swift package for launching subprocesses, 
-built from the ground up with Swift concurrency.
+A cross-platform Swift package for launching subprocesses, built from the 
+ground up with Swift concurrency.
 
 ## Overview
 
 Subprocess centers on a set of `run` functions. Each launches an executable, 
-waits for it to terminate, and returns an ``ExecutionResult`` carrying the 
-process identifier, the ``TerminationStatus``, and whatever output you asked it 
-to collect. The simplest form runs a command and collects its standard output:
+waits for it to terminate, and returns an ``ExecutionResult``. The result 
+carries the process identifier, the ``TerminationStatus``, and whatever output 
+you asked it to collect. The simplest form runs a command and collects its 
+standard output:
 
 ```swift
 import Subprocess
@@ -27,10 +28,9 @@ take a trailing closure: the closure receives an ``Execution`` value you use to
 write to standard input, stream standard output and standard error, and signal 
 or tear down the process.
 
-There are three independent parameters for input, output, and errors, so a 
-single call can mix collecting and streaming. Input, output, and errors conform 
-to ``InputProtocol``, ``OutputProtocol``, or ``ErrorOutputProtocol``, 
-respectively.
+Input, output, and errors are three independent parameters, so a single call 
+can mix collecting and streaming. Each conforms to ``InputProtocol``, 
+``OutputProtocol``, or ``ErrorOutputProtocol``, respectively.
 
 You can read input from a string, an array, a file descriptor, or, in the 
 closure-based API, from the body itself through ``StandardInputWriter``. You 
@@ -59,7 +59,7 @@ dependency.
 
 ## Topics
 
-### Running a Subprocess
+### Running a subprocess
 
 - ``run(_:arguments:environment:workingDirectory:platformOptions:input:output:error:)-(_,_,_,_,_,Input,_,_)``
 - ``run(_:arguments:environment:workingDirectory:platformOptions:input:output:error:)-(_,_,_,_,_,Span<InputElement>,_,_)``
@@ -69,14 +69,14 @@ dependency.
 - ``Environment``
 - ``PlatformOptions``
 
-### Configuring and running a Subprocess
+### Configuring and running a subprocess
 
 - ``run(_:input:output:error:)-(_,Input,_,_)``
 - ``run(_:input:output:error:)-(_,Span<InputElement>,_,_)``
 - ``run(_:input:output:error:body:)``
 - ``Configuration``
 
-### Collecting Output
+### Collecting output
 
 - ``OutputProtocol``
 - ``DiscardedOutput``
@@ -85,17 +85,17 @@ dependency.
 - ``FileDescriptorOutput``
 - ``DataOutput``
 
-### Streaming Output
+### Streaming output
 
 - ``SequenceOutput``
 - ``SubprocessOutputSequence``
 
-### Redirecting Standard Error
+### Redirecting standard error
 
 - ``ErrorOutputProtocol``
 - ``CombinedErrorOutput``
 
-### Providing Input
+### Providing input
 
 - ``InputProtocol``
 - ``NoInput``
@@ -103,26 +103,26 @@ dependency.
 - ``ArrayInput``
 - ``FileDescriptorInput``
 - ``CustomWriteInput``
-- ``StandardInputWriter``
 - ``DataInput``
 - ``DataSequenceInput``
 - ``DataAsyncSequenceInput``
 
-### Interacting with a Running Subprocess
+### Interacting with a running subprocess
 
 - ``Execution``
+- ``StandardInputWriter``
 
-### Inspecting Results
+### Inspecting results
 
 - ``ExecutionResult``
 - ``TerminationStatus``
 - ``ProcessIdentifier``
 
-### Terminating a Subprocess
+### Terminating a subprocess
 
 - ``TeardownStep``
 - ``Signal``
 
-### Handling Errors
+### Handling errors
 
 - ``SubprocessError``

--- a/Sources/Subprocess/Documentation.docc/reference/Arguments.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Arguments.md
@@ -1,0 +1,14 @@
+# ``Arguments``
+
+## Topics
+
+### Creating arguments
+
+- ``init(arrayLiteral:)``
+- ``init(_:)-([String])``
+- ``init(_:)-([[UInt8]])``
+
+### Overriding the executable path
+
+- ``init(executablePathOverride:remainingValues:)-(String?,_)``
+- ``init(executablePathOverride:remainingValues:)-([UInt8]?,_)``

--- a/Sources/Subprocess/Documentation.docc/reference/Buffer.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Buffer.md
@@ -1,0 +1,13 @@
+# ``SubprocessOutputSequence/Buffer``
+
+## Topics
+
+### Inspecting the buffer
+
+- ``count``
+- ``isEmpty``
+
+### Accessing the bytes
+
+- ``bytes``
+- ``withUnsafeBytes(_:)``

--- a/Sources/Subprocess/Documentation.docc/reference/Configuration.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Configuration.md
@@ -1,0 +1,15 @@
+# ``Configuration``
+
+## Topics
+
+### Creating a configuration
+
+- ``init(executable:arguments:environment:workingDirectory:platformOptions:)``
+
+### Configuring the subprocess
+
+- ``executable``
+- ``arguments``
+- ``environment``
+- ``workingDirectory``
+- ``platformOptions``

--- a/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
@@ -1,0 +1,12 @@
+# ``Environment/Key``
+
+## Topics
+
+### Creating a key
+
+- ``init(stringLiteral:)``
+- ``init(rawValue:)``
+
+### Reading the key
+
+- ``rawValue``

--- a/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Environment.Key.md
@@ -5,8 +5,8 @@
 ### Creating a key
 
 - ``init(stringLiteral:)``
+
+### Working with raw values
+
 - ``init(rawValue:)``
-
-### Reading the key
-
 - ``rawValue``

--- a/Sources/Subprocess/Documentation.docc/reference/Environment.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Environment.md
@@ -1,0 +1,17 @@
+# ``Environment``
+
+## Topics
+
+### Creating an environment
+
+- ``inherit``
+- ``custom(_:)-([Environment.Key:String])``
+- ``custom(_:)-([[UInt8]])``
+
+### Modifying an environment
+
+- ``updating(_:)``
+
+### Accessing environment keys
+
+- ``Key``

--- a/Sources/Subprocess/Documentation.docc/reference/ErrorOutputProtocol.md
+++ b/Sources/Subprocess/Documentation.docc/reference/ErrorOutputProtocol.md
@@ -1,0 +1,7 @@
+# ``ErrorOutputProtocol``
+
+## Topics
+
+### Combining standard error with standard output
+
+- ``combinedWithOutput``

--- a/Sources/Subprocess/Documentation.docc/reference/Executable.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Executable.md
@@ -1,0 +1,12 @@
+# ``Executable``
+
+## Topics
+
+### Creating an executable
+
+- ``name(_:)``
+- ``path(_:)``
+
+### Resolving the executable path
+
+- ``resolveExecutablePath(in:)``

--- a/Sources/Subprocess/Documentation.docc/reference/Execution.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Execution.md
@@ -1,0 +1,18 @@
+# ``Execution``
+
+## Topics
+
+### Identifying the subprocess
+
+- ``processIdentifier``
+
+### Accessing standard streams
+
+- ``standardOutput``
+- ``standardError``
+- ``standardInputWriter``
+
+### Controlling the subprocess
+
+- ``send(signal:toProcessGroup:)``
+- ``teardown(using:)``

--- a/Sources/Subprocess/Documentation.docc/reference/ExecutionResult.md
+++ b/Sources/Subprocess/Documentation.docc/reference/ExecutionResult.md
@@ -1,0 +1,18 @@
+# ``ExecutionResult``
+
+## Topics
+
+### Inspecting the outcome
+
+- ``terminationStatus``
+- ``processIdentifier``
+
+### Accessing collected output
+
+- ``standardOutput``
+- ``standardError``
+
+### Retrieving the closure result
+
+- ``closureResult``
+- ``takeClosureResult()``

--- a/Sources/Subprocess/Documentation.docc/reference/InputProtocol.md
+++ b/Sources/Subprocess/Documentation.docc/reference/InputProtocol.md
@@ -1,0 +1,23 @@
+# ``InputProtocol``
+
+## Topics
+
+### Creating an input
+
+- ``string(_:)``
+- ``string(_:using:)``
+- ``array(_:)``
+- ``data(_:)``
+- ``sequence(_:)-4opex``
+- ``sequence(_:)-d1k1``
+- ``fileDescriptor(_:closeAfterSpawningProcess:)``
+- ``none``
+
+### Accessing standard input
+
+- ``standardInput``
+- ``inputWriter``
+
+### Implementing a custom input type
+
+- ``write(with:)``

--- a/Sources/Subprocess/Documentation.docc/reference/OutputProtocol.md
+++ b/Sources/Subprocess/Documentation.docc/reference/OutputProtocol.md
@@ -1,0 +1,26 @@
+# ``OutputProtocol``
+
+## Topics
+
+### Creating an output
+
+- ``string(limit:)``
+- ``string(limit:encoding:)``
+- ``bytes(limit:)``
+- ``data(limit:)``
+- ``fileDescriptor(_:closeAfterSpawningProcess:)``
+- ``discarded``
+- ``sequence``
+
+### Accessing standard streams
+
+- ``standardOutput``
+- ``standardError``
+- ``currentStandardOutput``
+- ``currentStandardError``
+
+### Implementing a custom output type
+
+- ``OutputType``
+- ``output(from:)``
+- ``maxSize``

--- a/Sources/Subprocess/Documentation.docc/reference/PlatformOptions.md
+++ b/Sources/Subprocess/Documentation.docc/reference/PlatformOptions.md
@@ -1,0 +1,44 @@
+# ``PlatformOptions``
+
+## Topics
+
+### Creating platform options
+
+- ``init()``
+
+### Setting user and group identity
+
+- ``userID``
+- ``groupID``
+- ``supplementaryGroups``
+
+### Configuring the process group
+
+- ``processGroupID``
+- ``createSession``
+
+### Setting quality of service
+
+- ``qualityOfService``
+- ``QualityOfService``
+
+### Tearing down the subprocess
+
+- ``teardownSequence``
+
+### Customizing process launching
+
+- ``preSpawnProcessConfigurator``
+
+### Configuring the console and window on Windows
+
+- ``consoleBehavior``
+- ``ConsoleBehavior``
+- ``windowStyle``
+- ``WindowStyle``
+- ``createProcessGroup``
+
+### Setting user credentials on Windows
+
+- ``UserCredentials``
+

--- a/Sources/Subprocess/Documentation.docc/reference/ProcessIdentifier.md
+++ b/Sources/Subprocess/Documentation.docc/reference/ProcessIdentifier.md
@@ -1,0 +1,11 @@
+# ``ProcessIdentifier``
+
+## Topics
+
+### Creating a process identifier
+
+- ``init(value:)``
+
+### Reading the identifier
+
+- ``value``

--- a/Sources/Subprocess/Documentation.docc/reference/Signal.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Signal.md
@@ -1,0 +1,31 @@
+# ``Signal``
+
+## Topics
+
+### Terminating a process
+
+- ``terminate``
+- ``kill``
+- ``interrupt``
+- ``quit``
+
+### Controlling execution
+
+- ``suspend``
+- ``resume``
+
+### Responding to terminal events
+
+- ``terminalClosed``
+- ``windowSizeChange``
+
+### Sending alarm and user-defined signals
+
+- ``alarm``
+- ``userDefinedOne``
+- ``userDefinedTwo``
+
+### Creating a signal
+
+- ``init(rawValue:)``
+- ``rawValue``

--- a/Sources/Subprocess/Documentation.docc/reference/Signal.md
+++ b/Sources/Subprocess/Documentation.docc/reference/Signal.md
@@ -25,7 +25,7 @@
 - ``userDefinedOne``
 - ``userDefinedTwo``
 
-### Creating a signal
+### Working with raw values
 
 - ``init(rawValue:)``
 - ``rawValue``

--- a/Sources/Subprocess/Documentation.docc/reference/StandardInputWriter.md
+++ b/Sources/Subprocess/Documentation.docc/reference/StandardInputWriter.md
@@ -1,0 +1,21 @@
+# ``StandardInputWriter``
+
+## Topics
+
+### Writing bytes
+
+- ``write(_:)-([UInt8])``
+- ``write(_:)-(RawSpan)``
+- ``write(_:)-(Data)``
+
+### Writing strings
+
+- ``write(_:using:)``
+
+### Writing an asynchronous sequence
+
+- ``write(_:)-(AsyncSendableSequence)``
+
+### Finishing input
+
+- ``finish()``

--- a/Sources/Subprocess/Documentation.docc/reference/SubprocessError.Code.md
+++ b/Sources/Subprocess/Documentation.docc/reference/SubprocessError.Code.md
@@ -1,0 +1,21 @@
+# ``SubprocessError/Code``
+
+## Topics
+
+### Locating and launching the executable
+
+- ``executableNotFound``
+- ``spawnFailed``
+- ``failedToChangeWorkingDirectory``
+
+### Communicating with the process
+
+- ``failedToReadFromSubprocess``
+- ``failedToWriteToSubprocess``
+- ``outputLimitExceeded``
+
+### Monitoring the process
+
+- ``failedToMonitorProcess``
+- ``processControlFailed``
+- ``asyncIOFailed``

--- a/Sources/Subprocess/Documentation.docc/reference/SubprocessError.WindowsError.md
+++ b/Sources/Subprocess/Documentation.docc/reference/SubprocessError.WindowsError.md
@@ -1,0 +1,17 @@
+# ``SubprocessError/WindowsError``
+
+## Topics
+
+### Reading the error value
+
+- ``ntStatus(_:)``
+- ``win32(_:)``
+- ``hresult(_:)``
+- ``cRuntime(_:)``
+
+### Creating an error
+
+- ``init(ntStatus:)``
+- ``init(win32Error:)``
+- ``init(hresult:)``
+- ``init(cRuntimeError:)``

--- a/Sources/Subprocess/Documentation.docc/reference/SubprocessError.md
+++ b/Sources/Subprocess/Documentation.docc/reference/SubprocessError.md
@@ -1,0 +1,16 @@
+# ``SubprocessError``
+
+## Topics
+
+### Inspecting the error
+
+- ``code``
+- ``underlyingError``
+
+### Accessing error codes
+
+- ``Code``
+
+### Inspecting the underlying error on Windows
+
+- ``WindowsError``

--- a/Sources/Subprocess/Documentation.docc/reference/SubprocessOutputSequence.StringSequence.md
+++ b/Sources/Subprocess/Documentation.docc/reference/SubprocessOutputSequence.StringSequence.md
@@ -1,0 +1,13 @@
+# ``SubprocessOutputSequence/StringSequence``
+
+## Topics
+
+### Configuring string decoding
+
+- ``BufferingPolicy``
+- ``Separator``
+
+### Iterating over strings
+
+- ``makeAsyncIterator()``
+- ``AsyncIterator``

--- a/Sources/Subprocess/Documentation.docc/reference/SubprocessOutputSequence.md
+++ b/Sources/Subprocess/Documentation.docc/reference/SubprocessOutputSequence.md
@@ -1,0 +1,18 @@
+# ``SubprocessOutputSequence``
+
+## Topics
+
+### Reading output as strings
+
+- ``strings(separatedBy:bufferingPolicy:)``
+- ``strings(separatedBy:bufferingPolicy:as:)``
+
+### Iterating over output buffers
+
+- ``makeAsyncIterator()``
+- ``Iterator``
+- ``Buffer``
+
+### Decoding output into strings
+
+- ``StringSequence``

--- a/Sources/Subprocess/Documentation.docc/reference/TerminationStatus.md
+++ b/Sources/Subprocess/Documentation.docc/reference/TerminationStatus.md
@@ -1,0 +1,9 @@
+# ``TerminationStatus``
+
+## Topics
+
+### Reading the status
+
+- ``exited(_:)``
+- ``signaled(_:)``
+- ``isSuccess``

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -98,7 +98,7 @@ public struct FileDescriptorOutput: OutputProtocol, ErrorOutputProtocol {
     }
 }
 
-/// An output type that collects the subprocess's output as decoded text using the given encoding.
+/// An output type that collects the subprocess's output as decoded text using the encoding you provide.
 public struct StringOutput<Encoding: Unicode.Encoding>: OutputProtocol, ErrorOutputProtocol {
     /// The type for this output.
     public typealias OutputType = String?
@@ -252,7 +252,7 @@ extension OutputProtocol where Self == StringOutput<UTF8> {
 
 extension OutputProtocol {
     /// Creates a subprocess output that collects output as
-    /// a string using the given encoding, up to `limit` bytes.
+    /// a string using the encoding you provide, up to `limit` bytes.
     ///
     /// The subprocess throws an error if the process
     /// produces more bytes than `limit`.

--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -587,7 +587,7 @@ public struct ProcessIdentifier: Sendable, Hashable {
     /// The platform-specific process identifier value.
     public let value: pid_t
 
-    /// Creates a process identifier with the given value.
+    /// Creates a process identifier with the value you provide.
     public init(value: pid_t) {
         self.value = value
     }

--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -100,7 +100,7 @@ public struct Signal: Hashable, Sendable {
 }
 
 extension Execution {
-    /// Sends the given signal to the subprocess.
+    /// Sends the signal you provide to the subprocess.
     /// - Parameters:
     ///   - signal: The signal to send.
     ///   - shouldSendToProcessGroup: A Boolean value that indicates whether this signal should be sent to

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -609,7 +609,7 @@ internal func reapProcess(
 // MARK: - Subprocess Control
 
 extension Execution {
-    /// Terminates the current subprocess with the given exit code.
+    /// Terminates the current subprocess with the exit code you provide.
     /// - Parameters:
     ///   - exitCode: The exit code to use for the subprocess.
     ///   - toProcessGroup: When `true`, terminates the subprocess and everything

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -142,7 +142,7 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
         )
     }
 
-    /// Splits the buffer into strings with the given encoding
+    /// Splits the buffer into strings with the encoding you provide
     /// and separator.
     ///
     /// The separator characters are not included in the returned strings,


### PR DESCRIPTION
I ran through and assembled a deeper curation , organizing the symbols within all the various types. There's some notable symbols in here for Windows that - without the symbolgraphs from a Windows build - result in DocC warnings (such as building on Darwin or Linux directly) that I'm intentionally leaving in place, in the hopes that we'll have something to help wrangle the multi-platform capture of symbol graphs here in the near-ish future. It falls back reasonably - missing symbols simply don't appear.