### PR TITLE
Close .sequence output/error pipes even when the consumer stops early

### DIFF
--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -368,26 +368,25 @@ public func run<
                 outputStream: outputSequence,
                 errorStream: errorSequence
             )
-            defer {
-                // `execution` (and the `.sequence` streams it exposes) is
-                // only valid for the duration of `body`. If `body` returns
-                // or throws without fully draining `outputSequence`/
-                // `errorSequence` -- for example, breaking out of a
-                // `for await` loop early -- their underlying pipe
-                // descriptors are otherwise never closed. `closeIfNeeded()`
-                // is a no-op if the sequence's own iterator already closed
-                // it by reaching end-of-stream.
-                try? outputSequence?.closeIfNeeded()
-                try? errorSequence?.closeIfNeeded()
-            }
             do {
                 resultBox = try await body(execution)
             } catch {
+                // `execution` (and the `.sequence` streams it exposes) is only
+                // valid for the duration of `body`. Close its streams now,
+                // whether or not `body` fully drained them -- for example,
+                // by breaking out of a `for await` loop early -- so their
+                // underlying pipe descriptors aren't leaked. Not a `defer`:
+                // a future asynchronous close implementation needs an async
+                // context, which a `defer` body can't provide.
+                try? outputSequence?.close()
+                try? errorSequence?.close()
                 if Input.self == CustomWriteInput.self {
                     try await writer?.finish()
                 }
                 throw error
             }
+            try? outputSequence?.close()
+            try? errorSequence?.close()
             if Input.self == CustomWriteInput.self {
                 try await writer?.finish()
             }

--- a/Sources/Subprocess/API.swift
+++ b/Sources/Subprocess/API.swift
@@ -368,6 +368,18 @@ public func run<
                 outputStream: outputSequence,
                 errorStream: errorSequence
             )
+            defer {
+                // `execution` (and the `.sequence` streams it exposes) is
+                // only valid for the duration of `body`. If `body` returns
+                // or throws without fully draining `outputSequence`/
+                // `errorSequence` -- for example, breaking out of a
+                // `for await` loop early -- their underlying pipe
+                // descriptors are otherwise never closed. `closeIfNeeded()`
+                // is a no-op if the sequence's own iterator already closed
+                // it by reaching end-of-stream.
+                try? outputSequence?.closeIfNeeded()
+                try? errorSequence?.closeIfNeeded()
+            }
             do {
                 resultBox = try await body(execution)
             } catch {

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -63,11 +63,13 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
         private let processIdentifier: ProcessIdentifier
         private let preferredBufferSize: Int
         private var buffer: [Buffer]
+        private let closeGate: AtomicCounter
 
-        internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
+        internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier, closeGate: AtomicCounter) {
             self.diskIO = diskIO
             self.processIdentifier = processIdentifier
             self.buffer = []
+            self.closeGate = closeGate
             // Only need to query it once at beginning of stream
             self.preferredBufferSize = AsyncIO.queryPipeBufferSize(for: diskIO)
         }
@@ -85,12 +87,16 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
                 upTo: self.preferredBufferSize
             )
             guard let data else {
-                // We finished reading. Close the file descriptor now
-                #if canImport(WinSDK)
-                try _safelyClose(.handle(self.diskIO))
-                #else
-                try _safelyClose(.fileDescriptor(self.diskIO))
-                #endif
+                // We finished reading. Close the file descriptor now, unless
+                // `SubprocessOutputSequence.closeIfNeeded()` already did (see
+                // that method for why both sides can race to close this).
+                if self.closeGate.addOne() == 1 {
+                    #if canImport(WinSDK)
+                    try _safelyClose(.handle(self.diskIO))
+                    #else
+                    try _safelyClose(.fileDescriptor(self.diskIO))
+                    #endif
+                }
                 return nil
             }
             return Buffer(data: data)
@@ -105,11 +111,13 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     private let diskIO: DiskIO
     private let processIdentifier: ProcessIdentifier
     private let state: State
+    private let closeGate: AtomicCounter
 
     internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
         self.diskIO = diskIO
         self.processIdentifier = processIdentifier
         self.state = State()
+        self.closeGate = AtomicCounter()
     }
 
     /// Creates an iterator for this asynchronous sequence.
