### PR TITLE
Document Darwin SDK requirement in Swift Versions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ The following table maps package releases to their minimum required Swift toolch
 | swift-subprocess 0.2.x | >= Swift 6.1  | >= Xcode 16.3 |
 | swift-subprocess 0.3.x | >= Swift 6.1  | >= Xcode 16.3 |
 | swift-subprocess 0.4.x | >= Swift 6.1  | >= Xcode 16.3 |
+| swift-subprocess 0.5.x | >= Swift 6.2  | >= Xcode 26   |
+| swift-subprocess 1.0.x | >= Swift 6.2  | >= Xcode 26   |
 | main                   | >= Swift 6.2  | >= Xcode 26   |
+
+> [!NOTE]
+> On Darwin, the Xcode column states an SDK requirement as well as a toolchain requirement. Foundation and the other SDK modules come from the active Xcode, so a toolchain installed from swift.org still needs the listed Xcode selected through `xcode-select` or `DEVELOPER_DIR`.
 
 
 ## Feature Overview


### PR DESCRIPTION
The Swift Versions table ends at 0.4.x, so a client on a released 0.5.x or 1.0.x has no row to check. This PR adds explicit rows for both versions, and notes that on Darwin the Xcode column states an SDK requirement rather than only a toolchain one.

Building 1.0.0 with a swift.org 6.3.3 toolchain fails at `Sources/Subprocess/SubprocessFoundation/Input+Foundation.swift:154` with `value of type 'Data' has no member 'bytes'` when an older Xcode is selected, since Foundation comes from the SDK rather than from the toolchain. I tested this on one macos-15 image, holding the OS, the toolchain, and the checkout constant and varying only `DEVELOPER_DIR`: Xcode 16.4 (macOS 15.5 SDK) reproduces the failure and Xcode 26.0.1 (macOS 26.0 SDK) builds clean.

The requirement is build-time only. `Package.swift` declares `.macOS(.v13)`, and that target compiles clean against the macOS 26 SDK with no availability diagnostic, so the accessor back-deploys and a client's deployment target is unaffected.

The requirement didn't change in 1.0. #326 removed the internal `Data.bytes` shim, so `AsyncIO.write(_:to:for:)` now binds to Foundation's accessor; 0.5 declared Xcode 26 but carried the shim and so didn't depend on the macOS 26 SDK. The alternative to documenting this is making that call site SDK-agnostic: every backend already accepts `[UInt8]`, so `self.write(Array(data), ...)` would compile everywhere, at the cost of a full copy of each `Data` written to standard input and of supporting a new-compiler/old-SDK configuration that no CI job covers. I went with documentation since 1.0 requires exactly what the project already stated.

Note: The README in `release/0.5` has the same table, with its `main` row standing in for 0.5's requirement; I can open a follow-up targeting that branch if it's still being patched.

Reported in #363.