### PR TITLE
Fix use-after-free when Windows monitor fails with pending I/O

### DIFF
--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -292,16 +292,24 @@ final class AsyncIO: @unchecked Sendable {
         let bytesRead: DWORD
         do {
             guard let next = try await iterator.next() else {
-                // `next()` resolved to `nil` because the owning task was cancelled
-                // (`group.cancelAll()` on child termination), not because the read
-                // failed. The `ReadFile` issued above may have already completed,
+                // `next()` resolved to `nil` because `group.cancelAll()` on
+                // subprocess termination cancelled the read, not because it
+                // failed. A `ReadFile` issued above may have already completed,
                 // with its bytes sitting in `resultBuffer`. Those bytes have been
                 // pulled out of the pipe, so the post-cancellation drain cannot
                 // recover them: dropping them here loses exactly one buffer.
-                return self.reconcileReadOverlappedAfterCancellation(
+                //
+                // Settle the operation and surface any recovered bytes. On a
+                // byte-mode pipe, a cancelled pending read almost always
+                // reports zero, so the `.read` arm fires only when bytes land
+                // in the narrow window between issue and cancel.
+                let transferred = self.settlePendingOverlapped(
                     handle: handle,
                     overlapped: &overlapped
                 )
+                return transferred > 0
+                    ? .read(Int(truncatingIfNeeded: transferred))
+                    : .finished
             }
             bytesRead = next
         } catch {
@@ -319,153 +327,59 @@ final class AsyncIO: @unchecked Sendable {
         return .read(Int(truncatingIfNeeded: bytesRead))
     }
 
-    /// Reconciles an overlapped `ReadFile` whose awaiting task was cancelled
-    /// before its completion was delivered through the signal stream.
+    /// Drives an overlapped operation to a terminal state and reports the
+    /// bytes it transferred.
     ///
-    /// When the capture task is cancelled, the `ReadFile` this function's caller
-    /// issued is in one of three states, and returning `.finished`
-    /// unconditionally is wrong for two of the three states: for a completed
-    /// read it silently drops the bytes already moved out of the pipe, and for
-    /// a pending read it abandons an operation whose buffer the kernel may still
-    /// be writing into (use-after-free once that buffer goes out of scope). The
-    /// third state, a completed-empty or aborted read, is the one an
-    /// unconditional `.finished` handles correctly. The pending case is reached
-    /// when a surviving launched process holds the write end open and the read is
-    /// parked at cancellation (the same condition as
-    /// `drainBufferedDataAfterCancellation()`).
+    /// This is called on cancellation, when `group.cancelAll()` on child
+    /// termination stops the signal stream from delivering this operation's
+    /// completion. The `ReadFile`/`WriteFile` being reconciled is then in one
+    /// of three states:
     ///
-    /// - Important: `overlapped` must reference the same storage passed to the
-    /// `ReadFile` call, and `resultBuffer` (owned by the caller) must outlive
-    /// this call. On the pending path this function blocks until the cancelled
-    /// read has fully unwound, guaranteeing the kernel is done with both before
-    /// they are freed.
-    private func reconcileReadOverlappedAfterCancellation(
-        handle: HANDLE,
-        overlapped: inout _OVERLAPPED
-    ) -> OverlappedReadOutcome {
-        var transferred: DWORD = 0
-
-        // Did the read already complete?
-        if GetOverlappedResult(handle, &overlapped, &transferred, false) {
-            // Completed. If it carried bytes, they are in `resultBuffer` and must
-            // be surfaced; the drain can't re-read them (already out of pipe).
-            if transferred > 0 {
-                return .read(Int(truncatingIfNeeded: transferred))
-            }
-            // Completed with zero bytes: EOF-like. Let the caller fall through
-            // to the drain (which will see broken pipe/empty and finish).
-            return .finished
-        }
-
-        let gle = GetLastError()
-        if gle == ERROR_IO_INCOMPLETE {
-            // The read is still pending. Returning now would let `resultBuffer`
-            // and `overlapped` go out of scope while the kernel may still write
-            // into them, so cancel this specific operation and block until it
-            // has fully unwound.
-            //
-            // With `overlapped.hEvent` `NULL`, the wait below falls back to
-            // signaling on `handle` itself. Microsoft discourages that only
-            // because a handle carrying several concurrent overlapped
-            // operations can't disambiguate which one completed. This handle
-            // never does: stdout is read-only and reads on it are strictly
-            // sequential (the capture loop awaits each read before issuing the
-            // next), so at most one operation is in flight, and `ReadFile`
-            // resets the handle to nonsignaled at issue, so no prior read's
-            // signal can satisfy this wait early. `drainBufferedDataAfterCancellation()`
-            // issues its own read and can therefore afford a private event with
-            // the IOCP-suppressing low bit; this operation was already issued
-            // IOCP-bound, so it reuses the handle's own signal instead.
-            _ = CancelIoEx(handle, &overlapped)
-            // Wait for the cancelled operation to finish unwinding. After this
-            // returns (success or failure), the kernel is done with the buffer.
-            //
-            // The pipes are byte-mode (`PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT`),
-            // so a read never sits partially filled: it completes the moment any
-            // byte is available, or stays pending with nothing transferred. So
-            // a cancelled pending read almost always reports zero bytes and falls
-            // through to the drain; the `transferred > 0` arm is defensive. It
-            // fires only in the narrow window where the read produces bytes
-            // between the two checks (byte pipes fill from the front, so the
-            // reported count is a contiguous prefix).
-            if GetOverlappedResult(handle, &overlapped, &transferred, true),
-                transferred > 0
-            {
-                return .read(Int(truncatingIfNeeded: transferred))
-            }
-            return .finished
-        }
-
-        // Any other status: no bytes to recover here. The drain handles anything
-        // still buffered.
-        return .finished
-    }
-
-    /// Reconciles an overlapped `WriteFile` whose awaiting task was cancelled
-    /// before its completion was delivered through the signal stream.
+    /// - Already completed: `GetOverlappedResult` reports the outcome
+    ///   immediately, and the returned count reflects what it transferred.
+    /// - Still pending: the kernel is mid-operation against the caller's buffer
+    ///   and `overlapped`. Returning now would let both go out of scope while
+    ///   the kernel still holds them (use-after-free), so this cancels the
+    ///   specific operation and blocks until it has fully unwound.
+    /// - Any other terminal status: the operation is already done and nothing
+    ///   was recovered, so the returned count is zero.
     ///
-    /// On cancellation, the `WriteFile` this function's caller issued is in
-    /// one of three states. If it already finished, the kernel has released
-    /// both the source buffer and `overlapped`, and there is nothing to do. If
-    /// it is still pending, the kernel is reading from the caller's `span`
-    /// storage and will still write the result into `overlapped`; returning
-    /// now would end the borrow on `span` and pop `overlapped` off the stack
-    /// while the kernel is mid-operation (use-after-free of the kernel's read
-    /// source). This cancels that specific operation and blocks until it has
-    /// fully unwound, so both are provably idle before they are freed.
-    ///
-    /// Unlike the read counterpart, this returns nothing. Whatever
-    /// `GetOverlappedResult` reports as transferred on the cancelled write is
-    /// deliberately not folded into the caller's returned count: cancellation
-    /// here means the only reader of this pipe has terminated, so nothing will
-    /// consume those bytes, and whether any landed before or after the cancel
-    /// is a race upon which the caller cannot act. The count is left as the
-    /// total confirmed through the completion port, truncated by cancellation.
+    /// The blocking wait uses a `NULL` `hEvent`, so `GetOverlappedResult` falls
+    /// back to signaling on `handle` itself. Microsoft discourages that only
+    /// because a handle carrying several concurrent overlapped operations can't
+    /// disambiguate which one completed. These handles never do that: stdout
+    /// and stderr are read-only, and their reads are strictly sequential (the
+    /// capture loop awaits each read before issuing the next); stdin is
+    /// write-only, and its writes are serialized by `StandardInputWriter`. At
+    /// most one operation is ever in flight per handle, and
+    /// `ReadFile`/`WriteFile` reset the handle to nonsignaled at issue, so no
+    /// earlier operation's signal can satisfy this wait early.
     ///
     /// - Important: `overlapped` must reference the same storage passed to the
-    /// `WriteFile` call, and the `span` that call read from must outlive this
-    /// call. On the pending path this function blocks until the cancelled write
-    /// has fully unwound, guaranteeing the kernel is done with both before the
-    /// borrow is released.
-    private func reconcileWriteOverlappedAfterCancellation(
+    ///   originating `ReadFile`/`WriteFile`, and the buffer from which that
+    ///   call read or wrote into must remain alive until this returns. On the
+    ///   pending path this blocks until the cancelled operation has fully
+    ///   unwound, guaranteeing the kernel is done with both before they're freed.
+    /// - Returns: The bytes the operation transferred, as confirmed through
+    ///   `GetOverlappedResult`. Callers that recover data (the read path)
+    ///   surface this count; lifetime-only callers (the write path) discard it.
+    @discardableResult
+    private func settlePendingOverlapped(
         handle: HANDLE,
         overlapped: inout _OVERLAPPED
-    ) {
+    ) -> DWORD {
         var transferred: DWORD = 0
-
-        // Already finished (completed, aborted, or broken pipe)? The kernel
-        // has released the source buffer and `overlapped`; nothing to reclaim.
         if GetOverlappedResult(handle, &overlapped, &transferred, false) {
-            return
+            return transferred
         }
         guard GetLastError() == ERROR_IO_INCOMPLETE else {
-            // `ERROR_OPERATION_ABORTED`, `ERROR_BROKEN_PIPE`, or any other
-            // terminal status: the operation is done and the buffer is idle.
-            return
+            return 0
         }
-
-        // The write is still pending. Returning now would let `span`'s storage
-        // and `overlapped` go out of scope while the kernel is still reading
-        // the former and poised to write the latter, so cancel this specific
-        // operation and block until it has fully unwound.
-        //
-        // With `overlapped.hEvent` `NULL`, the wait below falls back to
-        // signaling on `handle` itself. Microsoft discourages that only because
-        // a handle carrying several concurrent overlapped operations can't
-        // disambiguate which one completed. This handle never does that: stdin
-        // is write-only and writes on it are strictly sequential (the
-        // `StandardInputWriter` actor serializes them), so at most one
-        // operation is in flight, and `WriteFile` resets the handle to
-        // nonsignaled at issue, so no earlier write's signal can satisfy this
-        // wait early. The operation was issued IOCP-bound (its completion must
-        // reach the monitor to yield the byte count), so it cannot carry a
-        // private IOCP-suppressing event the way the drain path's self-issued
-        // read can; it reuses the handle's own signal instead.
         _ = CancelIoEx(handle, &overlapped)
-        // After this returns (success or abort), the kernel is done reading
-        // `span` and writing `overlapped`. `transferred` is required by the
-        // signature but intentionally unused.
-        _ = GetOverlappedResult(handle, &overlapped, &transferred, true)
+        if GetOverlappedResult(handle, &overlapped, &transferred, true) {
+            return transferred
+        }
+        return 0
     }
 
     /// Reads bytes already buffered in the pipe after the owning process has
@@ -733,12 +647,13 @@ final class AsyncIO: @unchecked Sendable {
                     // and poised to write into `overlapped`; both release once
                     // this call returns and the borrow on `span` ends.
                     //
-                    // Reconcile it first so neither is freed while the kernel
-                    // is still using it, then return the bytes confirmed
-                    // through the completion port (a partial or zero count;
-                    // recovered bytes are intentionally not folded in; see
-                    // `reconcileWriteOverlappedAfterCancellation()`).
-                    self.reconcileWriteOverlappedAfterCancellation(
+                    // Settle it first so neither is freed while the kernel is
+                    // still using it, then return the bytes confirmed through
+                    // the completion port. Bytes the settlement observes as
+                    // transferred are intentionally not folded in; the pipe's
+                    // only reader (the subprocess) has terminated, so nothing
+                    // will consume them.
+                    self.settlePendingOverlapped(
                         handle: handle,
                         overlapped: &overlapped
                     )

--- a/Sources/Subprocess/IO/AsyncIO+Windows.swift
+++ b/Sources/Subprocess/IO/AsyncIO+Windows.swift
@@ -313,6 +313,14 @@ final class AsyncIO: @unchecked Sendable {
             }
             bytesRead = next
         } catch {
+            // The signal stream threw, which happens only when the IOCP
+            // monitor hits a fatal `GetQueuedCompletionStatus` error and
+            // finishes every continuation. A `ReadFile` issued above may still
+            // be pending against `resultBuffer`; settle it before the buffer
+            // goes out of scope. Recovered bytes are discarded: this path
+            // rethrows the monitor's failure and returns no output, so nothing
+            // would consume them.
+            self.settlePendingOverlapped(handle: handle, overlapped: &overlapped)
             if let subprocessError = error as? SubprocessError {
                 throw subprocessError
             }
@@ -330,10 +338,11 @@ final class AsyncIO: @unchecked Sendable {
     /// Drives an overlapped operation to a terminal state and reports the
     /// bytes it transferred.
     ///
-    /// This is called on cancellation, when `group.cancelAll()` on child
-    /// termination stops the signal stream from delivering this operation's
-    /// completion. The `ReadFile`/`WriteFile` being reconciled is then in one
-    /// of three states:
+    /// This is called when the signal stream stops delivering this operation's
+    /// completion, either because `group.cancelAll()` on child termination
+    /// cancelled the awaiting task, or because the IOCP monitor finished every
+    /// continuation while reporting a fatal error. The `ReadFile`/`WriteFile`
+    /// being reconciled is then in one of three states:
     ///
     /// - Already completed: `GetOverlappedResult` reports the outcome
     ///   immediately, and the returned count reflects what it transferred.
@@ -354,6 +363,17 @@ final class AsyncIO: @unchecked Sendable {
     /// most one operation is ever in flight per handle, and
     /// `ReadFile`/`WriteFile` reset the handle to nonsignaled at issue, so no
     /// earlier operation's signal can satisfy this wait early.
+    ///
+    /// The handle's own signal driving the wait keeps this correct when the
+    /// trigger is monitor death rather than cancellation. A fatal
+    /// `GetQueuedCompletionStatus` failure breaks the monitor loop and drives
+    /// the `reportError` that finishes this operation's continuation, so the
+    /// monitor is gone by the time this runs. The kernel still sets the file
+    /// handle's signal on completion independently of any IOCP dequeue, so the
+    /// wait resolves without it; the completion port stays open (only
+    /// `shutdown()` closes it), so when the operation is still pending the
+    /// packet the abort enqueues is never dequeued, producing a one-packet
+    /// leak on an already-failed subsystem.
     ///
     /// - Important: `overlapped` must reference the same storage passed to the
     ///   originating `ReadFile`/`WriteFile`, and the buffer from which that
@@ -661,6 +681,12 @@ final class AsyncIO: @unchecked Sendable {
                 }
                 bytesWritten = next
             } catch {
+                // The signal stream threw, which happens only when the IOCP
+                // monitor hits a fatal `GetQueuedCompletionStatus` error and
+                // finishes every continuation. A `WriteFile` issued above may
+                // still be pending against `span`'s storage and `overlapped`;
+                // settle it before the borrow is released.
+                self.settlePendingOverlapped(handle: handle, overlapped: &overlapped)
                 if let subprocessError = error as? SubprocessError {
                     throw subprocessError
                 }


### PR DESCRIPTION
Follow-up to #325 and #336, which fixed the same class of lifetime bug on the Windows read and write cancellation paths. This PR fixes the same bug on the branch where the stream throws an error.

On Windows, `issueAndAwaitRead()` and `write(_:to:for:)` await an overlapped `ReadFile()`/`WriteFile()` completion through the signal stream. When the stream finishes without delivering that completion, both reconcile the pending operation before its buffer is freed. When the stream throws an error, the `catch` branch rethrows with the operation still pending against the caller's buffer: a pending `ReadFile()` is the kernel writing into `resultBuffer`, and a pending `WriteFile()` is the kernel reading from the caller's borrowed `span` and poised to write into the stack `overlapped`. Both are released as the frame unwinds, so the kernel can touch freed storage.

This PR routes both `catch` branches through `settlePendingOverlapped()` before rethrowing, so a pending operation is cancelled with `CancelIoEx()` and waited on with `GetOverlappedResult()` before its buffer goes out of scope. On the thrown-error path the reconciliation provides only lifetime safety; the returned bytes are discarded. The previous `reconcile*` methods are folded into the new method.

The stream throws only when the IOCP monitor finishes every continuation with an error, which it does on a fatal `GetQueuedCompletionStatus()` failure that's neither `ERROR_BROKEN_PIPE` nor `ERROR_OPERATION_ABORTED`. That same failure kills the monitor, so it's already gone by the time the reconciliation runs. The kernel still sets the file handle's signal on completion independently of any IOCP dequeue, so the wait resolves without it; the completion port stays open (only `shutdown()` closes it), so when the operation is still pending the packet the abort enqueues is never dequeued, producing a one-packet leak on an already-failed subsystem.

On non-Windows platforms, the read and write paths issue a synchronous `read()`/`write()` and retain no reference to the buffer across the `await`. The stream can throw, but no operation is pending against a buffer when it does, so there's nothing to reconcile.

<details>
<summary>Testing and documentation</summary>

As with #336, this bug produces no observable behavioral difference to assert against: the returned count and captured output are identical with or without the fix, and the defect would surface only as memory corruption under a checking allocator whose heap reuse lands in the freed window. Forcing the interleaving requires injecting a `GetQueuedCompletionStatus()` failure while an overlapped operation is parked, which has no entry point without a hook in the monitor thread (which isn't suitable to ship, as discussed in #325).

Related documentation:

- [`CancelIoEx()` completion semantics](https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-cancelioex):

> The application must not free or reuse the [`OVERLAPPED`](https://learn.microsoft.com/en-us/windows/desktop/api/minwinbase/ns-minwinbase-overlapped) structure associated with the canceled I/O operations until they have completed. The thread can use the [`GetOverlappedResult`](https://learn.microsoft.com/en-us/windows/desktop/api/ioapiset/nf-ioapiset-getoverlappedresult) function to determine when the I/O operations themselves have been completed.

> For asynchronous operations still pending, the cancel operation will queue an I/O completion packet.

- [`GetOverlappedResult()` `NULL` `hEvent` fallback to file handle](https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresult#remarks):

> If the `hEvent` member of the [`OVERLAPPED`](https://learn.microsoft.com/en-us/windows/desktop/api/minwinbase/ns-minwinbase-overlapped) structure is `NULL`, the system uses the state of the `hFile` handle to signal when the operation has been completed. Use of file, named pipe, or communications-device handles for this purpose is discouraged. It is safer to use an event object because of the confusion that can occur when multiple simultaneous overlapped operations are performed on the same file, named pipe, or communications device. In this situation, there is no way to know which operation caused the object's state to be signaled.

- [Setting the file handle to nonsignaled/signaled](https://learn.microsoft.com/en-us/windows/win32/fileio/synchronous-and-asynchronous-i-o#synchronous-and-asynchronous-io-considerations):

> Each time an I/O operation is started, the operating system sets the file handle to the nonsignaled state. Each time an I/O operation is completed, the operating system sets the file handle to the signaled state.

</details>