### PR TITLE
Don't resolve a directory as an executable

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -371,11 +371,11 @@ extension Executable {
         switch self.storage {
         case .executable(let executableName):
             // If the executableName in is already a full path, return it directly
-            if Configuration.pathAccessible(executableName, mode: X_OK) {
+            if Configuration.executableAccessible(executableName) {
                 return executableName
             }
             let firstAccessibleExecutable = possibleExecutablePaths(withPathValue: pathValue)
-                .first { Configuration.pathAccessible($0, mode: X_OK) }
+                .first { Configuration.executableAccessible($0) }
             if let firstAccessibleExecutable {
                 return firstAccessibleExecutable
             }
@@ -467,6 +467,22 @@ extension Configuration {
         return path.withCString {
             return access($0, mode) == 0
         }
+    }
+
+    /// Returns whether `path` refers to a regular file this process may execute.
+    ///
+    /// `access(_:X_OK)` alone is not enough: on a directory the execute bit
+    /// means "searchable", so a directory would otherwise be reported as a
+    /// runnable executable.
+    internal static func executableAccessible(_ path: String) -> Bool {
+        guard Self.pathAccessible(path, mode: X_OK) else {
+            return false
+        }
+        var status = stat()
+        guard path.withCString({ stat($0, &status) == 0 }) else {
+            return false
+        }
+        return (status.st_mode & mode_t(S_IFMT)) == mode_t(S_IFREG)
     }
 }
 

--- a/Sources/Subprocess/Platforms/Subprocess+Windows.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Windows.swift
@@ -230,6 +230,18 @@ extension Configuration {
                     continue
                 }
 
+                // `CreateProcessW` reports ERROR_ACCESS_DENIED when the path
+                // names a directory, so a directory sharing the executable's
+                // name would otherwise fail the spawn outright instead of
+                // falling through to the remaining candidates. A directory is
+                // never runnable, so treat it as a miss. Genuine permission
+                // failures on a real file still throw below.
+                if windowsError == DWORD(ERROR_ACCESS_DENIED),
+                    Configuration.isDirectory(executablePath)
+                {
+                    continue
+                }
+
                 try self.safelyCloseMultiple(
                     inputRead: inputReadFileDescriptor,
                     inputWrite: inputWriteFileDescriptor,
@@ -695,45 +707,79 @@ extension Executable {
     internal func resolveExecutablePath(withPathValue pathValue: String?) throws(SubprocessError) -> String {
         switch self.storage {
         case .executable(let executableName):
-            return try executableName._withCString(
-                encodedAs: UTF16.self
-            ) { exeName throws(SubprocessError) -> String in
-                return try pathValue.withOptionalCString(
-                    encodedAs: UTF16.self
-                ) { path throws(SubprocessError) -> String in
-                    let pathLength = SearchPathW(
-                        path,
-                        exeName,
-                        nil,
-                        0,
-                        nil,
-                        nil
-                    )
-                    guard pathLength > 0 else {
-                        throw SubprocessError.executableNotFound(
-                            executableName,
-                            underlyingError: SubprocessError.WindowsError(win32Error: GetLastError())
-                        )
-                    }
-                    return withUnsafeTemporaryAllocation(
-                        of: WCHAR.self,
-                        capacity: Int(pathLength) + 1
-                    ) {
-                        _ = SearchPathW(
-                            path,
-                            exeName,
-                            nil,
-                            pathLength + 1,
-                            $0.baseAddress,
-                            nil
-                        )
-                        return String(decodingCString: $0.baseAddress!, as: UTF16.self)
-                    }
+            let (searchResult, searchError) = try Self.searchPath(
+                for: executableName,
+                withPathValue: pathValue
+            )
+            if let searchResult {
+                if Configuration.executableAccessible(searchResult) {
+                    return searchResult
+                }
+                // `SearchPathW` matches directories as well as files, and it
+                // stops at its first match with no way to resume, so a
+                // directory named like the executable hides every later
+                // candidate. A directory is never runnable; continue the
+                // search over the candidate paths, which replicate the same
+                // search order, and take the first one that is a real file.
+                let firstAccessibleExecutable = possibleExecutablePaths(withPathValue: pathValue)
+                    .first { Configuration.executableAccessible($0) }
+                if let firstAccessibleExecutable {
+                    return firstAccessibleExecutable
                 }
             }
+            throw SubprocessError.executableNotFound(
+                executableName,
+                underlyingError: SubprocessError.WindowsError(win32Error: searchError)
+            )
         case .path(let executablePath):
             // Use path directly
             return executablePath.string
+        }
+    }
+
+    /// Runs `SearchPathW` for `executableName`, returning the path it matched
+    /// and, when it matched nothing, the reason it reported.
+    ///
+    /// The `withCString` helpers this uses carry a typed `throws`, so this is
+    /// declared throwing even though `SearchPathW` itself reports failure in
+    /// its return value rather than by throwing.
+    private static func searchPath(
+        for executableName: String,
+        withPathValue pathValue: String?
+    ) throws(SubprocessError) -> (path: String?, error: DWORD) {
+        return try executableName._withCString(
+            encodedAs: UTF16.self
+        ) { exeName throws(SubprocessError) -> (String?, DWORD) in
+            return try pathValue.withOptionalCString(
+                encodedAs: UTF16.self
+            ) { path throws(SubprocessError) -> (String?, DWORD) in
+                let pathLength = SearchPathW(
+                    path,
+                    exeName,
+                    nil,
+                    0,
+                    nil,
+                    nil
+                )
+                guard pathLength > 0 else {
+                    return (nil, GetLastError())
+                }
+                let resolved = withUnsafeTemporaryAllocation(
+                    of: WCHAR.self,
+                    capacity: Int(pathLength) + 1
+                ) {
+                    _ = SearchPathW(
+                        path,
+                        exeName,
+                        nil,
+                        pathLength + 1,
+                        $0.baseAddress,
+                        nil
+                    )
+                    return String(decodingCString: $0.baseAddress!, as: UTF16.self)
+                }
+                return (resolved, DWORD(ERROR_FILE_NOT_FOUND))
+            }
         }
     }
 
@@ -1535,10 +1581,26 @@ extension Configuration {
         return quoted
     }
 
-    private static func pathAccessible(_ path: String) -> Bool {
+    /// Returns whether `path` names something this process can execute: it must
+    /// exist, and it must not be a directory.
+    ///
+    /// Existence alone is not enough. Both `SearchPathW` and the
+    /// `CreateProcessW` candidate loop otherwise accept a directory whose name
+    /// matches the executable, and a directory can never be run.
+    internal static func executableAccessible(_ path: String) -> Bool {
         return path.withCString(encodedAs: UTF16.self) {
             let attrs = GetFileAttributesW($0)
             return attrs != INVALID_FILE_ATTRIBUTES
+                && (attrs & DWORD(FILE_ATTRIBUTE_DIRECTORY)) == 0
+        }
+    }
+
+    /// Returns whether `path` exists and is a directory.
+    internal static func isDirectory(_ path: String) -> Bool {
+        return path.withCString(encodedAs: UTF16.self) {
+            let attrs = GetFileAttributesW($0)
+            return attrs != INVALID_FILE_ATTRIBUTES
+                && (attrs & DWORD(FILE_ATTRIBUTE_DIRECTORY)) != 0
         }
     }
 }

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -387,6 +387,117 @@ extension SubprocessUnixTests {
                 "/usr/local/bin/test-bin",
             ])
     }
+
+    /// A `PATH` entry that contains a *directory* whose name matches the
+    /// executable must be skipped: the execute bit on a directory only means
+    /// "searchable", not "runnable".
+    @Test func testNameResolutionSkipsDirectoryInPathEntry() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let shadowDirectory = fixture.appendingPathComponent("shadow")
+            let binDirectory = fixture.appendingPathComponent("bin")
+            try FileManager.default.createDirectory(
+                at: shadowDirectory, withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: binDirectory, withIntermediateDirectories: true
+            )
+            let name = "test-executable-\(UUID().uuidString)"
+            // A directory that shares the executable's name, earlier on PATH
+            try FileManager.default.createDirectory(
+                at: shadowDirectory.appendingPathComponent(name),
+                withIntermediateDirectories: true
+            )
+            let executable = binDirectory.appendingPathComponent(name)
+            try Self.writeExecutableScript(at: executable, echoing: "REAL")
+
+            let environment = Environment.inherit.updating([
+                "PATH": "\(shadowDirectory._fileSystemPath):\(binDirectory._fileSystemPath)"
+            ])
+
+            // Eager resolution
+            let resolved = try await Executable.name(name).resolveExecutablePath(in: environment)
+            #expect(resolved.string == executable._fileSystemPath)
+
+            // Spawn-time resolution
+            let result = try await Subprocess.run(
+                .name(name),
+                environment: environment,
+                output: .string(limit: 16)
+            )
+            #expect(result.terminationStatus.isSuccess)
+            #expect(result.standardOutput.trimmingNewLineAndQuotes() == "REAL")
+        }
+    }
+
+    /// A name that is itself the path of a directory must not resolve to that
+    /// directory, even though the directory is "executable" to `access(X_OK)`.
+    @Test func testNameThatIsADirectoryPathIsNotResolved() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let directory = fixture.appendingPathComponent("test-executable-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            await #expect(throws: SubprocessError.self) {
+                _ = try await Executable.name(directory._fileSystemPath)
+                    .resolveExecutablePath(in: .inherit)
+            }
+        }
+    }
+
+    /// The regular-file requirement must not weaken the permission check: a
+    /// non-executable file that shares the name is still skipped.
+    @Test func testNameResolutionSkipsNonExecutableRegularFile() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let shadowDirectory = fixture.appendingPathComponent("shadow")
+            let binDirectory = fixture.appendingPathComponent("bin")
+            try FileManager.default.createDirectory(
+                at: shadowDirectory, withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: binDirectory, withIntermediateDirectories: true
+            )
+            let name = "test-executable-\(UUID().uuidString)"
+            // A regular file that shares the executable's name but is not
+            // executable, earlier on PATH
+            let shadow = shadowDirectory.appendingPathComponent(name)
+            try Data("not executable".utf8).write(to: shadow)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o644], ofItemAtPath: shadow._fileSystemPath
+            )
+            let executable = binDirectory.appendingPathComponent(name)
+            try Self.writeExecutableScript(at: executable, echoing: "REAL")
+
+            let resolved = try await Executable.name(name).resolveExecutablePath(
+                in: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath):\(binDirectory._fileSystemPath)"
+                ])
+            )
+            #expect(resolved.string == executable._fileSystemPath)
+        }
+    }
+
+    // MARK: Fixture helpers
+
+    /// Creates a unique temporary directory, passes it to `body`, and removes
+    /// it afterwards.
+    private func withExecutableSearchFixture(
+        _ body: (URL) async throws -> Void
+    ) async throws {
+        let fixture = FileManager.default.temporaryDirectory
+            .appendingPathComponent("executable-search-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: fixture, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: fixture) }
+        try await body(fixture)
+    }
+
+    private static func writeExecutableScript(at url: URL, echoing marker: String) throws {
+        try """
+        #!/bin/sh
+        echo "\(marker)"
+        """.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: url._fileSystemPath
+        )
+    }
 }
 
 // MARK: - Misc

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -478,7 +478,8 @@ extension SubprocessUnixTests {
     /// Only a *regular* file can be executed. A FIFO with the execute bit set
     /// satisfies `access(_, X_OK)` and is not a directory, yet `execve` rejects
     /// it with `EACCES`, so it must not shadow the real executable either.
-    @Test func testNameResolutionSkipsNonRegularFile() async throws {
+    @Test(.requiresFIFOCreation)
+    func testNameResolutionSkipsNonRegularFile() async throws {
         try await withExecutableSearchFixture { fixture in
             let shadowDirectory = fixture.appendingPathComponent("shadow")
             let binDirectory = fixture.appendingPathComponent("bin")
@@ -490,7 +491,8 @@ extension SubprocessUnixTests {
             )
             let name = "test-executable-\(UUID().uuidString)"
             let fifo = shadowDirectory.appendingPathComponent(name)
-            try #require(fifo._fileSystemPath.withCString { mkfifo($0, 0o755) } == 0)
+            let result = fifo._fileSystemPath.withCString { mkfifo($0, 0o755) }
+            try #require(result == 0, "mkfifo failed: \(Errno(rawValue: errno))")
             // `mkfifo` honors the umask, so set the execute bits explicitly.
             try FileManager.default.setAttributes(
                 [.posixPermissions: 0o755], ofItemAtPath: fifo._fileSystemPath
@@ -1387,6 +1389,26 @@ extension SubprocessUnixTests {
 
         #expect(result.terminationStatus.isSuccess)
         #expect(result.standardOutput.trimmingNewLineAndQuotes() == payload)
+    }
+}
+
+extension Trait where Self == ConditionTrait {
+    /// Creating a FIFO is not permitted everywhere: on Android `mkfifo` fails
+    /// in the temporary directory, and a sandbox can deny it anywhere.
+    static var requiresFIFOCreation: Self {
+        enabled(
+            "This test requires creating a FIFO in the temporary directory",
+            {
+                let path = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("fifo-probe-\(UUID().uuidString)")
+                    ._fileSystemPath
+                guard path.withCString({ mkfifo($0, 0o600) }) == 0 else {
+                    return false
+                }
+                try? FileManager.default.removeItem(atPath: path)
+                return true
+            }
+        )
     }
 }
 

--- a/Tests/SubprocessTests/UnixTests.swift
+++ b/Tests/SubprocessTests/UnixTests.swift
@@ -475,6 +475,97 @@ extension SubprocessUnixTests {
         }
     }
 
+    /// Only a *regular* file can be executed. A FIFO with the execute bit set
+    /// satisfies `access(_, X_OK)` and is not a directory, yet `execve` rejects
+    /// it with `EACCES`, so it must not shadow the real executable either.
+    @Test func testNameResolutionSkipsNonRegularFile() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let shadowDirectory = fixture.appendingPathComponent("shadow")
+            let binDirectory = fixture.appendingPathComponent("bin")
+            try FileManager.default.createDirectory(
+                at: shadowDirectory, withIntermediateDirectories: true
+            )
+            try FileManager.default.createDirectory(
+                at: binDirectory, withIntermediateDirectories: true
+            )
+            let name = "test-executable-\(UUID().uuidString)"
+            let fifo = shadowDirectory.appendingPathComponent(name)
+            try #require(fifo._fileSystemPath.withCString { mkfifo($0, 0o755) } == 0)
+            // `mkfifo` honors the umask, so set the execute bits explicitly.
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: fifo._fileSystemPath
+            )
+            let executable = binDirectory.appendingPathComponent(name)
+            try Self.writeExecutableScript(at: executable, echoing: "REAL")
+
+            let resolved = try await Executable.name(name).resolveExecutablePath(
+                in: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath):\(binDirectory._fileSystemPath)"
+                ])
+            )
+            #expect(resolved.string == executable._fileSystemPath)
+        }
+    }
+
+    /// Symlinks are resolved, not rejected: the check follows the link with
+    /// `stat` rather than inspecting the link itself, so a symlink to an
+    /// executable on `PATH` still resolves and runs.
+    @Test func testNameResolutionFollowsSymlinkToExecutable() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let binDirectory = fixture.appendingPathComponent("bin")
+            try FileManager.default.createDirectory(
+                at: binDirectory, withIntermediateDirectories: true
+            )
+            let target = fixture.appendingPathComponent("target-\(UUID().uuidString)")
+            try Self.writeExecutableScript(at: target, echoing: "LINKED")
+            let name = "test-executable-\(UUID().uuidString)"
+            let link = binDirectory.appendingPathComponent(name)
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+            let environment = Environment.inherit.updating([
+                "PATH": binDirectory._fileSystemPath
+            ])
+            let resolved = try await Executable.name(name).resolveExecutablePath(in: environment)
+            #expect(resolved.string == link._fileSystemPath)
+
+            let result = try await Subprocess.run(
+                .name(name),
+                environment: environment,
+                output: .string(limit: 16)
+            )
+            #expect(result.standardOutput.trimmingNewLineAndQuotes() == "LINKED")
+        }
+    }
+
+    /// A symlink that points at a *directory* is still a directory, and must be
+    /// skipped like any other.
+    @Test func testNameResolutionSkipsSymlinkToDirectory() async throws {
+        try await withExecutableSearchFixture { fixture in
+            let shadowDirectory = fixture.appendingPathComponent("shadow")
+            let binDirectory = fixture.appendingPathComponent("bin")
+            let target = fixture.appendingPathComponent("target-directory")
+            for directory in [shadowDirectory, binDirectory, target] {
+                try FileManager.default.createDirectory(
+                    at: directory, withIntermediateDirectories: true
+                )
+            }
+            let name = "test-executable-\(UUID().uuidString)"
+            try FileManager.default.createSymbolicLink(
+                at: shadowDirectory.appendingPathComponent(name),
+                withDestinationURL: target
+            )
+            let executable = binDirectory.appendingPathComponent(name)
+            try Self.writeExecutableScript(at: executable, echoing: "REAL")
+
+            let resolved = try await Executable.name(name).resolveExecutablePath(
+                in: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath):\(binDirectory._fileSystemPath)"
+                ])
+            )
+            #expect(resolved.string == executable._fileSystemPath)
+        }
+    }
+
     // MARK: Fixture helpers
 
     /// Creates a unique temporary directory, passes it to `body`, and removes

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -627,6 +627,112 @@ extension SubprocessWindowsTests {
     }
 }
 
