### PR TITLE
Fix misreported errno when posix_spawnattr configuration fails on Darwin

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Darwin.swift
@@ -410,7 +410,7 @@ extension Configuration {
 
                     let error: SubprocessError
                     if spawnAttributeError != 0 {
-                        error = SubprocessError.spawnFailed(withUnderlyingError: Errno(rawValue: result))
+                        error = SubprocessError.spawnFailed(withUnderlyingError: Errno(rawValue: spawnAttributeError))
                     } else {
                         error = SubprocessError.failedToChangeWorkingDirectory(
                             self.workingDirectory?.string,


### PR DESCRIPTION
## Summary
- The `spawnAttributeError` branch of `Configuration.spawn` on Darwin reported `Errno(rawValue: result)`, but `result` is left over from the preceding stdin/stdout/stderr `posix_spawn_file_actions_adddup2`/`addclose` setup calls above it, not the actual `posix_spawnattr_setflags`/`posix_spawnattr_setpgroup`/`posix_spawnattr_set_qos_class_np` failure.
- Report `spawnAttributeError` instead, so the underlying error actually reflects why `posix_spawnattr` configuration failed.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes (170 tests)