### PR TITLE
Rename InInputProtocol.standardInput to currentStandardInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ For the collected-result API, you must specify how to capture standard output.
 | --- | --- |
 | `.none` | No input (default) |
 | `.fileDescriptor(_:closeAfterSpawningProcess:)` | Read from a file descriptor |
-| `.standardInput` | Read from the parent process's standard input |
+| `.currentStandardInput` | Read from the parent process's standard input |
 | `.string(_:)` or `.string(_:using:)` | Read from a string with optional encoding |
 | `.array(_:)` | Read from a `[UInt8]` array |
 | `Span<BitwiseCopyable>` | Read from a span (passed directly as the `input` parameter) |

--- a/Sources/Subprocess/Execution.swift
+++ b/Sources/Subprocess/Execution.swift
@@ -94,7 +94,7 @@ extension Execution where Error == SequenceOutput {
 }
 
 extension Execution {
-    @available(*, unavailable, message: "this property requires that the input is .standardInput")
+    @available(*, unavailable, message: "this property requires that the input is .inputWriter")
     public var standardInputWriter: StandardInputWriter {
         fatalError()
     }

--- a/Sources/Subprocess/IO/Input.swift
+++ b/Sources/Subprocess/IO/Input.swift
@@ -206,7 +206,7 @@ extension InputProtocol where Self == FileDescriptorInput {
     /// Creates a subprocess input that reads from the current process's standard input.
     ///
     /// The file descriptor isn't closed afterward.
-    public static var standardInput: Self {
+    public static var currentStandardInput: Self {
         return Self.fileDescriptor(
             .standardInput,
             closeAfterSpawningProcess: false

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -1130,7 +1130,7 @@ extension SubprocessUnixTests {
         let result = try await Subprocess.run(
             .path("/bin/cat"),
             arguments: [],
-            input: .standardInput,
+            input: .currentStandardInput,
             output: .string(limit: 256),
             error: .discarded
         )


### PR DESCRIPTION
We missed renaming `.standardInput` to `.currentStandardInput` in https://github.com/swiftlang/swift-subprocess/pull/233. Renaming now to keep them consistent.