### PR TITLE
Remove deprecated `FileDescriptorOutput` aliases

### DIFF
--- a/Sources/Subprocess/Documentation.docc/reference/OutputProtocol.md
+++ b/Sources/Subprocess/Documentation.docc/reference/OutputProtocol.md
@@ -14,8 +14,6 @@
 
 ### Accessing standard streams
 
-- ``standardOutput``
-- ``standardError``
 - ``currentStandardOutput``
 - ``currentStandardError``
 

--- a/Sources/Subprocess/IO/Output.swift
+++ b/Sources/Subprocess/IO/Output.swift
@@ -219,12 +219,6 @@ extension OutputProtocol where Self == FileDescriptorOutput {
         )
     }
 
-    // TODO: remove for 1.0
-    @available(*, deprecated, renamed: "currentStandardOutput")
-    public static var standardOutput: Self {
-        return currentStandardOutput
-    }
-
     /// Creates a subprocess output that writes to the current process's standard error.
     ///
     /// The file descriptor isn't closed afterward.
@@ -233,12 +227,6 @@ extension OutputProtocol where Self == FileDescriptorOutput {
             .standardError,
             closeAfterSpawningProcess: false
         )
-    }
-
-    // TODO: remove for 1.0
-    @available(*, deprecated, renamed: "currentStandardError")
-    public static var standardError: Self {
-        return currentStandardError
     }
 }
 


### PR DESCRIPTION
The deprecated alias properties are removed leading up to Subprocess 1.0 per the [earlier discussion](https://github.com/swiftlang/swift-subprocess/pull/338#issuecomment-4916700488).