### PR TITLE
Remove explicit swift-docc-plugin dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,14 +9,6 @@ var dep: [Package.Dependency] = [
         from: "1.5.0"
     )
 ]
-#if !os(Windows)
-dep.append(
-    .package(
-        url: "https://github.com/apple/swift-docc-plugin",
-        from: "1.4.5"
-    ),
-)
-#endif
 
 // Enable SubprocessFoundation by default
 let defaultTraits: Set<String> = ["SubprocessFoundation"]


### PR DESCRIPTION
Nowadays (as weird as it is) projects are not expected to have the dependency declared explicitly. It must be added ad-hoc or by the swift package index. Otherwise all kinds of tools break, including swiftlang/docs.

It would be ideal that all projects can just add the plugin, but that's not the state of the world nowadays.

Meanwhile I did workarounds in adopter projects to unbreak swiftlang/docs building with those added, more details here https://github.com/swiftlang/swift-java/pull/845

cc @heckj

Here's the related swiftpm issue https://github.com/swiftlang/swift-package-manager/issues/10294