### PR TITLE
Call `setgid()` before `setuid()` in the spawned subprocess

### DIFF
--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -207,14 +207,17 @@ static int _subprocess_spawn_prefork(
             }
         }
 
-        if (uid != NULL) {
-            if (setuid(*uid) != 0) {
+        // Drop the group before the user. setuid() to a non-root uid clears
+        // the capabilities/privileges, so a following setgid() would fail
+        // with EPERM. https://github.com/swiftlang/swift-subprocess/issues/342
+        if (gid != NULL) {
+            if (setgid(*gid) != 0) {
                 write_error_and_exit;
             }
         }
 
-        if (gid != NULL) {
-            if (setgid(*gid) != 0) {
+        if (uid != NULL) {
+            if (setuid(*uid) != 0) {
                 write_error_and_exit;
             }
         }
@@ -679,14 +682,17 @@ int _subprocess_fork_exec(
             }
         }
 
-        if (uid != NULL) {
-            if (setuid(*uid) != 0) {
+        // Drop the group before the user. setuid() to a non-root uid clears
+        // the capabilities/privileges, so a following setgid() would fail
+        // with EPERM. https://github.com/swiftlang/swift-subprocess/issues/342
+        if (gid != NULL) {
+            if (setgid(*gid) != 0) {
                 write_error_and_exit;
             }
         }
 
-        if (gid != NULL) {
-            if (setgid(*gid) != 0) {
+        if (uid != NULL) {
+            if (setuid(*uid) != 0) {
                 write_error_and_exit;
             }
         }

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -86,6 +86,34 @@ extension SubprocessUnixTests {
             "This test requires root privileges"
         )
     )
+    func testSubprocessPlatformOptionsUserAndGroupID() async throws {
+        // setuid() before setgid() clears CAP_SETGID on Linux (and the
+        // saved-set-id privilege on Darwin/BSD), so the following setgid()
+        // fails with EPERM and the spawn fails outright.
+        let expectedUserID = uid_t(Int.random(in: 1000...2000))
+        let expectedGroupID = gid_t(Int.random(in: 2001...3000))
+        var platformOptions = PlatformOptions()
+        platformOptions.userID = expectedUserID
+        platformOptions.groupID = expectedGroupID
+        try await self.assertID(
+            withArgument: "-u",
+            platformOptions: platformOptions,
+            isEqualTo: expectedUserID
+        )
+        try await self.assertID(
+            withArgument: "-g",
+            platformOptions: platformOptions,
+            isEqualTo: expectedGroupID
+        )
+    }
+
+    // Run this test with sudo
+    @Test(
+        .enabled(
+            if: getgid() == 0,
+            "This test requires root privileges"
+        )
+    )
     func testSubprocessPlatformOptionsSupplementaryGroups() async throws {
         var expectedGroups: Set<gid_t> = Set()
         for _ in 0..<Int.random(in: 5...10) {


### PR DESCRIPTION
Closes #342.

Setting both `userID` and `groupID` in `PlatformOptions` currently fails to spawn with `EPERM`.

The subprocess applied `setuid()` before `setgid()`. On Linux, a `setuid()` that lowers a root effective UID sets the real, effective, and saved user IDs all nonzero, and the kernel then clears every capability from the permitted set, so the following `setgid()` failed with `EPERM`. Darwin and the BSDs reach the same failure through the saved-set-ID rules: once `setuid()` moves the effective UID out of the superuser, `setgid()` to an unrelated group is no longer permitted. Any configuration that set both user and group ID therefore could not spawn.

This PR reorders the calls so `setgid()` precedes `setuid()` in both spawn paths.

https://man7.org/linux/man-pages/man2/setuid.2.html
https://man7.org/linux/man-pages/man7/capabilities.7.html
https://man.freebsd.org/cgi/man.cgi?query=setuid&sektion=2