### PR TITLE
Fix exit detection for stopped child processes

### DIFF
--- a/Sources/Subprocess/Platforms/Subprocess+Unix.swift
+++ b/Sources/Subprocess/Platforms/Subprocess+Unix.swift
@@ -957,8 +957,8 @@ extension ProcessIdentifier {
     /// Checks whether the process has already exited without consuming the
     /// zombie.
     ///
-    /// Returns `true` if a child has exited (or stopped/continued in a
-    /// way `waitid` reports), `false` if the child is still running.
+    /// Returns `true` only for a terminal exit. Stop and continue notifications
+    /// do not mean the child has exited.
     /// The zombie remains available for a subsequent call to `blockingReap()`.
     internal func peekIfExited() throws(Errno) -> Bool {
         try _peekIfExited(pid: value)
@@ -984,7 +984,15 @@ internal func _peekIfExited(pid: pid_t) throws(Errno) -> Bool {
     // WNOWAIT leaves the zombie in the process table so a subsequent
     // `_blockingReap` (or `_reap`) can still consume it.
     let siginfo = try _waitid(idtype: P_PID, id: id_t(pid), flags: WEXITED | WNOHANG | WNOWAIT)
-    return !(siginfo.si_pid == 0 && siginfo.si_signo == 0)
+    // Darwin can report a pending stop notification even with WEXITED.
+    // Treating every nonempty result as an exit bypasses monitoring and sends
+    // CLD_STOPPED into the terminal-status decoder, which traps.
+    switch siginfo.si_code {
+    case .init(CLD_EXITED), .init(CLD_KILLED), .init(CLD_DUMPED):
+        return true
+    default:
+        return false
+    }
 }
 
 internal func _waitid(idtype: idtype_t, id: id_t, flags: Int32) throws(Errno) -> siginfo_t {

--- a/Tests/SubprocessTests/ProcessMonitoringTests.swift
+++ b/Tests/SubprocessTests/ProcessMonitoringTests.swift
@@ -272,6 +272,76 @@ extension SubprocessProcessMonitoringTests {
     }
 }
 
+#if !os(Windows)
+extension SubprocessProcessMonitoringTests {
+    @Test(.timeLimit(.minutes(1)))
+    func testStoppedChildIsNotReportedAsExited() async throws {
+        var config = self.longRunningProcess(withTimeOutSeconds: 30)
+        config.platformOptions.createSession = true
+        try await withSpawnedExecution(config: config) { execution in
+            let pid = execution.processIdentifier.value
+            defer {
+                // This fixture owns the unreaped child until this scope ends.
+                _ = kill(pid, SIGKILL)
+                var status: Int32 = 0
+                while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
+            }
+            try execution.send(signal: .suspend)
+            try await self.waitUntilStopped(pid)
+            #expect(try !execution.processIdentifier.peekIfExited(),
+                    "A stop notification is not a terminal exit")
+            // Observing an exit must not consume another observer's stop event.
+            var pending = siginfo_t()
+            try #require(waitid(P_PID, id_t(pid), &pending, WSTOPPED | WNOHANG | WNOWAIT) == 0)
+            #expect(pending.si_code == CLD_STOPPED)
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func testMonitoringStoppedChildWaitsForItsFinalExit() async throws {
+        var config = Configuration(
+            executable: .path("/bin/sh"),
+            arguments: ["-c", "kill -STOP $$; exit 42"]
+        )
+        config.platformOptions.createSession = true
+        try await withSpawnedExecution(config: config) { execution in
+            let pid = execution.processIdentifier.value
+            var reaped = false
+            defer {
+                if !reaped {
+                    _ = kill(pid, SIGKILL)
+                    var status: Int32 = 0
+                    while waitpid(pid, &status, 0) == -1 && errno == EINTR {}
+                }
+            }
+            try await self.waitUntilStopped(pid)
+            // The monitor must stay pending until the explicit resume allows exit.
+            let resume = Task {
+                try await Task.sleep(for: .milliseconds(100))
+                try execution.send(signal: .resume)
+            }
+            defer { resume.cancel() }
+            let result = try await monitorProcessTermination(for: execution.processIdentifier)
+            reaped = true
+            try await resume.value
+            #expect(result == .exited(42))
+        }
+    }
+
+    private func waitUntilStopped(_ pid: pid_t) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while ContinuousClock.now < deadline {
+            var info = siginfo_t()
+            try #require(waitid(P_PID, id_t(pid), &info, WSTOPPED | WNOHANG | WNOWAIT) == 0)
+            if info.si_code == CLD_STOPPED { return }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        Issue.record("The fixture did not stop before testing exit observation")
+        throw Errno.timedOut
+    }
+}
+#endif
+
 // MARK: Concurrency Tests
 extension SubprocessProcessMonitoringTests {
     @Test func testCanMonitorProcessConcurrently() async throws {


### PR DESCRIPTION
## Summary

This change makes `_peekIfExited` recognize only terminal child states: `CLD_EXITED`, `CLD_KILLED`, and `CLD_DUMPED`.

It addresses unexpected `waitid` behavior reproduced on macOS 27 beta and macOS 26.6.2: an exit-only query returned a stop notification for a child that was still alive and suspended.

This is proposed as defensive handling of the observed behavior, rather than a claim that the existing condition is incorrect on every platform.

## Expected and observed behavior

For a child suspended with `SIGSTOP`, this call should not report a terminal exit:

```c
waitid(P_PID, child, &info, WEXITED | WNOHANG | WNOWAIT);
```

With a freshly zero-initialized `siginfo_t`, the observed result was:

```text
return value = 0
si_pid       = child PID
si_signo     = SIGCHLD
si_code      = CLD_STOPPED
si_status    = SIGSTOP
```

Because `si_pid` and `si_signo` are nonzero, the original `_peekIfExited` condition returns `true`, although the child is paused rather than terminated. This can bypass exit monitoring and lead to a nonterminal status reaching `TerminationStatus`, which traps on unexpected status codes.

The proposed condition returns `false` for this stop notification.

## Reproduction and validation

### macOS 27.0 beta — build `26A5425a`

Environment:

- Apple Silicon (`arm64`)
- Xcode 27.0 beta, build `27A5252f`
- Swift 6.4 (`swiftlang-6.4.0.33.1`)

The PR includes two Swift regression tests:

- `testStoppedChildIsNotReportedAsExited`: suspend a child and verify that exit observation returns false without consuming the pending stop notification.
- `testMonitoringStoppedChildWaitsForItsFinalExit`: monitor a stopped child, resume it, and verify its final exit status is 42.

Both tests passed with the patch in the latest local run on this environment.

An independent C diagnostic reproduced the unexpected OS result in 80/80 trials: 20 trials for each combination of `fork`/`posix_spawn` and exit queries with/without `WNOWAIT`.

That diagnostic observed the paused state through `proc_pidinfo`, without any preceding `waitid` call. All 80 children subsequently resumed and exited with status 42. A live, non-paused child returned zero PID, signal, and code as a negative control.

Summary lines from that run:

```text
fork reap: old false exits 20/20; stop reports 20/20; subsequent real exits 20/20
fork peek: old false exits 20/20; stop reports 20/20; subsequent real exits 20/20
spawn reap: old false exits 20/20; stop reports 20/20; subsequent real exits 20/20
spawn peek: old false exits 20/20; stop reports 20/20; subsequent real exits 20/20
running control: rc=0 pid=0 signo=0 code=0
```

Here, “old false exits” counts how often the original nonzero-PID/signal condition would classify a paused child as exited. “Subsequent real exits” counts the later `CLD_EXITED` results with status 42, after explicitly resuming the children.

### macOS 26.6.2 — build `25G83`

A smaller, single-case C diagnostic also reproduced the behavior using `fork` and `WEXITED | WNOHANG | WNOWAIT`.

Recorded output:

```text
Paused child: nonzero PID=1, signal=20, code=5, status=17
REPRODUCED: exit-only query returned a pause notification.
Confirmed: after resuming, the child really exited with status 42.
```

`nonzero PID=1` is a Boolean indicator, not the child's actual PID. The other values correspond to `SIGCHLD = 20`, `CLD_STOPPED = 5`, and `SIGSTOP = 17`.

This extends the reproduction evidence beyond macOS 27 beta. The 80-trial matrix, the query without `WNOWAIT`, and the Swift regression tests have not been run on macOS 26.6.2 as part of this validation.

## Standalone reproduction

The source below is the smaller diagnostic used for the macOS 26.6.2 result, not the earlier 80-trial matrix.

It does not link against Swift or Swift Subprocess. It creates its own child, confirms the paused state through `proc_pidinfo`, and then makes the exit-only `waitid` query with freshly initialized output. It subsequently resumes the child and checks its actual exit status.

It includes cleanup for normal exits and interruption/timeout signals.

1. Save the source as `waitid-check.c`.
2. Compile and run from the directory containing the file:

```sh
xcrun clang -Wall -Wextra -Werror waitid-check.c -o waitid-check
./waitid-check
```

<details>
<summary>C diagnostic source</summary>

```c
#include <errno.h>
#include <libproc.h>
#include <signal.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/proc.h>
#include <sys/wait.h>
#include <unistd.h>

/* No file/network access. Every signal targets an owned, unreaped child. */
static volatile sig_atomic_t owned_child = 0;
static sigset_t cleanup_signals;

static void cleanup(void) {
    sigset_t previous;
    sigprocmask(SIG_BLOCK, &cleanup_signals, &previous);
    pid_t pid = (pid_t)owned_child;
    if (pid > 0) {
        kill(pid, SIGKILL);
        while (waitpid(pid, NULL, 0) < 0 && errno == EINTR) {}
        owned_child = 0;
    }
    sigprocmask(SIG_SETMASK, &previous, NULL);
}

static void interrupted(int signal_number) {
    cleanup();
    const char message[] = "Interrupted or timed out; test-child cleanup completed.\n";
    (void)write(STDERR_FILENO, message, sizeof(message) - 1);
    _exit(128 + signal_number);
}

int main(void) {
    const int signals[] = {SIGALRM, SIGINT, SIGTERM, SIGHUP};
    sigemptyset(&cleanup_signals);
    for (unsigned i = 0; i < sizeof(signals) / sizeof(signals[0]); i++)
        sigaddset(&cleanup_signals, signals[i]);
    struct sigaction action = {0};
    action.sa_handler = interrupted;
    action.sa_mask = cleanup_signals;
    for (unsigned i = 0; i < sizeof(signals) / sizeof(signals[0]); i++)
        if (sigaction(signals[i], &action, NULL)) return 1;
    alarm(15);

    sigset_t previous;
    if (sigprocmask(SIG_BLOCK, &cleanup_signals, &previous)) return 1;
    pid_t pid = fork();
    if (pid < 0) { perror("fork"); return 1; }
    if (pid == 0) {
        action.sa_handler = SIG_DFL;
        for (unsigned i = 0; i < sizeof(signals) / sizeof(signals[0]); i++)
            if (sigaction(signals[i], &action, NULL)) _exit(1);
        if (sigprocmask(SIG_SETMASK, &previous, NULL)) _exit(1);
        if (raise(SIGSTOP)) _exit(1);
        _exit(42);
    }
    owned_child = pid;
    atexit(cleanup);
    sigprocmask(SIG_SETMASK, &previous, NULL);

    /* Observe the pause without making a preliminary wait/waitid call. */
    int paused = 0;
    for (int i = 0; i < 5000; i++) {
        struct proc_bsdinfo state = {0};
        if (proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &state, sizeof(state)) != sizeof(state)) break;
        if (state.pbi_status == SSTOP) { paused = 1; break; }
        usleep(1000);
    }
    if (!paused) { puts("INCONCLUSIVE: could not confirm the test child was paused."); return 2; }
    siginfo_t info = {0};
    if (waitid(P_PID, (id_t)pid, &info, WEXITED | WNOHANG | WNOWAIT)) {
        perror("waitid"); return 3;
    }
    printf("Paused child: nonzero PID=%d, signal=%d, code=%d, status=%d\n",
        info.si_pid != 0, info.si_signo, info.si_code, info.si_status);
    int reproduced = info.si_code == CLD_STOPPED && (info.si_pid != 0 || info.si_signo != 0);
    if (reproduced) puts("REPRODUCED: exit-only query returned a pause notification.");
    else if (info.si_pid == 0 && info.si_signo == 0)
        puts("NOT REPRODUCED: exit-only query did not report the paused child.");
    else puts("INCONCLUSIVE: a different result needs examination.");

    if (kill(pid, SIGCONT)) { perror("resume"); return 4; }
    for (int i = 0; i < 5000; i++) {
        siginfo_t final = {0};
        if (waitid(P_PID, (id_t)pid, &final, WEXITED | WNOHANG | WNOWAIT)) {
            perror("final waitid"); return 5;
        }
        if (final.si_code == CLD_EXITED && final.si_status == 42) {
            puts("Confirmed: after resuming, the child really exited with status 42.");
            cleanup();
            alarm(0);
            return 0;
        }
        usleep(1000);
    }
    puts("INCONCLUSIVE: final exit was not confirmed before the deadline.");
    return 6;
}
```

</details>

## Interpretation and scope

The diagnostics demonstrate that an exit-only query can return `CLD_STOPPED` on the two tested macOS versions, and that the original library condition misclassifies that result as terminal.

Apple's published [XNU implementation](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_exit.c) gates stop notifications on `WSTOPPED`. The observed behavior therefore warrants investigation at the OS boundary as well as consideration of defensive handling in the library.

The C diagnostics isolate the OS behavior; they do not themselves execute the Swift library's subsequent crash path.

The investigation began with application subprocess hangs. After adopting the patched library, I observed the application working normally again. However, I haven't established that this specific condition caused the original hangs, so I’m treating that improvement as supporting context rather than proof of the root cause.

## Remaining review

- Whether the behavior occurs on other macOS versions or non-macOS platforms.
- Why the tested OS versions return a stop notification for an exit-only query.
- Whether defensive handling in Swift Subprocess is the preferred solution.
- Extending the handling and regression coverage to `_reap`, if that approach is agreed upon.

The adjacent `_reap` helper still uses the original nonempty-result check. The macOS 27 diagnostic reproduced the same stop notification without `WNOWAIT`, so that path also needs consideration and focused regression coverage. The current patch does not address it.

Feedback is welcome on whether this approach is appropriate or whether a different solution would be preferable.