+// MARK: - Executable Resolution
+extension SubprocessWindowsTests {
+    /// A `PATH` entry that contains a *directory* whose name matches the
+    /// executable must be skipped. `GetFileAttributesW` succeeds for a
+    /// directory and `SearchPathW` happily matches one, so the real executable
+    /// later on `PATH` would otherwise be shadowed.
+    @Test func testNameResolutionSkipsDirectoryInPathEntry() async throws {
+        try await Self.withExecutableSearchFixture { shadowDirectory, binDirectory, name in
+            // A directory that shares the executable's name, earlier on PATH
+            try FileManager.default.createDirectory(
+                at: shadowDirectory.appendingPathComponent(name),
+                withIntermediateDirectories: true
+            )
+            let executable = binDirectory.appendingPathComponent(name)
+            try Self.copyCmdExe(to: executable)
+
+            let resolved = try await Executable.name(name).resolveExecutablePath(
+                in: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath);\(binDirectory._fileSystemPath)"
+                ])
+            )
+            #expect(Self.isSamePath(resolved.string, executable._fileSystemPath))
+        }
+    }
+
+    /// A name that is itself the path of a directory must not resolve to that
+    /// directory.
+    @Test func testNameThatIsADirectoryPathIsNotResolved() async throws {
+        try await Self.withExecutableSearchFixture { shadowDirectory, _, name in
+            let directory = shadowDirectory.appendingPathComponent(name)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+            await #expect(throws: SubprocessError.self) {
+                _ = try await Executable.name(directory._fileSystemPath)
+                    .resolveExecutablePath(in: .inherit)
+            }
+        }
+    }
+
+    /// The spawn-time candidate loop is only used when argument 0 is
+    /// overridden. `CreateProcessW` fails with ERROR_ACCESS_DENIED on a
+    /// directory, which must not abort the spawn while real candidates remain.
+    @Test func testSpawnSkipsDirectoryCandidateWithArgumentZeroOverride() async throws {
+        try await Self.withExecutableSearchFixture { shadowDirectory, binDirectory, name in
+            try FileManager.default.createDirectory(
+                at: shadowDirectory.appendingPathComponent(name),
+                withIntermediateDirectories: true
+            )
+            try Self.copyCmdExe(to: binDirectory.appendingPathComponent(name))
+
+            let result = try await Subprocess.run(
+                .name(name),
+                arguments: .init(
+                    executablePathOverride: name,
+                    remainingValues: ["/c", "echo REAL"]
+                ),
+                environment: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath);\(binDirectory._fileSystemPath)"
+                ]),
+                output: .string(limit: 32)
+            )
+            #expect(result.terminationStatus.isSuccess)
+            #expect(result.standardOutput.trimmingCharacters(in: .whitespacesAndNewlines) == "REAL")
+        }
+    }
+
+    /// Compares two Windows paths, which may mix `/` and `\` separators and
+    /// differ in case.
+    private static func isSamePath(_ lhs: String, _ rhs: String) -> Bool {
+        func normalized(_ path: String) -> String {
+            path.replacingOccurrences(of: "/", with: "\\")
+        }
+        return normalized(lhs).caseInsensitiveCompare(normalized(rhs)) == .orderedSame
+    }
+
+    /// Creates a throwaway `shadow` and `bin` directory pair plus a unique
+    /// executable name, and removes them afterwards.
+    private static func withExecutableSearchFixture(
+        _ body: (URL, URL, String) async throws -> Void
+    ) async throws {
+        let fixture = URL.temporaryDirectory
+            .appendingPathComponent("executable-search-\(UUID().uuidString)")
+        let shadowDirectory = fixture.appendingPathComponent("shadow")
+        let binDirectory = fixture.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: shadowDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: binDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: fixture) }
+        try await body(shadowDirectory, binDirectory, "test-executable-\(UUID().uuidString).exe")
+    }
+
+    /// Copies `cmd.exe` to `destination` to stand in for an arbitrary
+    /// executable that the tests can both resolve and run.
+    private static func copyCmdExe(to destination: URL) throws {
+        let systemDirectory = try fillNullTerminatedWideStringBuffer(
+            initialSize: DWORD(MAX_PATH),
+            maxSize: DWORD(Int16.max)
+        ) {
+            GetSystemDirectoryW($0.baseAddress, DWORD($0.count))
+        }
+        try FileManager.default.copyItem(
+            at: URL(filePath: systemDirectory).appendingPathComponent("cmd.exe"),
+            to: destination
+        )
+    }
+}
+
 // MARK: - User Utils
 extension SubprocessWindowsTests {
     private func withTemporaryUser(

--- a/Tests/SubprocessTests/WindowsTests.swift
+++ b/Tests/SubprocessTests/WindowsTests.swift
@@ -693,6 +693,45 @@ extension SubprocessWindowsTests {
         }
     }
 
+    /// Reparse points must be classified by what they point at, not rejected
+    /// outright: `GetFileAttributesW` reports `REPARSE_POINT` alone for a file
+    /// symlink but `DIRECTORY|REPARSE_POINT` for a directory symlink or
+    /// junction. So a symlink to an executable still resolves, while one
+    /// pointing at a directory is skipped like any other directory.
+    @Test(.requiresSymbolicLinkPrivilege)
+    func testNameResolutionClassifiesSymlinksByTarget() async throws {
+        try await Self.withExecutableSearchFixture { shadowDirectory, binDirectory, name in
+            let target = binDirectory.appendingPathComponent("target-\(UUID().uuidString).exe")
+            try Self.copyCmdExe(to: target)
+            let targetDirectory = shadowDirectory.appendingPathComponent("target-directory")
+            try FileManager.default.createDirectory(
+                at: targetDirectory, withIntermediateDirectories: true
+            )
+            try FileManager.default.createSymbolicLink(
+                at: shadowDirectory.appendingPathComponent(name),
+                withDestinationURL: targetDirectory
+            )
+            try FileManager.default.createSymbolicLink(
+                at: binDirectory.appendingPathComponent(name),
+                withDestinationURL: target
+            )
+
+            let resolved = try await Executable.name(name).resolveExecutablePath(
+                in: .inherit.updating([
+                    "PATH": "\(shadowDirectory._fileSystemPath);\(binDirectory._fileSystemPath)"
+                ])
+            )
+            // The directory symlink was skipped; the symlink to the executable
+            // resolved without being followed to its target.
+            #expect(
+                Self.isSamePath(
+                    resolved.string,
+                    binDirectory.appendingPathComponent(name)._fileSystemPath
+                )
+            )
+        }
+    }
+
     /// Compares two Windows paths, which may mix `/` and `\` separators and
     /// differ in case.
     private static func isSamePath(_ lhs: String, _ rhs: String) -> Bool {
@@ -1036,6 +1075,40 @@ extension SubprocessWindowsTests {
             }
             state.finishOnce()
         }