@@ -120,7 +128,27 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
         guard self.state.initializedCount() == 1 else {
             fatalError("SubprocessOutputSequence is single-pass. It can only be iterated once.")
         }
-        return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier)
+        return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier, closeGate: self.closeGate)
+    }
+
+    /// Closes the underlying descriptor if the iterator hasn't already
+    /// closed it by reaching end-of-stream.
+    ///
+    /// `run` calls this once the body closure that received this sequence
+    /// returns, so a caller that stops consuming the sequence before it
+    /// reaches end-of-stream (for example, `break`ing out of a `for await`
+    /// loop early) doesn't leak the underlying pipe descriptor. Safe to call
+    /// whether or not the sequence was ever iterated, or was fully drained.
+    internal func closeIfNeeded() throws(SubprocessError) {
+        guard self.closeGate.addOne() == 1 else {
+            // The iterator already closed it upon reaching end-of-stream.
+            return
+        }
+        #if canImport(WinSDK)
+        try _safelyClose(.handle(self.diskIO))
+        #else
+        try _safelyClose(.fileDescriptor(self.diskIO))
+        #endif
     }
 
     /// Splits the buffer into strings using the specified separator.

--- a/Sources/Subprocess/SubprocessOutputSequence.swift
+++ b/Sources/Subprocess/SubprocessOutputSequence.swift
@@ -63,13 +63,11 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
         private let processIdentifier: ProcessIdentifier
         private let preferredBufferSize: Int
         private var buffer: [Buffer]
-        private let closeGate: AtomicCounter
 
-        internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier, closeGate: AtomicCounter) {
+        internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
             self.diskIO = diskIO
             self.processIdentifier = processIdentifier
             self.buffer = []
-            self.closeGate = closeGate
             // Only need to query it once at beginning of stream
             self.preferredBufferSize = AsyncIO.queryPipeBufferSize(for: diskIO)
         }
@@ -87,16 +85,11 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
                 upTo: self.preferredBufferSize
             )
             guard let data else {
-                // We finished reading. Close the file descriptor now, unless
-                // `SubprocessOutputSequence.closeIfNeeded()` already did (see
-                // that method for why both sides can race to close this).
-                if self.closeGate.addOne() == 1 {
-                    #if canImport(WinSDK)
-                    try _safelyClose(.handle(self.diskIO))
-                    #else
-                    try _safelyClose(.fileDescriptor(self.diskIO))
-                    #endif
-                }
+                // We finished reading, but don't close the descriptor here:
+                // `run` owns closing it exactly once, at the end of the
+                // scope in which this sequence is valid, whether or not the
+                // sequence was ever iterated or was fully drained. See
+                // `SubprocessOutputSequence.close()`.
                 return nil
             }
             return Buffer(data: data)
@@ -111,13 +104,11 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
     private let diskIO: DiskIO
     private let processIdentifier: ProcessIdentifier
     private let state: State
-    private let closeGate: AtomicCounter
 
     internal init(diskIO: DiskIO, processIdentifier: ProcessIdentifier) {
         self.diskIO = diskIO
         self.processIdentifier = processIdentifier
         self.state = State()
-        self.closeGate = AtomicCounter()
     }
 
     /// Creates an iterator for this asynchronous sequence.
@@ -128,22 +119,18 @@ public struct SubprocessOutputSequence: AsyncSequence, @unchecked Sendable {
         guard self.state.initializedCount() == 1 else {
             fatalError("SubprocessOutputSequence is single-pass. It can only be iterated once.")
         }
-        return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier, closeGate: self.closeGate)
+        return Iterator(diskIO: self.diskIO, processIdentifier: self.processIdentifier)
     }
 
-    /// Closes the underlying descriptor if the iterator hasn't already
-    /// closed it by reaching end-of-stream.
+    /// Closes the underlying descriptor.
     ///
