### PR TITLE
Run macOS root tests in separate CI job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -55,6 +55,42 @@ jobs:
         done
         # empty line to ignore the --swift-sdk given by swiftlang/github-workflows/.github/workflows/scripts/install-and-build-with-sdk.sh \
 
+  test_macos_root:
+    name: Test macOS (root)
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app
+      ROOT_SUITE: SubprocessUnixRootTests
+    steps:
+      - name: Remove leftover root build
+        run: sudo -n rm -rf "${GITHUB_WORKSPACE}/.build-root" || true
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Verify passwordless sudo
+        run: |
+          uid="$(sudo -n id -u)" || { echo "::error::passwordless sudo unavailable"; exit 1; }
+          [ "$uid" -eq 0 ] || { echo "::error::sudo did not elevate to root (uid=$uid)"; exit 1; }
+
+      - name: Build root test suite
+        run: sudo -n env DEVELOPER_DIR="$DEVELOPER_DIR" xcrun swift build --build-tests --scratch-path "${GITHUB_WORKSPACE}/.build-root"
+
+      - name: Discover root test suite
+        run: |
+          sudo -n env DEVELOPER_DIR="$DEVELOPER_DIR" xcrun swift test list --scratch-path "${GITHUB_WORKSPACE}/.build-root" > "$RUNNER_TEMP/root-list.txt"
+          count="$(grep -c "${ROOT_SUITE}/" "$RUNNER_TEMP/root-list.txt" || true)"
+          echo "discovered ${count} ${ROOT_SUITE} test(s)"
+          [ "${count:-0}" -ge 1 ] || { echo "::error::${ROOT_SUITE} not found"; cat "$RUNNER_TEMP/root-list.txt"; exit 1; }
+
+      - name: Run root test suite
+        run: sudo -n env DEVELOPER_DIR="$DEVELOPER_DIR" xcrun swift test --scratch-path "${GITHUB_WORKSPACE}/.build-root" --filter "$ROOT_SUITE"
+
+      - name: Clean up root test suite
+        if: always()
+        run: sudo -n rm -rf "${GITHUB_WORKSPACE}/.build-root" || true
+
   test_linux_kernel:
     name: Test Linux Kernel / ${{ matrix.dist-kern }}
     runs-on: ubuntu-latest

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -35,6 +35,13 @@ import SystemPackage
 #endif
 
 @Suite(.serialized)
+struct SubprocessUnixRootTests {
+    init() {
+        _ = globallyIgnoredSIGPIPE
+    }
+}
+
+@Suite(.serialized)
 struct SubprocessUnixTests {
     init() {
         _ = globallyIgnoredSIGPIPE
@@ -42,8 +49,7 @@ struct SubprocessUnixTests {
 }
 
 // MARK: - PlatformOption Tests
-extension SubprocessUnixTests {
-    // Run this test with sudo
+extension SubprocessUnixRootTests {
     @Test(
         .enabled(
             if: getgid() == 0,
@@ -61,7 +67,6 @@ extension SubprocessUnixTests {
         )
     }
 
-    // Run this test with sudo
     @Test(
         .enabled(
             if: getgid() == 0,
@@ -79,7 +84,6 @@ extension SubprocessUnixTests {
         )
     }
 
-    // Run this test with sudo
     @Test(
         .enabled(
             if: getgid() == 0,
@@ -107,7 +111,6 @@ extension SubprocessUnixTests {
         )
     }
 
-    // Run this test with sudo
     @Test(
         .enabled(
             if: getgid() == 0,
@@ -171,7 +174,9 @@ extension SubprocessUnixTests {
         // PGID should == PID
         #expect(match.output.pid == match.output.pgid)
     }
+}
 
+extension SubprocessUnixTests {
     @Test(
         .enabled(
             "This test requires ps (install procps package on Debian or RedHat Linux distros)",
@@ -893,7 +898,7 @@ extension SubprocessUnixTests {
 }
 
 // MARK: - Utils
-extension SubprocessUnixTests {
+extension SubprocessUnixRootTests {
     private func assertID(
         withArgument argument: String,
         platformOptions: PlatformOptions,


### PR DESCRIPTION
Unix tests that require root access are run on Linux and FreeBSD, but are skipped on macOS. This PR adds a new macOS CI job to run only those root tests using `sudo`.

Note: This PR description is a placeholder and will be updated based on the discussion in #345. Passwordless `sudo` isn't available on the self-hosted runner, but it is available on `macos-26`. If we decide to use the hosted-macOS approach, the CI job will be simplified since no cleanup is necessary on the ephemeral runner.