+    }
+}
+
+extension Trait where Self == ConditionTrait {
+    /// Creating a symbolic link on Windows requires
+    /// `SeCreateSymbolicLinkPrivilege`, which an unelevated process only holds
+    /// when Developer Mode is enabled.
+    static var requiresSymbolicLinkPrivilege: Self {
+        enabled(
+            "This test requires the privilege to create symbolic links (enable Developer Mode)",
+            {
+                let directory = URL.temporaryDirectory
+                    .appendingPathComponent("symlink-probe-\(UUID().uuidString)")
+                guard
+                    let _ = try? FileManager.default.createDirectory(
+                        at: directory,
+                        withIntermediateDirectories: true
+                    )
+                else {
+                    return false
+                }
+                defer { try? FileManager.default.removeItem(at: directory) }
+                let link = directory.appendingPathComponent("link")
+                do {
+                    try FileManager.default.createSymbolicLink(
+                        at: link,
+                        withDestinationURL: directory
+                    )
+                    return true
+                } catch {
+                    return false
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Problem

Executable resolution accepted candidates that can never be executed, on both platforms, because the "can I run this?" check was really an "does this exist / is it searchable?" check.

**Unix.** `access(_, X_OK)` returns 0 for any directory the process can traverse — on a directory the execute bit means "searchable", not "runnable". Probed on macOS:

```
access("docker", X_OK) = 0      // a directory named `docker`
posix_spawn("docker") -> 13     // EACCES — it was never runnable
```

**Windows.** `GetFileAttributesW` succeeds for a directory, and `SearchPathW` matches directories as well as files. Probed on Windows 11 arm64, with `shadow\` containing directories named `tool` and `tool.exe` and `real\` containing a real `tool.exe`:

```
SearchPathW name="tool"     ext=nil    -> E:\probe\shadow\tool       (a directory)
SearchPathW name="tool"     ext=".exe" -> E:\probe\shadow\tool.exe   (a directory)
SearchPathW name="tool.exe" ext=nil    -> E:\probe\shadow\tool.exe   (a directory)
CreateProcessW lpApplicationName=E:\probe\shadow\tool.exe -> failed: 5 (ERROR_ACCESS_DENIED)
```

Consequences, all reachable today:

- A `PATH` entry containing a `docker/` (or `tool.exe\`) subdirectory shadows the real binary: `resolveExecutablePath(in:)` returns the directory instead of continuing the search.
- The path handed back can then only fail later. On Unix, running it as `.path(...)` produces `Executable "docker" is not found or cannot be executed.`, pointing at the executable name rather than at the directory that actually matched.
- On Windows the spawn-time candidate loop — used when argument 0 is overridden — gets `ERROR_ACCESS_DENIED` from a directory candidate, which is not in its retry set, so it throws `spawnFailed` immediately instead of trying the real executable later in the list.

Two things that are *not* broken, and are therefore untouched here:

- The Unix spawn loops already recover from a directory candidate: `execve` fails with `EACCES`, which is in their retry set.
- `CreateProcessW`'s own search, which the Windows fast path relies on, already skips directories. Verified:
  ```
  CWD = shadow (contains a tool.exe directory), PATH = real (contains a real tool.exe)
  CreateProcessW(nil, "tool.exe") -> created -> E:\probe\real\tool.exe
  CreateProcessW(nil, "tool")     -> created -> E:\probe\real\tool.exe
  ```

## Change

Each platform gets an `executableAccessible(_:)` helper that answers the question the resolver actually needs, and the resolvers use it.

**Unix** (`Subprocess+Unix.swift`) — `Configuration.executableAccessible(_:)` requires a candidate to be a regular file (`S_IFREG`) in addition to being executable, and both candidate checks in `resolveExecutablePath(withPathValue:)` use it. `possibleExecutablePaths(withPathValue:)`, the spawn loops, and `.path(_:)` are untouched.

`mode_t(S_IFMT)` rather than a bare `&`: `st_mode` is `mode_t` (`UInt16` on Darwin, `UInt32` on Linux) while `S_IFMT`/`S_IFREG` are octal integer macros that import as `Int32` on glibc and musl. Confirmed against the musl 1.2.5 SDK headers (`typedef unsigned mode_t;`, `#define S_IFMT 0170000`).

The two checks differ deliberately — regular-file on Unix, not-a-directory on Windows — and both handle symlinks correctly as a result:

- Unix uses `stat`, which follows symlinks, so a link is classified by its target: a link to an executable resolves, a link to a directory is rejected, and a dangling link fails the `access` check. Using `lstat` would break the first of those.
- Requiring a *regular* file also matches what `execve` accepts, so it is not gratuitously stricter than reality. A FIFO with the execute bit set satisfies `access(_, X_OK)` and is not a directory, yet `posix_spawn` rejects it with `EACCES` — "not a directory" would let it through.
- Windows has no `S_IFREG` equivalent, and `GetFileAttributesW` already reports reparse points by what they point at: `REPARSE_POINT` alone for a file symlink, `DIRECTORY|REPARSE_POINT` for a directory symlink *or* a junction. The directory-bit test therefore covers all three, and file symlinks keep resolving and running.

```
Unix    realexe      access(X_OK)= 0  stat S_ISREG=1 S_ISDIR=0
        link-to-exe  access(X_OK)= 0  stat S_ISREG=1 S_ISDIR=0  lstat S_ISLNK=1
        link-to-dir  access(X_OK)= 0  stat S_ISREG=0 S_ISDIR=1  lstat S_ISLNK=1
        dangling     access(X_OK)=-1  stat failed
        myfifo       access(X_OK)= 0  stat S_ISREG=0 S_ISFIFO=1  posix_spawn -> 13 (EACCES)

Windows link-to-exe      -> REPARSE_POINT            CreateProcessW -> created
        link-to-dir      -> DIRECTORY|REPARSE_POINT  CreateProcessW -> 5 (ERROR_ACCESS_DENIED)
        junction-to-dir  -> DIRECTORY|REPARSE_POINT
```

**Windows** (`Subprocess+Windows.swift`) — `Configuration.executableAccessible(_:)` (exists and is not a directory) and `Configuration.isDirectory(_:)` replace the unused private `pathAccessible(_:)`, which checked existence only. Then:

- `resolveExecutablePath(withPathValue:)` rejects a `SearchPathW` match that is a directory. `SearchPathW` stops at its first match and cannot be resumed, so on that outcome it falls back to walking `possibleExecutablePaths(withPathValue:)` — which already replicates `CreateProcessW`'s documented search order — and takes the first candidate that is a real file. Behavior is bit-for-bit unchanged whenever `SearchPathW` matches a file, including the error it reports when it matches nothing. One consequence worth calling out: `SearchPathW` is given the `PATH` value as `lpPath`, so it searches only those directories, whereas `possibleExecutablePaths` also covers the app directory and the current directory. In the directory-match case only, resolution can therefore land on a candidate `SearchPathW` would not have considered. That matches what the spawn path already does on Windows, and it is the search order this file documents; #357 covers whether that order is the one we want.
- the arg0-override spawn loop treats `ERROR_ACCESS_DENIED` as a miss *only when the candidate is a directory*, and tries the next candidate. Genuine permission failures on a real file still throw `spawnFailed` as before.

## Tests

In `SubprocessUnixTests` and `SubprocessWindowsTests`, all `PATH`-based with no dependency on the process's working directory:

| | Unix | Windows |
|---|---|---|
| directory sharing the name, earlier on `PATH`, is skipped in favor of the real executable | `testNameResolutionSkipsDirectoryInPathEntry` (eager + `Subprocess.run`) | `testNameResolutionSkipsDirectoryInPathEntry` |
| a name that is itself a directory path throws instead of resolving | `testNameThatIsADirectoryPathIsNotResolved` | `testNameThatIsADirectoryPathIsNotResolved` |
| a symlink to a directory is skipped, a symlink to an executable resolves | `testNameResolutionSkipsSymlinkToDirectory`, `testNameResolutionFollowsSymlinkToExecutable` | `testNameResolutionClassifiesSymlinksByTarget` |
| the new requirement doesn't weaken the rest of the check | `testNameResolutionSkipsNonExecutableRegularFile`, `testNameResolutionSkipsNonRegularFile` | `testSpawnSkipsDirectoryCandidateWithArgumentZeroOverride` |

Every test above fails before this change and passes after, except `testNameResolutionSkipsNonExecutableRegularFile` and `testNameResolutionFollowsSymlinkToExecutable`, which pass in both states by design: the first guards against the `access` check being replaced by hand-rolled mode-bit logic, the second against `stat` being swapped for `lstat`.

Two tests are gated on a capability probe rather than on a platform check, so they skip cleanly where the environment forbids the setup:

- The Windows symlink test needs `SeCreateSymbolicLinkPrivilege`, which an unelevated process only holds with Developer Mode enabled → `requiresSymbolicLinkPrivilege`. It did run and pass on the machine used here.
- The FIFO test needs `mkfifo` to succeed in the temporary directory, which it does not on Android (CI reported `mkfifo(...) → -1` at the fixture setup) → `requiresFIFOCreation`. Probing the capability also covers sandboxes elsewhere that deny FIFO creation. I confirmed the trait reports the test as *skipped* rather than failed when the probe fails, and that the test target still cross-compiles for `aarch64-unknown-linux-android24`.

On Windows, pre-fix, the failures are exactly as diagnosed:

```
× testNameResolutionSkipsDirectoryInPathEntry — resolved ...\shadow\test-executable-….exe
× testNameThatIsADirectoryPathIsNotResolved  — an error was expected but none was thrown
× testSpawnSkipsDirectoryCandidateWithArgumentZeroOverride — Failed to launch the new process. Underlying error: win32(5)
× testNameResolutionClassifiesSymlinksByTarget — resolved the directory symlink
```

Full suites: **160/160 on macOS 26 arm64**, **139/139 on Windows 11 arm64** (Swift 6.3.2). `swift format lint --strict` clean.

## Not addressed here

Whether `Executable.name(_:)` should consult the current working directory at all is a separate, larger question — the spawn path searches it ahead of `PATH` on both platforms, which contradicts the documented `PATH`-only contract, while the eager API's behavior differs per platform. That is tracked in #357 with measurements from both platforms and the options; this PR deliberately settles none of it, and none of its tests assert anything about the working directory.