-    /// `run` calls this once the body closure that received this sequence
-    /// returns, so a caller that stops consuming the sequence before it
-    /// reaches end-of-stream (for example, `break`ing out of a `for await`
-    /// loop early) doesn't leak the underlying pipe descriptor. Safe to call
-    /// whether or not the sequence was ever iterated, or was fully drained.
-    internal func closeIfNeeded() throws(SubprocessError) {
-        guard self.closeGate.addOne() == 1 else {
-            // The iterator already closed it upon reaching end-of-stream.
-            return
-        }
+    /// `run` calls this exactly once the body closure that received this
+    /// sequence returns or throws, whether or not the sequence was ever
+    /// iterated, or was fully drained to end-of-stream first. The iterator
+    /// itself never closes the descriptor, so a caller that stops consuming
+    /// the sequence before end-of-stream (for example, `break`ing out of a
+    /// `for await` loop early) doesn't leak it.
+    internal func close() throws(SubprocessError) {
         #if canImport(WinSDK)
         try _safelyClose(.handle(self.diskIO))
         #else

--- a/Tests/SubprocessTests/IntegrationTests.swift
+++ b/Tests/SubprocessTests/IntegrationTests.swift
@@ -3906,6 +3906,72 @@ extension SubprocessIntegrationTests {
             )
         }
     }
+
+    /// Breaking out of a `.sequence` output stream before it reaches
+    /// end-of-stream must not leak the underlying pipe descriptor.
+    @Test func testBreakingOutOfSequenceOutputEarlyDoesNotLeakResources() async throws {
+        await #expect(processExitsWith: .success) {
+            #if os(Windows)
+            let executable: Executable = .name("cmd.exe")
+            func makeArguments(_ i: Int) -> Arguments { ["/c", "echo", "hello-\(i)"] }
+            #else
+            let executable: Executable = .name("echo")
+            func makeArguments(_ i: Int) -> Arguments { ["hello-\(i)"] }
+            #endif
+
+            // Warm up once so lazily-created singletons are allocated before
+            // we sample the baseline.
+            _ = try await Subprocess.run(
+                executable,
+                arguments: makeArguments(0),
+                input: .none,
+                output: .sequence,
+                error: .discarded
+            ) { execution in
+                for try await _ in execution.standardOutput {
+                    break
+                }
+            }
+            guard let before = openResourceCount() else {
+                #if compiler(>=6.3)
+                try Test.cancel("Cannot determine the number of open resources")
+                #else
+                return
+                #endif
+            }
+
+            let iterations = 200
+            for i in 0..<iterations {
+                _ = try await Subprocess.run(
+                    executable,
+                    arguments: makeArguments(i),
+                    input: .none,
+                    output: .sequence,
+                    error: .discarded
+                ) { execution in
+                    for try await _ in execution.standardOutput {
+                        // Stop consuming before end-of-stream, the way an
+                        // application that only wants the first chunk would.
+                        break
+                    }
+                }
+            }
+
+            guard let after = openResourceCount() else {
+                #if compiler(>=6.3)
+                try Test.cancel("Cannot determine the number of open resources")
+                #else
+                return
+                #endif
+            }
+            let delta = after - before
+
+            precondition(
+                delta < iterations,
+                "Subprocess leaked \(delta) resources while breaking out of .sequence output early \(iterations) times."
+            )
+        }
+    }
 }
 #endif // !os(Android)
 


### PR DESCRIPTION
## Summary
- `SubprocessOutputSequence.Iterator` only closed its underlying pipe descriptor when a read returned EOF. If a caller stopped consuming `execution.standardOutput`/`standardError` before reaching end-of-stream -- for example, breaking out of a `for await` loop early -- that read end was never closed. This leaks one fd per invocation, unbounded, with no relationship to how many subprocesses are running concurrently: a long-running process that streams output and doesn't always drain to completion can leak thousands of fds over its lifetime this way.
- Confirmed with a targeted repro before writing the fix: a control group that fully drains `.sequence` output leaked 0 fds over 30 iterations, while a group that broke out after the first chunk leaked exactly 1 fd every single iteration (30/30).
- The iterator itself never closes its descriptor. `run()` is the sole owner of closing each `.sequence` output/error stream, doing so exactly once right after the body closure returns or throws -- whether or not the stream was ever iterated or fully drained. This is done with explicit calls on both the success and thrown-error paths rather than `defer`, so a future asynchronous close implementation (e.g. backed by io_uring) has an async context to run in.

## Test plan
- [x] Added `testBreakingOutOfSequenceOutputEarlyDoesNotLeakResources`, which breaks out of a `.sequence` output stream early across 200 iterations and asserts the process's open fd/handle count doesn't grow unbounded.
- [x] Verified the new test fails without the fix (traps on the leak-detection precondition) and passes with it.
- [x] `swift build` succeeds
- [x] `swift test` passes (171 tests)